### PR TITLE
Use more consistent table/fieldnames for locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To set up the database
     create database c2corg_{user} owner "www-data";
     \c c2corg_{user}
     create extension postgis;
-    create schema topoguide authorization "www-data";
+    create schema guidebook authorization "www-data";
     \q
     .build/venv/bin/initialize_app_api_db development.ini
 
@@ -43,7 +43,7 @@ Create a database that will be used to run the tests:
     create database c2corg_{user}_tests owner "www-data";
     \c c2corg_{user}_tests
     create extension postgis;
-    create schema topoguide authorization "www-data";
+    create schema guidebook authorization "www-data";
     \q
 
 Then run the tests with:

--- a/app_api/models/__init__.py
+++ b/app_api/models/__init__.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import (
 
 from zope.sqlalchemy import ZopeTransactionExtension
 
-schema = 'topoguide'
+schema = 'guidebook'
 
 DBSession = scoped_session(sessionmaker(extension=ZopeTransactionExtension()))
 

--- a/app_api/models/document.py
+++ b/app_api/models/document.py
@@ -95,7 +95,7 @@ class _DocumentLocaleMixin(object):
 
 
 class DocumentLocale(Base, _DocumentLocaleMixin):
-    __tablename__ = 'documents_i18n'
+    __tablename__ = 'documents_locales'
 
     _ATTRIBUTES = ['document_id', 'culture', 'title', 'description']
 
@@ -105,4 +105,4 @@ class DocumentLocale(Base, _DocumentLocaleMixin):
 
 
 class ArchiveDocumentLocale(Base, _DocumentLocaleMixin):
-    __tablename__ = 'documents_i18n_archives'
+    __tablename__ = 'documents_locales_archives'

--- a/app_api/models/document_history.py
+++ b/app_api/models/document_history.py
@@ -46,12 +46,12 @@ class DocumentVersion(Base):
     document_archive = relationship(
         ArchiveDocument, primaryjoin=document_archive_id == ArchiveDocument.id)
 
-    document_i18n_archive_id = Column(
-        Integer, ForeignKey(schema + '.documents_i18n_archives.id'),
+    document_locales_archive_id = Column(
+        Integer, ForeignKey(schema + '.documents_locales_archives.id'),
         nullable=False)
-    document_i18n_archive = relationship(
+    document_locales_archive = relationship(
         ArchiveDocumentLocale,
-        primaryjoin=document_i18n_archive_id == ArchiveDocumentLocale.id)
+        primaryjoin=document_locales_archive_id == ArchiveDocumentLocale.id)
 
     history_metadata_id = Column(
         Integer, ForeignKey(schema + '.history_metadata.id'), nullable=False)

--- a/app_api/models/route.py
+++ b/app_api/models/route.py
@@ -82,11 +82,11 @@ class _RouteLocaleMixin(object):
 class RouteLocale(_RouteLocaleMixin, DocumentLocale):
     """
     """
-    __tablename__ = 'routes_i18n'
+    __tablename__ = 'routes_locales'
 
     id = Column(
                 Integer,
-                ForeignKey(schema + '.documents_i18n.id'), primary_key=True)
+                ForeignKey(schema + '.documents_locales.id'), primary_key=True)
 
     _ATTRIBUTES = ['gear']
 
@@ -101,11 +101,12 @@ class RouteLocale(_RouteLocaleMixin, DocumentLocale):
 class ArchiveRouteLocale(_RouteLocaleMixin, ArchiveDocumentLocale):
     """
     """
-    __tablename__ = 'routes_i18n_archives'
+    __tablename__ = 'routes_locales_archives'
 
     id = Column(
         Integer,
-        ForeignKey(schema + '.documents_i18n_archives.id'), primary_key=True)
+        ForeignKey(schema + '.documents_locales_archives.id'),
+        primary_key=True)
 
 
 schema_route_locale = SQLAlchemySchemaNode(

--- a/app_api/models/waypoint.py
+++ b/app_api/models/waypoint.py
@@ -99,11 +99,11 @@ class _WaypointLocaleMixin(object):
 class WaypointLocale(_WaypointLocaleMixin, DocumentLocale):
     """
     """
-    __tablename__ = 'waypoints_i18n'
+    __tablename__ = 'waypoints_locales'
 
     id = Column(
                 Integer,
-                ForeignKey(schema + '.documents_i18n.id'), primary_key=True)
+                ForeignKey(schema + '.documents_locales.id'), primary_key=True)
 
     _ATTRIBUTES = ['pedestrian_access']
 
@@ -118,11 +118,12 @@ class WaypointLocale(_WaypointLocaleMixin, DocumentLocale):
 class ArchiveWaypointLocale(_WaypointLocaleMixin, ArchiveDocumentLocale):
     """
     """
-    __tablename__ = 'waypoints_i18n_archives'
+    __tablename__ = 'waypoints_locales_archives'
 
     id = Column(
         Integer,
-        ForeignKey(schema + '.documents_i18n_archives.id'), primary_key=True)
+        ForeignKey(schema + '.documents_locales_archives.id'),
+        primary_key=True)
 
 
 schema_waypoint_locale = SQLAlchemySchemaNode(

--- a/app_api/tests/views/test_route.py
+++ b/app_api/tests/views/test_route.py
@@ -111,7 +111,7 @@ class TestRouteRest(BaseTestCase):
         self.assertEqual(archive_route.activities, 'hiking')
         self.assertEqual(archive_route.height, 750)
 
-        archive_locale = version.document_i18n_archive
+        archive_locale = version.document_locales_archive
         self.assertEqual(archive_locale.document_id, document_id)
         self.assertEqual(archive_locale.culture, 'en')
         self.assertEqual(archive_locale.title, 'Some nice loop')

--- a/app_api/tests/views/test_waypoint.py
+++ b/app_api/tests/views/test_waypoint.py
@@ -111,7 +111,7 @@ class TestWaypointRest(BaseTestCase):
         self.assertEqual(archive_waypoint.waypoint_type, 'summit')
         self.assertEqual(archive_waypoint.elevation, 3779)
 
-        archive_locale = version.document_i18n_archive
+        archive_locale = version.document_locales_archive
         self.assertEqual(archive_locale.document_id, document_id)
         self.assertEqual(archive_locale.culture, 'en')
         self.assertEqual(archive_locale.title, 'Mont Pourri')

--- a/app_api/views/document.py
+++ b/app_api/views/document.py
@@ -20,7 +20,7 @@ class DocumentRest(object):
                 version=1,
                 nature='ft',
                 document_archive=archive,
-                document_i18n_archive=locale,
+                document_locales_archive=locale,
                 history_metadata=meta_data
             )
             versions.append(version)

--- a/scripts/travis-db.sql
+++ b/scripts/travis-db.sql
@@ -2,5 +2,5 @@ create user "www-data" with password 'www-data';
 create database c2corg_tests owner "www-data";
 \c c2corg_tests
 create extension postgis;
-create schema topoguide authorization "www-data";
+create schema guidebook authorization "www-data";
 \q


### PR DESCRIPTION
and rename the "topoguide" schema to "guidebook" to be more english friendly.

This change requires to drop and recreate the database.

Fix #4 