### PR TITLE
Main instance config directly include the makefile, not the dev config

### DIFF
--- a/config/main
+++ b/config/main
@@ -1,4 +1,4 @@
-include config/dev
+include Makefile
 
 export debug_port = 6543
 export instanceid = api


### PR DESCRIPTION
The main instance is not a dev instance. It uses apache, the standard URL, etc.

This PR fixes the cors_origins problem mentioned in #98 