### PR TITLE
Add geometry field to document

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Insert a waypoint:
 
     curl -X POST -v \
     -H "Content-Type: application/json" \
-    -d '{"waypoint_type": "summit", "elevation": 3779, "locales": [{"culture": "fr", "title": "Mont Pourri"}]}' \
+    -d '{"waypoint_type": "summit", "elevation": 3779, "geometry": {"geom": "{\"type\": \"Point\", \"coordinates\": [635956, 5723604]}"},"locales": [{"culture": "fr", "title": "Mont Pourri"}]}' \
     http://localhost:6543/waypoints
 
 Updating a waypoint:

--- a/c2corg_api/ext/colander_ext.py
+++ b/c2corg_api/ext/colander_ext.py
@@ -1,0 +1,89 @@
+# Inspired from c2cgeoform colander extension
+# https://github.com/camptocamp/c2cgeoform/blob/master/c2cgeoform/ext/
+
+from colander import (null, Invalid, SchemaType)
+
+from geoalchemy2 import WKBElement
+from geoalchemy2.shape import to_shape, from_shape
+from shapely.geometry import mapping, shape
+from shapely.ops import transform
+from functools import partial
+import pyproj
+import json
+
+
+class Geometry(SchemaType):
+    """ A Colander type meant to be used with GeoAlchemy 2 geometry columns.
+    Example usage
+    .. code-block:: python
+        geom = Column(
+            geoalchemy2.Geometry('POLYGON', 4326, management=True), info={
+                'colanderalchemy': {
+                    'typ': colander_ext.Geometry(
+                        'POLYGON', srid=4326, map_srid=3857),
+                    'widget': deform_ext.MapWidget()
+                }})
+    **Attributes/Arguments**
+    geometry_type
+        The geometry type should match the column geometry type.
+    srid
+        The SRID of the geometry should also match the column definition.
+    map_srid
+        The projection used for the OpenLayers map. The geometries will be
+        reprojected to this projection.
+    """
+    def __init__(self, geometry_type='GEOMETRY', srid=-1, map_srid=-1):
+        self.geometry_type = geometry_type.upper()
+        self.srid = int(srid)
+        self.map_srid = int(map_srid)
+        if self.map_srid == -1:
+            self.map_srid = self.srid
+
+        if self.srid != self.map_srid:
+            self.project_db_to_map = partial(
+                pyproj.transform,
+                pyproj.Proj(init='epsg:' + str(self.srid)),
+                pyproj.Proj(init='epsg:' + str(self.map_srid)))
+            self.project_map_to_db = partial(
+                pyproj.transform,
+                pyproj.Proj(init='epsg:' + str(self.map_srid)),
+                pyproj.Proj(init='epsg:' + str(self.srid)))
+
+    def serialize(self, node, appstruct):
+        """
+        In Colander speak: Converts a Python data structure (an appstruct) into
+        a serialization (a cstruct).
+        Or: Converts a `WKBElement` into a GeoJSON string.
+        """
+        if appstruct is null:
+            return null
+        if isinstance(appstruct, WKBElement):
+            geometry = to_shape(appstruct)
+            if self.srid != self.map_srid and appstruct.srid != self.map_srid:
+                geometry = transform(self.project_db_to_map, geometry)
+
+            return json.dumps(mapping(geometry))
+        raise Invalid(node, 'Unexpected value: %r' % appstruct)
+
+    def deserialize(self, node, cstruct):
+        """
+        In Colander speak: Converts a serialized value (a cstruct) into a
+        Python data structure (a appstruct).
+        Or: Converts a GeoJSON string into a `WKBElement`.
+        """
+        if cstruct is null or cstruct == '':
+            return null
+        try:
+            # TODO Shapely does not support loading GeometryCollections from
+            # GeoJSON, see https://github.com/Toblerity/Shapely/issues/115
+            geometry = shape(json.loads(cstruct))
+        except Exception:
+            raise Invalid(node, 'Invalid geometry: %r' % cstruct)
+
+        if self.srid != self.map_srid:
+            geometry = transform(self.project_map_to_db, geometry)
+
+        return from_shape(geometry, srid=self.srid)
+
+    def cstruct_children(self, node, cstruct):
+        return []

