### PR TITLE
Switch to Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 
 python:
-- 2.7
+- 3.4
 
 addons:
   postgresql: "9.4"

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ upgrade-dev:
 
 .build/venv:
 	mkdir -p $(dir $@)
-	virtualenv --no-site-packages $@
+	virtualenv --no-site-packages -p python3 $@
 
 $(SITE_PACKAGES)/c2corg_api.egg-link: .build/venv requirements.txt setup.py
 	.build/venv/bin/pip install -r requirements.txt

--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -14,14 +14,13 @@ from geoalchemy2 import Geometry
 import geoalchemy2
 from shapely import wkt
 from colander import MappingSchema, SchemaNode, String as ColanderString, null
-from itertools import ifilter
+
 import abc
 import enum
-import string
 
 from c2corg_api.models import Base, schema, DBSession
 from c2corg_api.ext import colander_ext
-from utils import copy_attributes
+from c2corg_api.models.utils import copy_attributes
 
 from pyramid.httpexceptions import HTTPInternalServerError
 
@@ -181,7 +180,7 @@ class Document(Base, _DocumentMixin):
         is present.
         """
         return next(
-            ifilter(lambda locale: locale.culture == culture, self.locales),
+            filter(lambda locale: locale.culture == culture, self.locales),
             None)
 
 
@@ -318,8 +317,8 @@ class DocumentGeometry(Base, _DocumentGeometryMixin):
             proj1 = self.geom.srid
         else:
             # WKT are used in the tests.
-            split1 = string.split(self.geom, ';')
-            proj1 = int(string.split(split1[0], '=')[1])
+            split1 = str.split(self.geom, ';')
+            proj1 = int(str.split(split1[0], '=')[1])
             str1 = split1[1]
             g1 = wkt.loads(str1)
 
@@ -330,8 +329,8 @@ class DocumentGeometry(Base, _DocumentGeometryMixin):
             proj2 = other.geom.srid
         else:
             # WKT are used in the tests.
-            split2 = string.split(other.geom, ';')
-            proj2 = int(string.split(split2[0], '=')[1])
+            split2 = str.split(other.geom, ';')
+            proj2 = int(str.split(split2[0], '=')[1])
             str2 = split2[1]
             g2 = wkt.loads(str2)
 

--- a/c2corg_api/models/document_history.py
+++ b/c2corg_api/models/document_history.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import relationship, backref
 import datetime
 
 from c2corg_api.models import Base, schema
-from document import (
+from c2corg_api.models.document import (
     Document, ArchiveDocument, ArchiveDocumentLocale, ArchiveDocumentGeometry)
 
 

--- a/c2corg_api/models/image.py
+++ b/c2corg_api/models/image.py
@@ -9,8 +9,8 @@ from sqlalchemy import (
 from colanderalchemy import SQLAlchemySchemaNode
 
 from c2corg_api.models import schema
-from utils import copy_attributes
-from document import (
+from c2corg_api.models.utils import copy_attributes
+from c2corg_api.models.document import (
     ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale,
     get_update_schema, geometry_schema_overrides)
 from c2corg_common.attributes import activities

--- a/c2corg_api/models/route.py
+++ b/c2corg_api/models/route.py
@@ -12,8 +12,8 @@ import colander
 
 from c2corg_api.models import schema
 from c2corg_api.models.utils import ArrayOfEnum
-from utils import copy_attributes
-from document import (
+from c2corg_api.models.utils import copy_attributes
+from c2corg_api.models.document import (
     ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale,
     get_update_schema, geometry_schema_overrides, schema_locale_attributes,
     schema_attributes)

--- a/c2corg_api/models/user.py
+++ b/c2corg_api/models/user.py
@@ -1,11 +1,10 @@
 import bcrypt
-
 from sqlalchemy import (
     Boolean,
     Column,
     Integer,
     String
-    )
+)
 
 from colanderalchemy import SQLAlchemySchemaNode
 
@@ -20,12 +19,16 @@ class PasswordUtil():
     """
     @staticmethod
     def encrypt_password(plain_password):
