### PR TITLE
Upgrade dependencies on `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ serve: install development.ini
 .build/venv/bin/nosetests: .build/dev-requirements.timestamp
 
 .build/dev-requirements.timestamp: .build/venv dev-requirements.txt
-	.build/venv/bin/pip install -r dev-requirements.txt
+	.build/venv/bin/pip install --upgrade -r dev-requirements.txt
 	touch $@
 
 .build/venv:
@@ -73,7 +73,7 @@ serve: install development.ini
 	virtualenv --no-site-packages $@
 
 $(SITE_PACKAGES)/c2corg_api.egg-link: .build/venv requirements.txt setup.py
-	.build/venv/bin/pip install -r requirements.txt
+	.build/venv/bin/pip install --upgrade -r requirements.txt
 
 development.ini production.ini: common.ini
 


### PR DESCRIPTION
Make sure that packages are updated when running ` make install`. This is to make sure that the latest version of the common project is used.