--- a/c2corg_api/ext/colander_ext.py
+++ b/c2corg_api/ext/colander_ext.py
@@ -1,4 +1,4 @@
-# Inspired from c2cgeoform colander extension
+# Inspired from the c2cgeoform colander extension
 # https://github.com/camptocamp/c2cgeoform/blob/master/c2cgeoform/ext/
 
 from colander import (null, Invalid, SchemaType)

--- a/c2corg_api/models/README.md
+++ b/c2corg_api/models/README.md
@@ -9,24 +9,26 @@ Data model
 
 The base class for all documents (waypoints, routes, ...) is `Document`.
 The translatable fields for each document are in `DocumentLocale` (and in its
-child classes like `WaypointLocale`). The tables for `Document` and
-`DocumentLocale` always contain the current version of a document (like a materialized
-view).
+child classes like `WaypointLocale`). And the geometries are in `DocumentGeometry`.
+The tables for `Document`, `DocumentLocale` and `DocumentGeometry` always
+contain the current version of a document (like a materialized view).
 
-Besides `Document` and `DocumentLocale`, there are the classes `ArchiveDocument`
-and `ArchiveDocumentLocale` which contain all versions of a document and its
-locales (including the current version).
+Besides `Document`, `DocumentLocale` and `DocumentGeometry`, there are the
+classes `ArchiveDocument`, `ArchiveDocumentLocale` and `ArchiveDocumentGeometry`
+which contain all versions of a document, its locales and geometry (including the
+current version).
 
 For the versioning there are two more classes: `HistoryMetaData` and `DocumentVersion`.
 `HistoryMetaData` contains a change comment and the date. `DocumentVersion`
 is the list of actual versions of a document for a language. A *document version*
 for a language/culture references an entry in `ArchiveDocument`,
-`ArchiveDocumentLocale` and `HistoryMetaData`. It has the following fields:
-`document_id`, `culture`, `document_archive_id`, `document_locales_archive_id`
-and `history_metadata_id`.
+`ArchiveDocumentLocale`, `ArchiveDocumentGeometry` and `HistoryMetaData`.
+It has the following fields: `document_id`, `culture`, `document_archive_id`,
+`document_locales_archive_id`, `document_geometry_archive_id` and
+`history_metadata_id`.
 
