### PR TITLE
Make version fields default to 1

### DIFF
--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -39,7 +39,7 @@ class _DocumentMixin(object):
     Contains the attributes that are common for `Document` and
     `ArchiveDocument`.
     """
-    version = Column(Integer, nullable=False)
+    version = Column(Integer, nullable=False, default=1)
     # move to metadata?
     protected = Column(Boolean)
     redirects_to = Column(Integer)
@@ -179,7 +179,7 @@ class ArchiveDocument(Base, _DocumentMixin):
 # Locales for documents
 class _DocumentLocaleMixin(object):
     id = Column(Integer, primary_key=True)
-    version = Column(Integer, nullable=False)
+    version = Column(Integer, nullable=False, default=1)
 
     @declared_attr
     def document_id(self):


### PR DESCRIPTION
I wonder if we don't need to set a default version value in the document* tables in order to ease the migration of the existing documents.

Not sure the suggested change is enough though: I have tested to run scripts/create_user_db.sh but not default value is provided for version fields in document* tables.