-        return bcrypt.hashpw(plain_password, bcrypt.gensalt())
+        if isinstance(plain_password, str):
+            plain_password = plain_password.encode('utf-8')
+        return bcrypt.hashpw(plain_password, bcrypt.gensalt()).decode('utf-8')
 
     @staticmethod
     def is_password_valid(plain, encrypted):
-        if isinstance(encrypted, unicode):
-            encrypted = encrypted.encode('UTF-8')
+        if isinstance(encrypted, str):
+            encrypted = encrypted.encode('utf-8')
+        if isinstance(plain, str):
+            plain = plain.encode('utf-8')
         return bcrypt.hashpw(plain, encrypted) == encrypted
 
 

--- a/c2corg_api/models/waypoint.py
+++ b/c2corg_api/models/waypoint.py
@@ -10,8 +10,8 @@ from sqlalchemy import (
 from colanderalchemy import SQLAlchemySchemaNode
 
 from c2corg_api.models import schema
-from utils import copy_attributes, ArrayOfEnum
-from document import (
+from c2corg_api.models.utils import copy_attributes, ArrayOfEnum
+from c2corg_api.models.document import (
     ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale,
     get_update_schema, geometry_schema_overrides, schema_attributes,
     schema_locale_attributes)

--- a/c2corg_api/scripts/initializees.py
+++ b/c2corg_api/scripts/initializees.py
@@ -43,7 +43,7 @@ def setup_es():
     if client.indices.exists(index_name):
         print('Index "{0}" already exists. To re-create the index, manually '
               'delete the index and run this script again.'.format(index_name))
-        print ('To delete the index run:')
+        print('To delete the index run:')
         print('curl -XDELETE \'http://{0}:{1}/{2}/\''.format(
             elasticsearch_config['host'], elasticsearch_config['port'],
             index_name))

--- a/c2corg_api/scripts/migration/documents/waypoints/sites.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/sites.py
@@ -138,7 +138,7 @@ class MigrateSites(MigrateWaypoints):
         self.add_section(sections, 'external_resources', document_in)
         self.add_section(sections, 'site_history', document_in)
 
-        return u'\n'.join(sections)
+        return '\n'.join(sections)
 
     def add_section(self, sections, field, document_in):
         text = document_in[field]
@@ -147,9 +147,9 @@ class MigrateSites(MigrateWaypoints):
         text = text.strip()
 
         if text:
-            section = u''
+            section = ''
             header = self.translate(field, document_in.culture)
-            section += u'## ' + header + u'\n'
+            section += '## ' + header + '\n'
             section += text
             sections.append(section)
 
@@ -158,40 +158,40 @@ class MigrateSites(MigrateWaypoints):
 
     translations = {
         'way_back': {
-            'ca': u'Baixada de las vies',
-            'de': u'Abstieg der Route',
-            'en': u'Means of descent',
-            'es': u'Bajada de las vías',
-            'eu': u'Luzeeren jeitsiera',
-            'fr': u'Descente des voies',
-            'it': u'Discesa delle vie'
+            'ca': 'Baixada de las vies',
+            'de': 'Abstieg der Route',
+            'en': 'Means of descent',
+            'es': 'Bajada de las vías',
+            'eu': 'Luzeeren jeitsiera',
+            'fr': 'Descente des voies',
+            'it': 'Discesa delle vie'
         },
         'remarks': {
-            'ca': u'Remarques',
-            'de': u'Bemerkungen',
-            'en': u'Remarks',
-            'es': u'Observaciones',
-            'eu': u'Azalpenak',
-            'fr': u'Remarques',
-            'it': u'Osservazioni'
+            'ca': 'Remarques',
+            'de': 'Bemerkungen',
+            'en': 'Remarks',
+            'es': 'Observaciones',
+            'eu': 'Azalpenak',
+            'fr': 'Remarques',
+            'it': 'Osservazioni'
         },
         'external_resources': {
-            'ca': u'Bibliografia i webgrafia',
-            'de': u'Bibliographie',
-            'en': u'External resources',
-            'es': u'Bibliografía y webgrafía',
-            'eu': u'Bibliografia et webografia',
-            'fr': u'Bibliographie et webographie',
-            'it': u'Bibliografia e riferimenti web'
+            'ca': 'Bibliografia i webgrafia',
+            'de': 'Bibliographie',
+            'en': 'External resources',
+            'es': 'Bibliografía y webgrafía',
+            'eu': 'Bibliografia et webografia',
+            'fr': 'Bibliographie et webographie',
+            'it': 'Bibliografia e riferimenti web'
         },
         'site_history': {
-            'ca': u'Històric',
-            'de': u'Geschichte des Klettersektors',
-            'en': u'Site history',
-            'es': u'Historia',
-            'eu': u'Historia',
-            'fr': u'Historique du site',
-            'it': u'Cenni storici'
+            'ca': 'Històric',
+            'de': 'Geschichte des Klettersektors',
+            'en': 'Site history',
+            'es': 'Historia',
+            'eu': 'Historia',
+            'fr': 'Historique du site',
+            'it': 'Cenni storici'
         }
     }
 

--- a/c2corg_api/scripts/migration/migrate_base.py
+++ b/c2corg_api/scripts/migration/migrate_base.py
@@ -16,7 +16,7 @@ class MigrateBase(object):
         pass
 
     def start(self, type):
-        print('Importing {0}'.format(type))
+        print(('Importing {0}'.format(type)))
         self.start_time = datetime.now()
 
     def stop(self):

--- a/c2corg_api/security/roles.py
+++ b/c2corg_api/security/roles.py
@@ -70,7 +70,7 @@ def try_login(user, password, request):
         now = datetime.datetime.utcnow()
         exp = now + datetime.timedelta(days=CONST_EXPIRE_AFTER_DAYS)
         claims = create_claims(user, exp)
-        token = policy.encode_jwt(request, claims=claims)
+        token = policy.encode_jwt(request, claims=claims).decode('utf-8')
         return add_or_retrieve_token(token, exp, user.id)
 
     return None
@@ -84,7 +84,7 @@ def renew_token(user, request):
         now = datetime.datetime.utcnow()
         exp = now + datetime.timedelta(days=CONST_EXPIRE_AFTER_DAYS)
         claims = create_claims(user, exp)
-        token_value = policy.encode_jwt(request, claims=claims)
+        token_value = policy.encode_jwt(request, claims=claims).decode('utf-8')
         return add_or_retrieve_token(token_value, exp, user.id)
 
     return None

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -60,7 +60,8 @@ def _add_global_test_data(session):
 
     for user in [moderator, contributor]:
         claims = create_claims(user, exp)
-        token = jwt.encode(claims, key=key, algorithm=algorithm)
+        token = jwt.encode(claims, key=key, algorithm=algorithm). \
+            decode('utf-8')
         add_or_retrieve_token(token, exp, user.id)
         global_userids[user.username] = user.id
         global_tokens[user.username] = token

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -1,5 +1,7 @@
 import json
-import urllib
+import urllib.request
+import urllib.parse
+import urllib.error
 
 from c2corg_api.search import elasticsearch_config
 from c2corg_api.search.mapping import SearchDocument
@@ -23,7 +25,7 @@ class BaseTestRest(BaseTestCase):
             headers = {}
         if not token:
             token = self.global_tokens[username]
-        headers['Authorization'] = 'JWT token="' + token.encode('ascii') + '"'
+        headers['Authorization'] = 'JWT token="' + token + '"'
         return headers
 
     def get_json_with_token(self, url, token, status=200):
@@ -68,7 +70,7 @@ class BaseDocumentTestRest(BaseTestRest):
         prefix = self._prefix
         limit = None
         if params:
-            prefix += "?" + urllib.urlencode(params)
+            prefix += "?" + urllib.parse.urlencode(params)
             limit = params['limit']
 
         response = self.app.get(prefix, status=200)
@@ -109,7 +111,7 @@ class BaseDocumentTestRest(BaseTestRest):
 
     def assertResultsEqual(self, actual, expected, total):  # noqa
         actual_docs = actual['documents']
-        actual_ids = map(lambda json: json['document_id'], actual_docs)
+        actual_ids = [json['document_id'] for json in actual_docs]
         self.assertListEqual(actual_ids, expected)
         actual_total = actual['total']
         self.assertEqual(actual_total, total)

--- a/c2corg_api/tests/views/test_user.py
+++ b/c2corg_api/tests/views/test_user.py
@@ -92,9 +92,9 @@ class TestUserRest(BaseTestRest):
         now = int(round(time.time()))
         expected = days * 24 * 3600 + now  # 14 days from now
         if (abs(expected - expire) > seconds_delta):
-            raise self.failureException, \
-                    '%r == %r within %r seconds' % \
-                    (expected, expire, seconds_delta)
+            raise self.failureException(
+                '%r == %r within %r seconds' %
+                (expected, expire, seconds_delta))
 
     def test_login_logout_success(self):
         body = self.login('moderator').json
@@ -123,7 +123,7 @@ class TestUserRest(BaseTestRest):
         token1 = self.login('contributor').json['token']
 
         import time
-        print 'Waiting for more than 1s to get a different token'
+        print('Waiting for more than 1s to get a different token')
         time.sleep(1.01)
 
         token2 = self.post_json_with_token('/users/renew', token1)['token']

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -87,12 +87,12 @@ def serialize(data):
     Returns the most agnostic version of specified data.
     (remove colander notions, datetimes in ISO, ...)
     """
-    if isinstance(data, basestring):
-        return unicode(data)
+    if isinstance(data, str):
+        return str(data)
     if isinstance(data, collections.Mapping):
-        return dict(map(serialize, data.iteritems()))
+        return dict(list(map(serialize, iter(data.items()))))
     if isinstance(data, collections.Iterable):
-        return type(data)(map(serialize, data))
+        return type(data)(list(map(serialize, data)))
     if isinstance(data, (datetime.date, datetime.datetime)):
         return data.isoformat()
     if isinstance(data, WKBElement):

--- a/c2corg_api/views/waypoint.py
+++ b/c2corg_api/views/waypoint.py
@@ -1,5 +1,4 @@
 from cornice.resource import resource, view
-from functools32 import lru_cache
 
 from c2corg_api.models.waypoint import (
     Waypoint, schema_waypoint, schema_update_waypoint,
@@ -15,7 +14,7 @@ from c2corg_api.views.validation import validate_id, validate_pagination, \
     validate_preferred_lang_param
 from c2corg_common.fields_waypoint import fields_waypoint
 from c2corg_common.attributes import waypoint_types
-
+from functools import lru_cache
 
 validate_waypoint_create = make_validator_create(
     fields_waypoint, 'waypoint_type', waypoint_types)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ GeoAlchemy2==0.2.6
 Shapely==1.5.13
 pyproj==1.9.4
 pyramid-jwtauth==0.1.3
-functools32==3.2.3-2
 bcrypt==2.0.0
 elasticsearch==2.1.0
 elasticsearch_dsl==0.0.9


### PR DESCRIPTION
Python 2.7 will at least be supported until 2020, but we have no reason not to use Python 3.

@gberaudo, I had to do some changes to the authentication and SSO code. The tests pass, but I would appreciate if you could test if the integration with Discourse still works without problem. Thanks!