### PR TITLE
Fix the version of v6_common in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,6 @@ git+https://github.com/tsauerwein/ColanderAlchemy.git@c2corg
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git
+git+https://github.com/c2corg/v6_common.git@15d580a7b0367617301a64941cc4148fddc3aa70
 
 -e .


### PR DESCRIPTION
Currently I can't push a change to the common project that I need for https://github.com/c2corg/v6_api/pull/125 because it would break master and all installations.