### PR TITLE
Move JWT master key to common config

### DIFF
--- a/common.ini.in
+++ b/common.ini.in
@@ -21,3 +21,6 @@ elasticsearch.index = {elasticsearch_index}
 logging.level = {logging_level}
 
 jwtauth.find_groups = c2corg_api.security.roles:groupfinder
+
+# FIXME: do not save the secret key on github
+jwtauth.master_secret = The master key

--- a/development.ini.in
+++ b/development.ini.in
@@ -24,9 +24,6 @@ sqlalchemy.url = postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_na
 # '127.0.0.1' and '::1'.
 debugtoolbar.hosts = 0.0.0.0/0
 
-# Key for developpement
-jwtauth.master_secret = The master key
-
 ###
 # wsgi server configuration
 ###


### PR DESCRIPTION
Related to #98

Else the login action fails in apache mode ("production" instead of "development") with error such as
```
[Fri Dec 11 13:51:18.496526 2015] [wsgi:error] [pid 32297] [remote 10.27.71.4:512]   File "/var/www/vhosts/c2cassoc_c2corgv6/private/v6_api/.build/venv/lib/python2.7/site-packages/pyramid_jwtauth/__init__.py", line 359, in encode_jwt
[Fri Dec 11 13:51:18.496661 2015] [wsgi:error] [pid 32297] [remote 10.27.71.4:512]     jwtauth_token = jwt.encode(encode_claims, key=key, algorithm=algorithm)
[Fri Dec 11 13:51:18.496770 2015] [wsgi:error] [pid 32297] [remote 10.27.71.4:512]   File "/var/www/vhosts/c2cassoc_c2corgv6/private/v6_api/.build/venv/lib/python2.7/site-packages/jwt/api_jwt.py", line 56, in encode
[Fri Dec 11 13:51:18.502079 2015] [wsgi:error] [pid 32297] [remote 10.27.71.4:512]     json_payload, key, algorithm, headers, json_encoder
[Fri Dec 11 13:51:18.502238 2015] [wsgi:error] [pid 32297] [remote 10.27.71.4:512]   File "/var/www/vhosts/c2cassoc_c2corgv6/private/v6_api/.build/venv/lib/python2.7/site-packages/jwt/api_jws.py", line 97, in encode
[Fri Dec 11 13:51:18.509265 2015] [wsgi:error] [pid 32297] [remote 10.27.71.4:512]     key = alg_obj.prepare_key(key)
[Fri Dec 11 13:51:18.509410 2015] [wsgi:error] [pid 32297] [remote 10.27.71.4:512]   File "/var/www/vhosts/c2cassoc_c2corgv6/private/v6_api/.build/venv/lib/python2.7/site-packages/jwt/algorithms.py", line 116, in prepare_key
[Fri Dec 11 13:51:18.513882 2015] [wsgi:error] [pid 32297] [remote 10.27.71.4:512]     raise TypeError('Expecting a string- or bytes-formatted key.')
[Fri Dec 11 13:51:18.514090 2015] [wsgi:error] [pid 32297] [remote 10.27.71.4:512] TypeError: Expecting a string- or bytes-formatted key.
```