### PR TITLE
Return empty locales list instead of 404

### DIFF
--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -168,6 +168,20 @@ class BaseDocumentTestRest(BaseTestRest):
         locale_en = locales[0]
         self.assertEqual(locale_en.get('culture'), self.locale_en.culture)
 
+    def get_new_lang(self, reference):
+        response = self.app.get(self._prefix + '/' +
+                                str(reference.document_id) + '?l=it',
+                                status=200)
+        self.assertEqual(response.content_type, 'application/json')
+
+        body = response.json
+        locales = body.get('locales')
+        self.assertEqual(len(locales), 0)
+
+    def get_404(self):
+        self.app.get(self._prefix + '/-9999', status=404)
+        self.app.get(self._prefix + '/-9999?l=es', status=404)
+
     def post_error(self, request_body):
         response = self.app.post_json(self._prefix, request_body,
                                       expect_errors=True, status=403)

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -51,6 +51,12 @@ class TestImageRest(BaseDocumentTestRest):
     def test_get_lang(self):
         self.get_lang(self.image)
 
+    def test_get_new_lang(self):
+        self.get_new_lang(self.image)
+
+    def test_get_404(self):
+        self.get_404()
+
     def test_post_error(self):
         body = self.post_error({})
         errors = body.get('errors')

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -63,6 +63,12 @@ class TestRouteRest(BaseDocumentTestRest):
     def test_get_lang(self):
         self.get_lang(self.route)
 
+    def test_get_new_lang(self):
+        self.get_new_lang(self.route)
+
+    def test_get_404(self):
+        self.get_404()
+
     def test_post_error(self):
         body = self.post_error({})
         errors = body.get('errors')

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -68,6 +68,12 @@ class TestWaypointRest(BaseDocumentTestRest):
     def test_get_lang(self):
         self.get_lang(self.waypoint)
 
+    def test_get_new_lang(self):
+        self.get_new_lang(self.waypoint)
+
+    def test_get_404(self):
+        self.get_404()
+
     def test_post_error(self):
         body = self.post_error({})
         errors = body.get('errors')


### PR DESCRIPTION
... when requesting a not-existing locale of a document.

Closes https://github.com/c2corg/v6_ui/issues/10