### PR TITLE
Add sever side caching

### DIFF
--- a/app_api/__init__.py
+++ b/app_api/__init__.py
@@ -6,6 +6,8 @@ from .models import (
     Base,
     )
 
+from .ext import caching
+
 
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.
@@ -15,5 +17,12 @@ def main(global_config, **settings):
     Base.metadata.bind = engine
     config = Configurator(settings=settings)
     config.include('cornice')
+
+    # dogpile.cache configuration
+    # TODO: get config from settings
+    # caching.init_region(settings["cache"])
+    caching.init_region({'backend': 'dogpile.cache.memory'})
+    caching.invalidate_region()
+
     config.scan(ignore='app_api.tests')
     return config.make_wsgi_app()

--- a/app_api/ext/caching.py
+++ b/app_api/ext/caching.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+
+# Taken from c2cgeoportal at
+# https://github.com/camptocamp/c2cgeoportal/blob/1.6/c2cgeoportal/lib/caching.py
+
+# Copyright (c) 2012-2015, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are
+# those of the authors and should not be interpreted as representing official
+# policies, either expressed or implied, of the FreeBSD Project.
+
+
+import inspect
+
+from dogpile.cache import compat
+from dogpile.cache.region import make_region
+
+_regions = {}
+
+
+def keygen_function(namespace, fn):
+    """Return a function that generates a string
+    key, based on a given function as well as
+    arguments to the returned function itself.
+
+    This is used by :meth:`.CacheRegion.cache_on_arguments`
+    to generate a cache key from a decorated function.
+    """
+
+    if namespace is None:
+        namespace = "%s:%s" % (fn.__module__, fn.__name__)
+    else:  # pragma: nocover
+        namespace = "%s:%s|%s" % (fn.__module__, fn.__name__, namespace)
+
+    args = inspect.getargspec(fn)
+    has_self = args[0] and args[0][0] in ("self", "cls")
+
+    def generate_key(*args, **kw):
+        if kw:  # pragma: nocover
+            raise ValueError(
+                "key creation function does not accept keyword arguments.")
+        parts = [namespace]
+        if has_self:
+            self_ = args[0]
+            if hasattr(self_, "request"):
+                parts.append(self_.request.application_url)
+            args = args[1:]
+        parts.append(" ".join(map(compat.text_type, args)))
+        return "|".join(parts)
+    return generate_key
+
+
+def init_region(conf, region=None):
+    """
+    Initialize the caching module.
+    """
+    cache_region = make_region(function_key_generator=keygen_function)
+    kwargs = dict(
+        (k, conf[k]) for k in
+        ("arguments", "expiration_time") if k in conf)
+    cache_region.configure(conf["backend"], **kwargs)
+    _regions[region] = cache_region
+    return cache_region
+
+
+def get_region(region=None):
+    """
+    Return a cache region.
+    """
+    try:
+        return _regions[region]
+    except KeyError:  # pragma: nocover
+        raise Exception(
+            "No such caching region. A region must be"
+            "initialized before it can be used")
+
+
+def invalidate_region(region=None):
+    return get_region(region).invalidate()
+
+
+NO_CACHE = 0
+PUBLIC_CACHE = 1
+PRIVATE_CACHE = 2
+
+
+def set_common_headers(
+        request, service_name, cache,
+        response=None, add_cors=False, vary=False, content_type=None):
+    if response is None:
+        response = request.response
+
+    if cache == NO_CACHE:
+        response.cache_control.no_cache = True
+    elif cache == PUBLIC_CACHE:
+        response.cache_control.public = True
+    elif cache == PRIVATE_CACHE:
+        if request.user is not None:
+            response.cache_control.private = True
+        else:
+            response.cache_control.public = True
+    else:  # pragma: nocover
+        raise "Invalid cache type"
+
+    if cache != NO_CACHE:
+        max_age = request.registry.settings["default_max_age"]
+
+        settings = request.registry.settings.get("cache_control", {})
+        if service_name in settings and "max_age" in settings[service_name]:
+            max_age = settings[service_name]["max_age"]
+
+        if max_age != 0:
+            response.cache_control.max_age = max_age
+        else:
+            response.cache_control.no_cache = True
+
+    if add_cors:
+        response.headers.update({
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Headers": "X-Requested-With, Content-Type"
+        })
+
+    if vary:
+        response.headers["Vary"] = "Accept-Language"
+
+    if content_type is not None:
+        response.content_type = content_type
+
+    return response

