### PR TITLE
Improve try_login function

### DIFF
--- a/c2corg_api/security/roles.py
+++ b/c2corg_api/security/roles.py
@@ -57,7 +57,7 @@ def try_login(username, password, request):
     user = DBSession.query(User). \
         filter(User.username == username).first()
 
-    if username and password and user.validate_password(password, DBSession):
+    if user and user.validate_password(password, DBSession):
         policy = request.registry.queryUtility(IAuthenticationPolicy)
         now = datetime.datetime.utcnow()
         exp = now + datetime.timedelta(weeks=CONST_EXPIRE_AFTER_DAYS)
@@ -65,3 +65,5 @@ def try_login(username, password, request):
         token = policy.encode_jwt(request, claims=claims)
         add_token(token, exp, user.id)
         return token
+
+    return None

--- a/c2corg_api/views/auth.py
+++ b/c2corg_api/views/auth.py
@@ -1,7 +1,5 @@
 from pyramid.view import view_config
-from c2corg_api.security.roles import try_login, remove_token
-
-import json
+from c2corg_api.security.roles import remove_token
 
 
 @view_config(route_name='logout', renderer='json', permission='authenticated')
@@ -14,20 +12,3 @@ def logout(request):
 @view_config(route_name='check_token', renderer='json')
 def token_permissions(request):
     return {'user': request.authenticated_userid}
-
-
-@view_config(route_name='login', renderer='json')
-def login(request):
-    form = json.loads(request.body)
-    user = form['username']
-    password = form['password']
-
-    token = try_login(user, password, request)
-    if token:
-        return {
-            'token': token
-        }
-    else:
-        return {
-            'error': 'login failed'
-        }


### PR DESCRIPTION
As for now if no user matches the username/password, ``user`` is None and we get an error when trying to run ``user.validate_password(password, DBSession)``.

By the way shouldn't we test sooner (at the beginning of the function, before making the user query?) that ``username`` and ``password`` are indeed set?

I have also added a ``return None`` statement because I think it is more consistent to return something anyway (maybe that's implicit but...).