### PR TITLE
Add missing webtest module in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ requires = [
     'cornice',
     'colander',
     'ColanderAlchemy>=0.3.2',
+    'webtest',
     ]
 
 setup(name='app_api',


### PR DESCRIPTION
When typing
```
make -f config/alex serve
```
I had the following error:
```
...
File "/home/alex/v6_api/app_api/tests/__init__.py", line 7, in <module>
    from webtest import TestApp
ImportError: No module named webtest
```

Is it the correct place to add the module?