### PR TITLE
Fix lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test: .build/venv/bin/nosetests
 	.build/venv/bin/nosetests
 
 .PHONY: lint
-flake8: .build/venv/bin/flake8
+lint: .build/venv/bin/flake8
 	.build/venv/bin/flake8 c2corg_api
 
 .PHONY: install


### PR DESCRIPTION
The change in #22 was incomplete, `make lint` didn't actually do something:

```
tsauerwein@c2corgv6-demo:~/c2corgv6/app_api$ make -f config/tsauerwein lint                              
make: Nothing to be done for 'lint'.
tsauerwein@c2corgv6-demo:~/c2corgv6/app_api$ make -f config/tsauerwein flake8
.build/venv/bin/flake8 c2corg_api
c2corg_api/tests/models/test_waypoint.py:7:1: E302 expected 2 blank lines, found 1
c2corg_api/tests/views/test_waypoint.py:167:80: E501 line too long (80 > 79 characters)
...
```