### PR TITLE
Add CORS headers

### DIFF
--- a/c2corg_api/__init__.py
+++ b/c2corg_api/__init__.py
@@ -1,10 +1,24 @@
 from pyramid.config import Configurator
 from sqlalchemy import engine_from_config
+from pyramid.events import NewRequest
 
 from c2corg_api.models import (
     DBSession,
     Base,
     )
+
+
+def add_cors_headers_response_callback(event):
+    def cors_headers(request, response):
+        response.headers.update({
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'POST,GET,DELETE,PUT,OPTIONS',
+            'Access-Control-Allow-Headers':
+                'Origin, Content-Type, Accept, Authorization',
+            'Access-Control-Allow-Credentials': 'true',
+            'Access-Control-Max-Age': '1728000',
+        })
+    event.request.add_response_callback(cors_headers)
 
 
 def main(global_config, **settings):
@@ -16,4 +30,5 @@ def main(global_config, **settings):
     config = Configurator(settings=settings)
     config.include('cornice')
     config.scan(ignore='c2corg_api.tests')
+    config.add_subscriber(add_cors_headers_response_callback, NewRequest)
     return config.make_wsgi_app()


### PR DESCRIPTION
In the UI when I try to push data to the API I get the following error in my JS dev tool:
```
XMLHttpRequest cannot load http://c2corgv6-demo.gis.internal:6545/waypoints. No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://c2corgv6-demo.gis.internal:6555' is therefore not allowed access. The response had HTTP status code 405.
```

I have found this solution:
http://stackoverflow.com/a/22862087

but not sure it is correct/enough since I then get the following error:
```
MLHttpRequest cannot load http://c2corgv6-demo.gis.internal:6545/waypoints. Invalid HTTP status code 405
```