--- a/app_api/views/route.py
+++ b/app_api/views/route.py
@@ -3,8 +3,12 @@ from sqlalchemy.orm import joinedload
 
 from app_api.models.route import Route, schema_route
 from app_api.models import DBSession
+from app_api.ext import caching
 from app_api.views.document import DocumentRest
 from . import validate_id, to_json_dict
+
+
+cache_region = caching.get_region()
 
 
 @resource(collection_path='/routes', path='/routes/{id}')
@@ -21,7 +25,10 @@ class RouteRest(DocumentRest):
     @view(validators=validate_id)
     def get(self):
         id = self.request.validated['id']
+        return self._get_by_id(id)
 
+    @cache_region.cache_on_arguments()
+    def _get_by_id(self, id):
         route = DBSession. \
             query(Route). \
             filter(Route.document_id == id). \

--- a/app_api/views/waypoint.py
+++ b/app_api/views/waypoint.py
@@ -3,8 +3,12 @@ from sqlalchemy.orm import joinedload
 
 from app_api.models.waypoint import Waypoint, schema_waypoint
 from app_api.models import DBSession
+from app_api.ext import caching
 from app_api.views.document import DocumentRest
 from . import validate_id, to_json_dict
+
+
+cache_region = caching.get_region()
 
 
 @resource(collection_path='/waypoints', path='/waypoints/{id}')
@@ -21,7 +25,10 @@ class WaypointRest(DocumentRest):
     @view(validators=validate_id)
     def get(self):
         id = self.request.validated['id']
+        return self._get_by_id(id)
 
+    @cache_region.cache_on_arguments()
+    def _get_by_id(self, id):
         waypoint = DBSession. \
             query(Waypoint). \
             filter(Waypoint.document_id == id). \

--- a/common.ini.in
+++ b/common.ini.in
@@ -12,3 +12,24 @@ version = {version}
 # elasticsearch.index = c2corg
 
 logging.level = {logging_level}
+
+# The dogpile.cache configuration.
+#
+# Do not touch if unsure.
+#
+# The cache section below takes three properties:
+#
+# - backend: the name of the cache backend (ex: dogpile.cache.memory,
+#   dogpile.cache.memcached, etc.). Mandatory.
+# - expiration_time: the cache expiration time. Optional (infinite if not
+#   specified).
+# - arguments: backend-specific arguments. Optional.
+#
+# Here is a dogpile.cache configuration example for the memcached backend
+# (equivalent of http://dogpilecache.readthedocs.org/en/latest/api.html#dogpile.cache.backends.memcached.MemcachedBackend)
+# cache:
+#   backend: dogpile.cache.memcached
+#   expiration_time: 3600
+#   arguments:
+#     url: 127.0.0.1:11211
+cache.backend = dogpile.cache.memory

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ requires = [
     'cornice',
     'colander',
     'ColanderAlchemy>=0.3.2',
+    'dogpile.cache',
     ]
 
 setup(name='app_api',


### PR DESCRIPTION
This PR makes use of dogpile.cache to cache the output of the "get" method (as for now lists are not cached).

I have used "as is" the dogpile implementation from c2cgeoportal:
https://github.com/camptocamp/c2cgeoportal/blob/1.6/c2cgeoportal/lib/caching.py
We should probably check if all this functions are needed or generic enough (at first sight yes). It provides for instance a ``set_common_headers()`` function to set the cache control HTTP headers.

The backend is currently the standard dogpile.cache.memory backend. dogpile also supports advanced backend such as memcached or Redis:
https://dogpilecache.readthedocs.org/en/latest/api.html#module-dogpile.cache.backends.memory
Using one of them would probably improve the performances. Please note that Discourse uses a Redis cache: http://www.discourse.org/faq/#tech

By the way the configuration of dogpile is at the moment hardcoded (even though I have added it in common.ini.in as well). Using the config files would indeed make sense but I was wondering if would use those ini file or another system such as yaml files.

No test is provided. Not sure it is easy to test if the cache works as expected. At least we could for instance if the attributes values of a WP are unchanged after 2 requests whereas the value in the DB has actually changed? We would need also to test the invalidation of the cache when a new version of the document is created (not available yet).

Related to #6 