### PR TITLE
Add server_default for documents version fields

### DIFF
--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -39,7 +39,7 @@ class _DocumentMixin(object):
     Contains the attributes that are common for `Document` and
     `ArchiveDocument`.
     """
-    version = Column(Integer, nullable=False, default=1)
+    version = Column(Integer, nullable=False, server_default='1')
     # move to metadata?
     protected = Column(Boolean)
     redirects_to = Column(Integer)
@@ -179,7 +179,7 @@ class ArchiveDocument(Base, _DocumentMixin):
 # Locales for documents
 class _DocumentLocaleMixin(object):
     id = Column(Integer, primary_key=True)
-    version = Column(Integer, nullable=False, default=1)
+    version = Column(Integer, nullable=False, server_default='1')
 
     @declared_attr
     def document_id(self):


### PR DESCRIPTION
In PR #39 I have added a "default=1" parameter for the documents version fields. The goal was that the create_all() script actually set a DEFAULT 1 property to the table fields. Which it doesn't.

According to http://docs.sqlalchemy.org/en/rel_0_9/core/metadata.html#column-table-metadata-api
```
default –
A scalar, Python callable, or ColumnElement expression representing the default value for this column, which will be invoked upon insert if this column is otherwise not specified in the VALUES clause of the insert. This is a shortcut to using ColumnDefault as a positional argument; see that class for full detail on the structure of the argument.

Contrast this argument to server_default which creates a default generator on the database side.
``` 

This PR then uses "server_default" (requires a string as argument) instead of "default". The latter is used as the default value in the ORM. Do we really need it? If yes, we should keep both arguments.