### PR TITLE
Install Cornice from PyPi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 --index-url http://pypi.camptocamp.net/pypi
 -e git+https://github.com/camptocamp/pyramid_closure#egg=pyramid_closure
 
-# needed for Cornice: https://github.com/mozilla-services/cornice/pull/309
-git+https://github.com/mozilla-services/cornice.git
-
 -e .

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requires = [
     'zope.sqlalchemy',
     'waitress',
     'psycopg2',
-    'cornice',
+    'cornice>=1.1.0',
     'colander',
     'ColanderAlchemy>=0.3.2',
     'enum34',


### PR DESCRIPTION
Cornice 1.1.0 was released last week, which includes https://github.com/mozilla-services/cornice/pull/309, so that we no longer need to install from the GitHub repository.