### PR TITLE
Allow * in CORS

### DIFF
--- a/c2corg_api/__init__.py
+++ b/c2corg_api/__init__.py
@@ -9,7 +9,6 @@ from c2corg_api.models import (
     Base,
     )
 from c2corg_api.search import configure_es_from_config
-from c2corg_api.views import cors_policy
 
 from pyramid.security import Allow, Everyone, Authenticated
 
@@ -72,9 +71,6 @@ def main(global_config, **settings):
     configure_es_from_config(settings)
 
     config = Configurator(settings=settings)
-
-    origins = settings['cors.origins']
-    cors_policy['origins'] = origins.split(',')
 
     # Add routes not handled by Cornice
     config.add_route('login', '/login')

--- a/common.ini.in
+++ b/common.ini.in
@@ -10,10 +10,6 @@ pyramid.default_locale_name = en
 
 version = {version}
 
-# the origins for CORS
-# e.g.: host1,host2
-cors.origins = {cors_origins}
-
 elasticsearch.host = {elasticsearch_host}
 elasticsearch.port = {elasticsearch_port}
 elasticsearch.index = {elasticsearch_index}

--- a/config/default
+++ b/config/default
@@ -7,7 +7,6 @@ export debug_port = 6543
 host = c2corgv6.demo-camptocamp.com
 url = http://$(host)
 
-export cors_origins = $(url)
 export noauthorization = False
 
 export db_host = localhost

--- a/config/dev
+++ b/config/dev
@@ -3,5 +3,3 @@ include Makefile
 export version = 0
 
 host = c2corgv6-demo.gis.internal
-
-export cors_origins = $(url):*

--- a/config/gberaudo
+++ b/config/gberaudo
@@ -7,4 +7,3 @@ export db_name = c2corg_gberaudo
 export tests_db_name = c2corg_gberaudo_tests
 export elasticsearch_index = c2corg_gberaudo
 export tests_elasticsearch_index = c2corg_gberaudo_tests
-export cors_origins = *


### PR DESCRIPTION
CORS * allows any web client to send requests to the API.
The API will check for the token so:
- browsers sending an authorization token will get access to protected
  content;
- browsers not sending an authorization token will only get access to
  public content.

There is no security reason to maintain and restrict access to some
whitelisted domains.

When using cookies together with a CSRF token, the situation is
identical and using * is also secure.