### PR TITLE
Add `upgrade` target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ help:
 	@echo "Secondary targets:"
 	@echo
 	@echo "- lint			Run flake8 checker on the Python code"
+	@echo "- upgrade		Upgrade the dependencies."
+	@echo "- upgrade-dev		Upgrade the dev. dependencies."
 
 .PHONY: check
 check: lint test
@@ -59,6 +61,14 @@ install-dev-egg: $(SITE_PACKAGES)/c2corg_api.egg-link
 .PHONY: serve
 serve: install development.ini
 	.build/venv/bin/pserve --reload development.ini
+
+.PHONY: upgrade
+upgrade:
+	.build/venv/bin/pip install --upgrade -r requirements.txt
+
+.PHONY: upgrade-dev
+upgrade-dev:
+	.build/venv/bin/pip install --upgrade -r dev-requirements.txt
 
 .build/venv/bin/flake8: .build/dev-requirements.timestamp
 

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ serve: install development.ini
 .build/venv/bin/nosetests: .build/dev-requirements.timestamp
 
 .build/dev-requirements.timestamp: .build/venv dev-requirements.txt
-	.build/venv/bin/pip install --upgrade -r dev-requirements.txt
+	.build/venv/bin/pip install -r dev-requirements.txt
 	touch $@
 
 .build/venv:
@@ -73,7 +73,7 @@ serve: install development.ini
 	virtualenv --no-site-packages $@
 
 $(SITE_PACKAGES)/c2corg_api.egg-link: .build/venv requirements.txt setup.py
-	.build/venv/bin/pip install --upgrade -r requirements.txt
+	.build/venv/bin/pip install -r requirements.txt
 
 development.ini production.ini: common.ini
 


### PR DESCRIPTION
This reverts #61 to avoid that the dependencies are updated every time when running `make serve`. This caused problems with the ui tests on Travis because the server took too long to start.

Instead the dependencies can be upgraded by manually running `make -f ... upgrade` or `make -f ... upgrade-dev`.