-`Document` and `DocumentLocale` both have a version field that is configured
-as [SQLAlchemy version counter](http://docs.sqlalchemy.org/en/latest/orm/versioning.html).
+`Document`, `DocumentLocale` and `DocumentGeometry` all have a version field
+that is configured as [SQLAlchemy version counter](http://docs.sqlalchemy.org/en/latest/orm/versioning.html).
 This version is incremented every time the row is updated. At the same time this
 version field serves as optimistic lock. When an update is made, the current
 version has to be provided to prevent concurrent updates. The update statement
@@ -43,59 +45,77 @@ following happens:
 
  - An insert is made in the table of `Document` (and in the `Waypoint` table).
  - An insert is made in the table of `DocumentLocale` (and of `WaypointLocale`).
+ - An insert is made in the table of `DocumentGeometry`.
  - An insert is made in the table of `ArchiveDocument` (and of `ArchiveWaypoint`).
  - An insert is made in the table of `ArchiveDocumentLocale` (and of `ArchiveWaypointLocale`).
+ - An insert is made in the table of `ArchiveDocumentGeometry`.
  - An insert is made in the table of `HistoryMetaData`.
  - An insert is made in the table of `DocumentVersion`. This entry has a foreign
-   key pointing to the new row in `ArchiveDocument` and `ArchiveDocumentLocale`.
+   key pointing to the new row in `ArchiveDocument`, `ArchiveDocumentLocale`
+   and `ArchiveDocumentGeometry`.
 
 Updating an existing document
 ------------------------------
 
 Updating an existing document is a bit more involved. To avoid that data is
 duplicated for no reason, it makes a difference if only figures (in `Document`/
-`Waypoint`) are changed or if only translation fields are changed. The process
-is as follows (see `views.document.DocumentRest._put`):
+`Waypoint`) are changed, if only translation fields are changed or if only
+the geometry has changed.. The process is as follows (see `views.document.DocumentRest._put`):
 
  - Using Colander a `Document` instance `document_in` is created from the JSON
    input data.
  - The current version of the document is loaded from the database.
- - The version numbers of the current document and its locales are stored in a
-   dictionary `old_versions`.
+ - The version numbers of the current document, its locales and geometry are stored
+   in a dictionary `old_versions`.
  - Then the attributes of `document_in` are copied onto `document`, so that
    `document` reflects the changes that should be made.
  - `document` is flushed to the database. SQLAlchemy will automatically
-   update the version numbers in `Document` and `DocumentLocale` in case
-   an attribute has changed. By comparing with the old version numbers, we
-   can detect if only figures have changed or if only locales have changed.
+   update the version numbers in `Document`, `DocumentLocale` and `DocumentGeometry`
+   in case an attribute has changed. By comparing with the old version numbers, we
+   can detect if only figures have changed, if only locales have changed or if only
+   the geometry has changed.
 
-Depending on the *update type* (`FIGURES_ONLY`, `LANG_ONLY`, `ALL`) the
-following actions are done.
+Depending on the *update types* (`FIGURES`, `LANG`, `GEOM`) the following actions
+are done.
 
-**FIGURES_ONLY**
+**Only FIGURES**
 
  * Because only the figures have changed, we only insert the new document in
    `ArchiveDocument` (and `ArchiveWaypoint`). No new version is inserted in
    `ArchiveDocumentLocale`.
  * A new entry is inserted in `HistoryMetaData`.
  * For every locale a new entry is made in `DocumentVersion` referencing the
-   new entry in `ArchiveDocument` and the old locale version in `ArchiveDocumentLocale`.
+   new entry in `ArchiveDocument`, the old locale version in `ArchiveDocumentLocale`
+   and also the old geometry in `ArchiveDocumentGeometry`.
 
-**LANG_ONLY**
+**Only LANG**
 
  * Because only locales have changed, we only insert the changed locale(s) in
    `ArchiveDocumentLocale` (and `ArchiveWaypointLocale`). No new version is
    inserted in `ArchiveDocument`.
  * A new entry is inserted in `HistoryMetaData`.
  * For every locale that has changed and for every new locale a new entry is made
-   in `DocumentVersion` referencing the old entry in `ArchiveDocument` and the
-   new locale version in `ArchiveDocumentLocale`.
+   in `DocumentVersion` referencing the old entry in `ArchiveDocument`, the old
+   entry in `ArchiveDocumentGeometry` and the new locale version in `ArchiveDocumentLocale`.
 
-**ALL**
+**Only GEOM**
 
- * The new document is inserted in `ArchiveDocument` (and `ArchiveWaypoint`)
-   and the locale(s) that have changed are inserted in `ArchiveDocumentLocale`
-   (and `ArchiveWaypointLocale`).
+ * Because only the geometry has changed, we only insert the new geometry in
+   `ArchiveDocumentGeometry`. No new version is inserted in
+   `ArchiveDocumentLocale` or `ArchiveDocument`.
+ * A new entry is inserted in `HistoryMetaData`.
+ * For every locale a new entry is made in `DocumentVersion` referencing the
+   new entry in `ArchiveDocumentGeometry`, the old locale version in `ArchiveDocumentLocale`
+   and also the old entry in `ArchiveDocument`.
+
+**GEOM xor LANG xor FIGURES**
+
+At least two types (figures, geometry or locales) have changed.
+
+ * The new document is inserted in `ArchiveDocument` (and `ArchiveWaypoint`),
+   the locale(s) that have changed are inserted in `ArchiveDocumentLocale`
+   (and `ArchiveWaypointLocale`) and if the geometry has changed a new entry
+   is added to `ArchiveDocumentGeometry`.
  * A new entry is inserted in `HistoryMetaData`.
  * For every locale a new entry is made in `DocumentVersion` referencing the
    new entry in `ArchiveDocument` and the new locale version in `ArchiveDocumentLocale`

--- a/c2corg_api/models/document_history.py
+++ b/c2corg_api/models/document_history.py
@@ -9,7 +9,8 @@ from sqlalchemy.orm import relationship, backref
 import datetime
 
 from c2corg_api.models import Base, schema
-from document import Document, ArchiveDocument, ArchiveDocumentLocale
+from document import (
+    Document, ArchiveDocument, ArchiveDocumentLocale, ArchiveDocumentGeometry)
 
 
 class HistoryMetaData(Base):
@@ -48,6 +49,12 @@ class DocumentVersion(Base):
     document_locales_archive = relationship(
         ArchiveDocumentLocale,
         primaryjoin=document_locales_archive_id == ArchiveDocumentLocale.id)
+
+    document_geometry_archive_id = Column(
+        Integer, ForeignKey(schema + '.documents_geometries_archives.id'))
+    document_geometry_archive = relationship(
+        ArchiveDocumentGeometry,
+        primaryjoin=document_geometry_archive_id == ArchiveDocumentGeometry.id)
 
     history_metadata_id = Column(
         Integer, ForeignKey(schema + '.history_metadata.id'), nullable=False)

--- a/c2corg_api/models/image.py
+++ b/c2corg_api/models/image.py
@@ -12,7 +12,7 @@ from c2corg_api.models import schema
 from utils import copy_attributes
 from document import (
     ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale,
-    get_update_schema)
+    get_update_schema, geometry_schema_overrides)
 from c2corg_api.attributes import activities
 
 
