### PR TITLE
Disable auth check for dev instances

### DIFF
--- a/common.ini.in
+++ b/common.ini.in
@@ -3,6 +3,9 @@
 [app:main]
 use = egg:c2corg_api
 
+# Disable the authorization checks if True
+noauthorization = {noauthorization}
+
 pyramid.default_locale_name = en
 
 version = {version}

--- a/config/default
+++ b/config/default
@@ -10,6 +10,7 @@ host = c2corgv6.demo-camptocamp.com
 url = http://$(host)
 
 export cors_origins = $(url)
+export noauthorization = False
 
 export db_host = localhost
 export db_port = 5432

--- a/config/dev
+++ b/config/dev
@@ -5,3 +5,4 @@ export version = 0
 host = c2corgv6-demo.gis.internal
 
 export cors_origins = $(url):*
+export noauthorization = True


### PR DESCRIPTION
Else it is no longer possible to make POST/PUT requests to the API from the UI until the authentication tool is available.