### PR TITLE
Remove the activities attribute for waypoints

### DIFF
--- a/c2corg_api/models/waypoint.py
+++ b/c2corg_api/models/waypoint.py
@@ -27,9 +27,6 @@ class _WaypointMixin(object):
     # type de WP
     waypoint_type = Column(enums.waypoint_type, nullable=False)
 
-    # activite (all types)
-    activities = Column(ArrayOfEnum(enums.activity_type))
-
     # altitude
     elevation = Column(SmallInteger)
 
@@ -177,7 +174,7 @@ attributes = [
     'public_transportation_types', 'product_types', 'ground_types',
     'weather_station_types', 'rain_proof', 'public_transportation_rating',
     'paragliding_rating', 'children_proof', 'snow_clearance_rating',
-    'exposition_rating', 'activities', 'rock_types', 'orientation',
+    'exposition_rating', 'rock_types', 'orientation',
     'best_periods', 'url', 'maps_info', 'phone', 'lift_access', 'toilet',
     'phone_custodian', 'custodianship', 'parking_fee', 'matress_unstaffed',
     'blanket_unstaffed', 'gas_unstaffed', 'heating_unstaffed',

--- a/c2corg_api/models/waypoint.py
+++ b/c2corg_api/models/waypoint.py
@@ -132,9 +132,6 @@ class _WaypointMixin(object):
     # servi par des remontees mecaniques (access)
     lift_access = Column(Boolean)
 
-    # wc (base_camp, access)
-    toilet = Column(Boolean)
-
     # parking payant (access)
     parking_fee = Column(enums.parking_fee_type)
 
@@ -175,7 +172,7 @@ attributes = [
     'weather_station_types', 'rain_proof', 'public_transportation_rating',
     'paragliding_rating', 'children_proof', 'snow_clearance_rating',
     'exposition_rating', 'rock_types', 'orientation',
-    'best_periods', 'url', 'maps_info', 'phone', 'lift_access', 'toilet',
+    'best_periods', 'url', 'maps_info', 'phone', 'lift_access',
     'phone_custodian', 'custodianship', 'parking_fee', 'matress_unstaffed',
     'blanket_unstaffed', 'gas_unstaffed', 'heating_unstaffed',
     'climbing_styles', 'access_time', 'climbing_rating_max',


### PR DESCRIPTION
Waypoints no longer have an "activities" attribute.
Related to https://github.com/c2corg/v6_common/pull/2

The tests fail but I guess it's because they need an up-to-date version of c2corg_common for the required fields.