@@ -116,7 +116,8 @@ schema_image = SQLAlchemySchemaNode(
     Image,
     # whitelisted attributes
     includes=[
-        'document_id', 'version', 'activities', 'height', 'locales'],
+        'document_id', 'version', 'activities', 'height', 'locales',
+        'geometry'],
     overrides={
         'document_id': {
             'missing': None
@@ -126,7 +127,8 @@ schema_image = SQLAlchemySchemaNode(
         },
         'locales': {
             'children': [schema_image_locale]
-        }
+        },
+        'geometry': geometry_schema_overrides
     })
 
 schema_update_image = get_update_schema(schema_image)

--- a/c2corg_api/models/route.py
+++ b/c2corg_api/models/route.py
@@ -13,7 +13,7 @@ from c2corg_api.models import schema
 from utils import copy_attributes
 from document import (
     ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale,
-    get_update_schema)
+    get_update_schema, geometry_schema_overrides)
 from c2corg_api.attributes import activities
 
 
@@ -119,7 +119,8 @@ schema_route = SQLAlchemySchemaNode(
     Route,
     # whitelisted attributes
     includes=[
-        'document_id', 'version', 'activities', 'height', 'locales'],
+        'document_id', 'version', 'activities', 'height', 'locales',
+        'geometry'],
     overrides={
         'document_id': {
             'missing': None
@@ -129,7 +130,8 @@ schema_route = SQLAlchemySchemaNode(
         },
         'locales': {
             'children': [schema_route_locale]
-        }
+        },
+        'geometry': geometry_schema_overrides
     })
 
 schema_update_route = get_update_schema(schema_route)

--- a/c2corg_api/models/utils.py
+++ b/c2corg_api/models/utils.py
@@ -10,8 +10,9 @@ def copy_attributes(obj_from, obj_to, attributes):
             current_val = getattr(obj_to, attribute)
             new_val = getattr(obj_from, attribute)
 
