### PR TITLE
Move activities and waypoint_types values in a dedicated file

### DIFF
--- a/app_api/attributes.py
+++ b/app_api/attributes.py
@@ -1,0 +1,43 @@
+activities = [
+    'skitouring',
+    'snow_ice_mixed',
+    'mountain_climbing',
+    'rock_climbing',
+    'ice_climbing',
+    'hiking',
+    'snowshoeing',
+    'paragliding',
+    'mountain_biking',
+    'via_ferrata'
+]
+
+waypoint_types = [
+    'summit',
+    'pass',
+    'lake',
+    'bisse',
+    'waterfall',
+    'cave',
+    'glacier',
+    'cliff',
+    'waterpoint',
+    'canyon',
+    'valley',
+    'locality',
+    'dam',
+    'webcam',
+    'weather_station',
+    'hut',
+    'gite',
+    'shelter',
+    'camp_site',
+    'base_camp',
+    'camping',
+    'access',
+    'crag',
+    'boulder',
+    'climbing',
+    'local_product',
+    'paragliding_takeoff',
+    'paragliding_landing'
+]

--- a/app_api/models/route.py
+++ b/app_api/models/route.py
@@ -13,20 +13,7 @@ from . import schema
 from utils import copy_attributes
 from document import (
     ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale)
-
-# TODO: move to a common place for outings etc.
-activities = [
-    'skitouring',
-    'snow_ice_mixed',
-    'mountain_climbing',
-    'rock_climbing',
-    'ice_climbing',
-    'hiking',
-    'snowshoeing',
-    'paragliding',
-    'mountain_biking',
-    'via_ferrata'
-    ]
+from app_api.attributes import activities
 
 
 class _RouteMixin(object):

--- a/app_api/models/waypoint.py
+++ b/app_api/models/waypoint.py
@@ -13,37 +13,7 @@ from . import schema
 from utils import copy_attributes
 from document import (
     ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale)
-
-waypoint_types = [
-    'summit',
-    'pass',
-    'lake',
-    'bisse',
-    'waterfall',
-    'cave',
-    'glacier',
-    'cliff',
-    'waterpoint',
-    'canyon',
-    'valley',
-    'locality',
-    'dam',
-    'webcam',
-    'weather_station',
-    'hut',
-    'gite',
-    'shelter',
-    'camp_site',
-    'base_camp',
-    'camping',
-    'access',
-    'crag',
-    'boulder',
-    'climbing',
-    'local_product',
-    'paragliding_takeoff',
-    'paragliding_landing'
-    ]
+from app_api.attributes import waypoint_types
 
 
 class _WaypointMixin(object):


### PR DESCRIPTION
Because
* some lists may be used in several models/views
* some lists may be long and pollute the models/views code
* it's good to have everything at the same place instead of dispatched in several places. (Should we use a YAML file instead of python?)

By the way:
* would it be relevant to be more consistent when importing modules?
Sometimes we have ``from ..models`` or ``from .models``, sometimes ``from app_api.models``. What's the best practise?
* I don't really like "app_api" (too complicated), would simply using "api" make sense?