### PR TITLE
Database session-related clean-up in the tests

### DIFF
--- a/app_api/scripts/initializedb.py
+++ b/app_api/scripts/initializedb.py
@@ -28,5 +28,4 @@ def main(argv=sys.argv):
     setup_logging(config_uri)
     settings = get_appsettings(config_uri, options=options)
     engine = engine_from_config(settings, 'sqlalchemy.')
-    DBSession.configure(bind=engine)
     Base.metadata.create_all(engine)

--- a/app_api/tests/__init__.py
+++ b/app_api/tests/__init__.py
@@ -59,12 +59,12 @@ class BaseTestCase(unittest.TestCase):
         # begin a non-ORM transaction
         self.trans = connection.begin()
 
-        # bind an individual Session to the connection
-        # Next line is needed to make several tests run in a row.
-        # See https://github.com/Pylons/webtest/issues/5
-        # FIXME Is there a better solution?
-        DBSession.remove()
+        # DBSession is the scoped session manager used in the views,
+        # reconfigure it to use this test's connection
         DBSession.configure(bind=connection)
+
+        # create a session bound the connection, this session is the one
+        # used in the test code
         self.session = self.Session(bind=connection)
 
     def tearDown(self):  # noqa
@@ -75,4 +75,5 @@ class BaseTestCase(unittest.TestCase):
             self.trans.rollback()
         else:
             self.trans.commit()
+        DBSession.remove()
         self.session.close()

--- a/app_api/tests/__init__.py
+++ b/app_api/tests/__init__.py
@@ -66,7 +66,6 @@ class BaseTestCase(unittest.TestCase):
         DBSession.remove()
         DBSession.configure(bind=connection)
         self.session = self.Session(bind=connection)
-        Base.session = self.session
 
     def tearDown(self):  # noqa
         # rollback - everything that happened with the Session above

--- a/app_api/tests/__init__.py
+++ b/app_api/tests/__init__.py
@@ -22,7 +22,6 @@ def get_engine():
 def setup_package():
     # set up database
     engine = get_engine()
-    DBSession.configure(bind=engine)
     Base.metadata.create_all(engine)
 
 # keep the database schema after a test run (useful for debugging)

--- a/config/elemoine
+++ b/config/elemoine
@@ -1,0 +1,7 @@
+include config/dev
+
+export debug_port = 6550
+export instanceid = elemoine
+export base_url = /${instanceid}
+export db_name = c2corg_elemoine
+export tests_db_name = c2corg_elemoine_tests


### PR DESCRIPTION
This PR suggests changes to the code that configures `DBSession` and the test Session (`self.session`) in the tests.

With this change the SQLAlchemy warning "SAWarning: At least one scoped session is already present.  configure() can not affect sessions that have already been created." goes away.