### PR TITLE
Manually set inheritance column in migration

### DIFF
--- a/c2corg_api/scripts/migration/documents/document.py
+++ b/c2corg_api/scripts/migration/documents/document.py
@@ -4,6 +4,8 @@ import zope
 import abc
 import re
 
+from c2corg_api.models.document import DocumentGeometry, \
+    ArchiveDocumentGeometry
 from c2corg_api.scripts.migration.documents.batch_document import DocumentBatch
 from c2corg_api.scripts.migration.migrate_base import MigrateBase
 
@@ -22,13 +24,11 @@ class MigrateDocuments(MigrateBase):
     def get_model_archive_document(self, locales):
         pass
 
-    @abc.abstractmethod
     def get_model_geometry(self):
-        pass
+        return DocumentGeometry
 
-    @abc.abstractmethod
     def get_model_archive_geometry(self):
-        pass
+        return ArchiveDocumentGeometry
 
     @abc.abstractmethod
     def get_query(self):
@@ -42,25 +42,26 @@ class MigrateDocuments(MigrateBase):
     def get_document(self, document_in, version):
         pass
 
-    @abc.abstractmethod
     def get_document_archive(self, document_in, version):
-        pass
+        doc = self.get_document(document_in, version)
+        doc['id'] = document_in.document_archive_id
+        return doc
 
     @abc.abstractmethod
     def get_document_geometry(self, document_in, version):
         pass
 
-    @abc.abstractmethod
     def get_document_geometry_archive(self, document_in, version):
-        pass
+        doc = self.get_document_geometry(document_in, version)
+        doc['id'] = document_in.document_archive_id
+        return doc
 
     @abc.abstractmethod
     def get_document_locale(self, document_in, version):
         pass
 
-    @abc.abstractmethod
     def get_document_locale_archive(self, document_in, version):
-        pass
+        return self.get_document_locale(document_in, version)
 
     @abc.abstractmethod
     def get_name(self):

--- a/c2corg_api/scripts/migration/documents/waypoints/huts.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/huts.py
@@ -47,6 +47,7 @@ class MigrateHuts(MigrateWaypoints):
 
         return dict(
             document_id=document_in.id,
+            type='w',
             version=version,
             waypoint_type=waypoint_type,
             protected=document_in.is_protected,
@@ -72,6 +73,7 @@ class MigrateHuts(MigrateWaypoints):
         return dict(
             document_id=document_in.id,
             id=document_in.document_i18n_archive_id,
+            type='w',
             version=version,
             culture=document_in.culture,
             title=document_in.name,

--- a/c2corg_api/scripts/migration/documents/waypoints/parking.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/parking.py
@@ -42,6 +42,7 @@ class MigrateParkings(MigrateWaypoints):
     def get_document(self, document_in, version):
         return dict(
             document_id=document_in.id,
+            type='w',
             version=version,
             waypoint_type='access',
             protected=document_in.is_protected,
@@ -65,6 +66,7 @@ class MigrateParkings(MigrateWaypoints):
         return dict(
             document_id=document_in.id,
             id=document_in.document_i18n_archive_id,
+            type='w',
             version=version,
             culture=document_in.culture,
             title=document_in.name,

--- a/c2corg_api/scripts/migration/documents/waypoints/products.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/products.py
@@ -40,6 +40,7 @@ class MigrateProducts(MigrateWaypoints):
     def get_document(self, document_in, version):
         return dict(
             document_id=document_in.id,
+            type='w',
             version=version,
             waypoint_type='local_product',
             protected=document_in.is_protected,
@@ -56,6 +57,7 @@ class MigrateProducts(MigrateWaypoints):
         return dict(
             document_id=document_in.id,
             id=document_in.document_i18n_archive_id,
+            type='w',
             version=version,
             culture=document_in.culture,
             title=document_in.name,

--- a/c2corg_api/scripts/migration/documents/waypoints/sites.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/sites.py
@@ -46,6 +46,7 @@ class MigrateSites(MigrateWaypoints):
         indoor_types, outdoor_types = self.get_climbing_types(document_in)
         return dict(
             document_id=document_in.id,
+            type='w',
             version=version,
             waypoint_type='climbing_indoor' if indoor_types
                           else 'climbing_outdoor',
@@ -87,6 +88,7 @@ class MigrateSites(MigrateWaypoints):
         return dict(
             document_id=document_in.id,
             id=document_in.document_i18n_archive_id,
+            type='w',
             version=version,
             culture=document_in.culture,
             title=document_in.name,

--- a/c2corg_api/scripts/migration/documents/waypoints/summit.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/summit.py
@@ -37,6 +37,7 @@ class MigrateSummits(MigrateWaypoints):
     def get_document(self, document_in, version):
         return dict(
             document_id=document_in.id,
+            type='w',
             version=version,
             waypoint_type=self.convert_type(
                 document_in.summit_type, MigrateSummits.summit_types),
@@ -51,6 +52,7 @@ class MigrateSummits(MigrateWaypoints):
         return dict(
             document_id=document_in.id,
             id=document_in.document_i18n_archive_id,
+            type='w',
             version=version,
             culture=document_in.culture,
             title=document_in.name,

--- a/c2corg_api/scripts/migration/documents/waypoints/waypoint.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/waypoint.py
@@ -1,5 +1,3 @@
-from c2corg_api.models.document import DocumentGeometry, \
-    ArchiveDocumentGeometry
 from c2corg_api.models.waypoint import Waypoint, ArchiveWaypoint, \
     WaypointLocale, ArchiveWaypointLocale
 from c2corg_api.scripts.migration.documents.document import MigrateDocuments
@@ -13,17 +11,6 @@ class MigrateWaypoints(MigrateDocuments):
     def get_model_archive_document(self, locales):
         return ArchiveWaypointLocale if locales else ArchiveWaypoint
 
-    def get_model_geometry(self):
-        return DocumentGeometry
-
-    def get_model_archive_geometry(self):
-        return ArchiveDocumentGeometry
-
-    def get_document_archive(self, document_in, version):
-        doc = self.get_document(document_in, version)
-        doc['id'] = document_in.document_archive_id
-        return doc
-
     def get_document_geometry(self, document_in, version):
         return dict(
             document_id=document_in.id,
@@ -31,11 +18,3 @@ class MigrateWaypoints(MigrateDocuments):
             version=version,
             geom=document_in.geom
         )
-
-    def get_document_geometry_archive(self, document_in, version):
-        doc = self.get_document_geometry(document_in, version)
-        doc['id'] = document_in.document_archive_id
-        return doc
-
-    def get_document_locale_archive(self, document_in, version):
-        return self.get_document_locale(document_in, version)


### PR DESCRIPTION
The type column in the documents table is the [discriminator column](http://docs.sqlalchemy.org/en/rel_1_0/orm/inheritance.html#joined-table-inheritance) for the inheritance. Usually this column is set automatically by SQLAlchemy. But when doing bulk-insertions, it seems that you have to set it manually.

Closes #64 