### PR TITLE
Make sure the discriminator column is set

### DIFF
--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -20,8 +20,7 @@ import enum
 
 from c2corg_api.models import Base, schema, DBSession
 from c2corg_api.ext import colander_ext
-from c2corg_api.models.utils import copy_attributes
-
+from c2corg_api.models.utils import copy_attributes, extend_dict
 from pyramid.httpexceptions import HTTPInternalServerError
 
 quality_types = [
@@ -80,9 +79,9 @@ class Document(Base, _DocumentMixin):
 
     available_cultures = None
 
-    __mapper_args__ = {
-            'version_id_col': _DocumentMixin.version
-    }
+    __mapper_args__ = extend_dict({
+        'version_id_col': _DocumentMixin.version
+    }, _DocumentMixin.__mapper_args__)
 
     _ATTRIBUTES_WHITELISTED = \
         ['document_id', 'version']

--- a/c2corg_api/models/utils.py
+++ b/c2corg_api/models/utils.py
@@ -44,3 +44,10 @@ class ArrayOfEnum(postgresql.ARRAY):
                 return None
             return super_rp(handle_raw_string(value))
         return process
+
+
+def extend_dict(d1, d2):
+    """Update `d1` with the entries of `d2` and return `d1`.
+    """
+    d1.update(d2)
+    return d1

--- a/c2corg_api/search/sync.py
+++ b/c2corg_api/search/sync.py
@@ -36,6 +36,7 @@ def sync_search_index(document):
     doc = {
         'doc_type': document.type
     }
+
     for locale in document.locales:
         culture = locale.culture
         doc['title_' + culture] = locale.title

--- a/c2corg_api/tests/models/test_waypoint.py
+++ b/c2corg_api/tests/models/test_waypoint.py
@@ -10,6 +10,26 @@ from c2corg_api.tests import BaseTestCase
 
 class TestWaypoint(BaseTestCase):
 
+    def test_inheritance(self):
+        waypoint = Waypoint(
+            waypoint_type='summit', elevation=2203,
+            locales=[
+                WaypointLocale(
+                    culture='en', title='A', description='abc')
+            ],
+            geometry=DocumentGeometry(
+                geom=from_shape(Point(1, 1), srid=3857))
+        )
+        self.session.add(waypoint)
+        self.session.flush()
+
+        self.assertIsNotNone(waypoint.document_id)
+        self.assertEqual('w', waypoint.type)
+
+        locale = waypoint.locales[0]
+        self.assertIsNotNone(locale.id)
+        self.assertEqual('w', locale.type)
+
     def test_to_archive(self):
         waypoint = Waypoint(
             document_id=1, waypoint_type='summit', elevation=2203,

--- a/c2corg_api/tests/search/test_sync.py
+++ b/c2corg_api/tests/search/test_sync.py
@@ -33,6 +33,7 @@ class SyncTest(BaseTestCase):
         doc = SearchDocument.get(id=51251, index=index)
         self.assertEqual(doc['title_fr'], 'Mont Granier')
         self.assertEqual(doc['summary_fr'], 'Le Mont  Granier ')
+        self.assertEqual(doc['doc_type'], 'w')
 
     def test_sync_search_index_update(self):
         """Tests that already existing documents are updated.
@@ -81,3 +82,4 @@ class SyncTest(BaseTestCase):
         self.assertEqual(doc['summary_fr'], 'Le Mont Granier')
         self.assertEqual(doc['title_en'], 'Mont Granier')
         self.assertEqual(doc['summary_en'], 'The Mont Granier')
+        self.assertEqual(doc['doc_type'], 'w')

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -368,6 +368,7 @@ class BaseDocumentTestRest(BaseTestRest):
             id=doc.document_id,
             index=elasticsearch_config['index'])
 
+        self.assertIsNotNone(search_doc['doc_type'])
         self.assertEqual(search_doc['doc_type'], doc.type)
         self.assertEqual(search_doc['title_en'], waypoint_locale_en.title)
 


### PR DESCRIPTION
Due to a wrong SQLAlchemy mapping the values for the inheritance discriminator column were not set (e.g. `type = 'w'` for waypoints).

Closes https://github.com/c2corg/v6_ui/issues/92
Closes https://github.com/c2corg/v6_api/issues/127