### PR TITLE
Add CORS parameters to Cornice services

### DIFF
--- a/c2corg_api/__init__.py
+++ b/c2corg_api/__init__.py
@@ -5,6 +5,7 @@ from c2corg_api.models import (
     DBSession,
     Base,
     )
+from c2corg_api.views import cors_policy
 
 
 def main(global_config, **settings):
@@ -14,6 +15,11 @@ def main(global_config, **settings):
     DBSession.configure(bind=engine)
     Base.metadata.bind = engine
     config = Configurator(settings=settings)
+
+    origins = settings['cors.origins']
+    cors_policy['origins'] = origins.split(',')
+
     config.include('cornice')
     config.scan(ignore='c2corg_api.tests')
+
     return config.make_wsgi_app()

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -12,6 +12,12 @@ from shapely.geometry import mapping
 import json
 
 
+cors_policy = dict(
+    headers=('Content-Type'),
+    origins=('*')
+)
+
+
 @view_config(context=HTTPNotFound)
 @view_config(context=HTTPError)
 def http_error_handler(exc, request):

--- a/c2corg_api/views/image.py
+++ b/c2corg_api/views/image.py
@@ -2,11 +2,12 @@ from cornice.resource import resource, view
 
 from c2corg_api.models.image import Image, schema_image, schema_update_image
 from c2corg_api.views.document import DocumentRest
-from c2corg_api.views import json_view
+from c2corg_api.views import json_view, cors_policy
 from c2corg_api.views.validation import validate_id
 
 
-@resource(collection_path='/images', path='/images/{id}')
+@resource(collection_path='/images', path='/images/{id}',
+          cors_policy=cors_policy)
 class ImageRest(DocumentRest):
 
     def collection_get(self):

--- a/c2corg_api/views/route.py
+++ b/c2corg_api/views/route.py
@@ -5,7 +5,7 @@ from c2corg_api.models.route import Route, schema_route, schema_update_route
 from c2corg_api.models.schema_utils import restrict_schema
 from c2corg_api.views.document import DocumentRest, make_validator_create, \
     make_validator_update, make_schema_adaptor
-from c2corg_api.views import json_view
+from c2corg_api.views import json_view, cors_policy
 from c2corg_api.views.validation import validate_id
 from c2corg_common.fields_route import fields_route
 
@@ -30,7 +30,8 @@ listing_schema_adaptor = make_schema_adaptor(
     adapt_schema_for_type, 'route_type', 'listing')
 
 
-@resource(collection_path='/routes', path='/routes/{id}')
+@resource(collection_path='/routes', path='/routes/{id}',
+          cors_policy=cors_policy)
 class RouteRest(DocumentRest):
 
     def collection_get(self):

--- a/c2corg_api/views/waypoint.py
+++ b/c2corg_api/views/waypoint.py
@@ -7,7 +7,7 @@ from c2corg_api.models.schema_utils import restrict_schema
 from c2corg_api.views.document import (
     DocumentRest, make_validator_create, make_validator_update,
     make_schema_adaptor)
-from c2corg_api.views import json_view
+from c2corg_api.views import json_view, cors_policy
 from c2corg_api.views.validation import validate_id
 from c2corg_common.fields_waypoint import fields_waypoint
 
@@ -34,7 +34,8 @@ listing_schema_adaptor = make_schema_adaptor(
     adapt_schema_for_type, 'waypoint_type', 'listing')
 
 
-@resource(collection_path='/waypoints', path='/waypoints/{id}')
+@resource(collection_path='/waypoints', path='/waypoints/{id}',
+          cors_policy=cors_policy)
 class WaypointRest(DocumentRest):
 
     def collection_get(self):

--- a/common.ini.in
+++ b/common.ini.in
@@ -9,7 +9,7 @@ version = {version}
 
 # the origins for CORS
 # e.g.: host1,host2
-cors.origins = c2corgv6-demo.gis.internal
+cors.origins = {cors_origins}
 
 # elasticsearch.host = {elasticsearch_host}
 # elasticsearch.port = 9200

--- a/common.ini.in
+++ b/common.ini.in
@@ -7,6 +7,10 @@ pyramid.default_locale_name = en
 
 version = {version}
 
+# the origins for CORS
+# e.g.: host1,host2
+cors.origins = c2corgv6-demo.gis.internal
+
 # elasticsearch.host = {elasticsearch_host}
 # elasticsearch.port = 9200
 # elasticsearch.index = c2corg

--- a/config/default
+++ b/config/default
@@ -10,6 +10,8 @@ host = c2corgv6.demo-camptocamp.com
 url = http://$(host)
 internalurl = http://localhost
 
+export cors_origins = $(url)
+
 export db_host = localhost
 export db_port = 5432
 export db_user = www-data

--- a/config/default
+++ b/config/default
@@ -8,7 +8,6 @@ export elasticsearch_host = ...
 
 host = c2corgv6.demo-camptocamp.com
 url = http://$(host)
-internalurl = http://localhost
 
 export cors_origins = $(url)
 

--- a/config/dev
+++ b/config/dev
@@ -3,6 +3,5 @@ include Makefile
 export version = 0
 
 host = c2corgv6-demo.gis.internal
-internalurl = $(url)
 
 export cors_origins = $(url):*

--- a/config/dev
+++ b/config/dev
@@ -2,5 +2,7 @@ include Makefile
 
 export version = 0
 
-host = c2corgv6.demo-camptocamp.com
+host = c2corgv6-demo.gis.internal
 internalurl = $(url)
+
+export cors_origins = $(url):*


### PR DESCRIPTION
Replace #47 

Based upon
https://blog.mozilla.org/services/2013/02/04/implementing-cross-origin-resource-sharing-cors-for-cornice/
https://cornice.readthedocs.org/en/latest/api.html?highlight=cors

I have tried to add the cors_policy to the DocumentRest class directly but it failed, most likely because I had omitted the path params in the @resource decorator. Anyway it's probably better to have all the cornice params explicitly set for each service.