### PR TITLE
Provide sso for discourse

### DIFF
--- a/c2corg_api/security/discourse_sso_provider.py
+++ b/c2corg_api/security/discourse_sso_provider.py
@@ -1,0 +1,53 @@
+from pyramid.httpexceptions import HTTPBadRequest
+
+import base64
+import hmac
+import hashlib
+import urllib
+
+from urlparse import parse_qs
+
+import logging
+log = logging.getLogger(__name__)
+
+
+def decode_payload(payload, key):
+    decoded = base64.decodestring(payload)
+    assert 'nonce' in decoded
+    assert len(payload) > 0
+    return decoded
+
+
+def discourse_redirect(user, sso, signature, settings):
+    base_url = '%s/session/sso_login' % settings.get('discourse.url')
+    key = str(settings.get('discourse.sso_secret'))  # must not be unicode
+
+    payload = urllib.unquote(sso)
+    try:
+        decoded = decode_payload(payload, key)
+    except Exception as e:
+        log.error('Failed to decode payload', e)
+        raise HTTPBadRequest('discourse login failed')
+
+    h = hmac.new(key, payload, digestmod=hashlib.sha256)
+    this_signature = h.hexdigest()
+
+    if this_signature != signature:
+        log.error('Signature mismatch')
+        raise HTTPBadRequest('discourse login failed')
+
+    # Build the return payload
+
+    qs = parse_qs(decoded)
+    params = {
+        'nonce': qs['nonce'][0],
+        'email': user.email,
+        'external_id': user.id,
+        'username': user.username,
+        'name': user.username,
+    }
+
+    return_payload = base64.encodestring(urllib.urlencode(params))
+    h = hmac.new(key, return_payload, digestmod=hashlib.sha256)
+    qs = urllib.urlencode({'sso': return_payload, 'sig': h.hexdigest()})
+    return '%s?%s' % (base_url, qs)

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -107,6 +107,7 @@ class BaseTestCase(unittest.TestCase):
         self.global_userids = global_userids
         self.global_tokens = global_tokens
         self.global_passwords = global_passwords
+        self.settings = settings
         unittest.TestCase.__init__(self, *args, **kwargs)
 
     @classmethod

--- a/common.ini.in
+++ b/common.ini.in
@@ -20,3 +20,7 @@ jwtauth.find_groups = c2corg_api.security.roles:groupfinder
 
 # FIXME: do not save the secret key on github
 jwtauth.master_secret = The master key
+
+# FIXME: do not save the forum key on github
+discourse.url = {discourse_url}
+discourse.sso_secret = some secret string

--- a/config/default
+++ b/config/default
@@ -19,6 +19,8 @@ export elasticsearch_host = localhost
 export elasticsearch_port = 9200
 export elasticsearch_index = c2corg
 
+export discourse_url = http://c2corgv6-discourse.demo-camptocamp.com
+
 # database to run the unit tests
 export tests_db_host = localhost
 export tests_db_port = 5432

--- a/config/gberaudo
+++ b/config/gberaudo
@@ -7,3 +7,4 @@ export db_name = c2corg_gberaudo
 export tests_db_name = c2corg_gberaudo_tests
 export elasticsearch_index = c2corg_gberaudo
 export tests_elasticsearch_index = c2corg_gberaudo_tests
+export discourse_url = http://localhost:3000

--- a/test.ini.in
+++ b/test.ini.in
@@ -10,3 +10,5 @@ jwtauth.master_secret = The master key
 elasticsearch.host = {tests_elasticsearch_host}
 elasticsearch.port = {tests_elasticsearch_port}
 elasticsearch.index = {tests_elasticsearch_index}
+discourse.url = http://discuss.example.com
+discourse.sso_secret = d836444a9e4084d5b224a60c208dce14


### PR DESCRIPTION
Try to read a discourse sso and sig from authentication request.
If present, validate and return the response in a redirect attribute.