-            # always copy geometries, but otherwise only copy if the values
-            # are different
+            # To make the SQLAlchemy check if a document has changed work
+            # properly, we only copy an attribute if the value has changed.
+            # For geometries, we always copy the value.
             if isinstance(current_val, WKBElement) or \
                     isinstance(new_val, WKBElement) or \
                     current_val != new_val:

--- a/c2corg_api/models/utils.py
+++ b/c2corg_api/models/utils.py
@@ -1,3 +1,6 @@
+from geoalchemy2 import WKBElement
+
+
 def copy_attributes(obj_from, obj_to, attributes):
     """
     Copies the given attributes from `obj_from` to `obj_to` (shallow copy).
@@ -6,5 +9,10 @@ def copy_attributes(obj_from, obj_to, attributes):
         if hasattr(obj_from, attribute):
             current_val = getattr(obj_to, attribute)
             new_val = getattr(obj_from, attribute)
-            if current_val != new_val:
+
+            # always copy geometries, but otherwise only copy if the values
+            # are different
+            if isinstance(current_val, WKBElement) or \
+                    isinstance(new_val, WKBElement) or \
+                    current_val != new_val:
                 setattr(obj_to, attribute, new_val)

--- a/c2corg_api/models/waypoint.py
+++ b/c2corg_api/models/waypoint.py
@@ -13,7 +13,7 @@ from c2corg_api.models import schema
 from utils import copy_attributes
 from document import (
     ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale,
-    get_update_schema)
+    get_update_schema, geometry_schema_overrides)
 from c2corg_api.attributes import waypoint_types
 
 
@@ -116,12 +116,13 @@ schema_waypoint_locale = SQLAlchemySchemaNode(
         }
     })
 
+
 schema_waypoint = SQLAlchemySchemaNode(
     Waypoint,
     # whitelisted attributes
     includes=[
         'document_id', 'version', 'waypoint_type', 'elevation',
-        'maps_info', 'locales'],
+        'maps_info', 'locales', 'geometry'],
     overrides={
         'document_id': {
             'missing': None
@@ -131,7 +132,8 @@ schema_waypoint = SQLAlchemySchemaNode(
         },
         'locales': {
             'children': [schema_waypoint_locale]
-        }
+        },
+        'geometry': geometry_schema_overrides
     })
 
 schema_update_waypoint = get_update_schema(schema_waypoint)

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -23,7 +23,7 @@ def setup_package():
     # set up database
     engine = get_engine()
     DBSession.configure(bind=engine)
-#     Base.metadata.drop_all(engine)
+    Base.metadata.drop_all(engine)
     initializedb.setup_db(engine, DBSession)
     DBSession.remove()
 

--- a/c2corg_api/tests/ext/colander_ext.py
+++ b/c2corg_api/tests/ext/colander_ext.py
@@ -1,0 +1,95 @@
+from colander import (null, Invalid)
+from geoalchemy2 import WKBElement
+from geoalchemy2.shape import to_shape, from_shape
+import json
+import unittest
+
+
+class TestGeometry(unittest.TestCase):
+
+    def test_serialize_null(self):
+        from c2corg_api.ext.colander_ext import Geometry
+        geom_schema = Geometry()
+
+        self.assertEquals(null, geom_schema.serialize({}, null))
+
+    def test_serialize_wkb(self):
+        from c2corg_api.ext.colander_ext import Geometry
+        geom_schema = Geometry()
+
+        from shapely.geometry.point import Point
+        wkb = from_shape(Point(1.0, 2.0))
+        self.assertEquals(
+            '{"type": "Point", "coordinates": [1.0, 2.0]}',
+            geom_schema.serialize({}, wkb))
+
+    def test_serialize_reproject(self):
+        from c2corg_api.ext.colander_ext import Geometry
+        geom_schema = Geometry(srid=4326, map_srid=3857)
+
+        from shapely.geometry.point import Point
+        wkb = from_shape(Point(1.0, 2.0), 4326)
+        geo_json = json.loads(geom_schema.serialize({}, wkb))
+        self.assertEquals('Point', geo_json['type'])
+        self.assertAlmostEqual(111319.49079327231, geo_json['coordinates'][0])
+        self.assertAlmostEqual(222684.20850554455, geo_json['coordinates'][1])
+
+    def test_serialize_invalid(self):
+        from c2corg_api.ext.colander_ext import Geometry
+        geom_schema = Geometry()
+
+        self.assertRaises(
+            Invalid,
+            geom_schema.serialize, {}, 'Point(1 0)')
+
+    def test_deserialize_null(self):
+        from c2corg_api.ext.colander_ext import Geometry
+        geom_schema = Geometry()
+
+        self.assertEquals(null, geom_schema.deserialize({}, null))
+        self.assertEquals(null, geom_schema.deserialize({}, ''))
+
+    def test_deserialize_valid_geojson(self):
+        from c2corg_api.ext.colander_ext import Geometry
+        geom_schema = Geometry()
+
+        from shapely.geometry.point import Point
+        expected_wkb = WKBElement(Point(1.0, 2.0).wkb)
+
+        wkb = geom_schema.deserialize(
+            {}, '{"type": "Point", "coordinates": [1.0, 2.0]}')
+        self.assertEquals(expected_wkb.desc, wkb.desc)
+
+    def test_deserialize_reproject(self):
+        from c2corg_api.ext.colander_ext import Geometry
+        geom_schema = Geometry(srid=4326, map_srid=3857)
+
+        wkb = geom_schema.deserialize(
+            {},
+            '{"type": "Point", '
+            '"coordinates": [111319.49079327231, 222684.20850554455]}')
+        self.assertEquals(4326, wkb.srid)
+
+        shape = to_shape(wkb)
+        self.assertAlmostEqual(1.0, shape.x)
+        self.assertAlmostEqual(2.0, shape.y)
+
+    def test_serialize_invalid_wrong_type(self):
+        from c2corg_api.ext.colander_ext import Geometry
+        geom_schema = Geometry()
+
+        self.assertRaises(
+            Invalid,
+            geom_schema.deserialize,
+            {},
+            '{"type": "InvalidType", "coordinates": [1.0, 2.0]}')
+
+    def test_serialize_invalid_syntax(self):
+        from c2corg_api.ext.colander_ext import Geometry
+        geom_schema = Geometry()
+
+        self.assertRaises(
+            Invalid,
+            geom_schema.deserialize,
+            {},
+            '"type": "Point", "coordinates": [1.0, 2.0]}')

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -5,6 +5,10 @@ from pyramid.httpexceptions import HTTPError, HTTPNotFound
 from pyramid.view import view_config
 from cornice import Errors
 from cornice.util import json_error
+from geoalchemy2 import WKBElement
+from geoalchemy2.shape import to_shape
+from shapely.geometry import mapping
+import json
 
 
 @view_config(context=HTTPNotFound)
@@ -49,8 +53,12 @@ def serialize(data):
         return type(data)(map(serialize, data))
     if isinstance(data, (datetime.date, datetime.datetime)):
         return data.isoformat()
+    if isinstance(data, WKBElement):
+        geometry = to_shape(data)
+        return json.dumps(mapping(geometry))
     if data is null:
         return None
+
     return data
 
 # Validation functions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 --index-url http://pypi.camptocamp.net/pypi
 -e git+https://github.com/camptocamp/pyramid_closure#egg=pyramid_closure
 
+# needed for ColanderAlchemy: https://github.com/stefanofontanelli/ColanderAlchemy/pull/90
+git+https://github.com/tsauerwein/ColanderAlchemy.git@objectify-none
+
 -e .

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ requires = [
     'colander',
     'ColanderAlchemy>=0.3.2',
     'enum34',
+    'geoalchemy2',
+    'shapely',
+    'pyproj',
     ]
 
 setup(name='c2corg_api',


### PR DESCRIPTION
The geometries are stocked in a separate table, to avoid that potentially big geometries (e.g. tracks) are copied when only a figure was changed.