### PR TITLE
Geo-associations

### DIFF
--- a/c2corg_api/models/__init__.py
+++ b/c2corg_api/models/__init__.py
@@ -29,3 +29,4 @@ from c2corg_api.models import user  # noqa
 from c2corg_api.models import association  # noqa
 from c2corg_api.models import topo_map  # noqa
 from c2corg_api.models import area  # noqa
+from c2corg_api.models import area_association  # noqa

--- a/c2corg_api/models/__init__.py
+++ b/c2corg_api/models/__init__.py
@@ -27,3 +27,5 @@ from c2corg_api.models import document_history  # noqa
 from c2corg_api.models import image  # noqa
 from c2corg_api.models import user  # noqa
 from c2corg_api.models import association  # noqa
+from c2corg_api.models import topo_map  # noqa
+from c2corg_api.models import area  # noqa

--- a/c2corg_api/models/area.py
+++ b/c2corg_api/models/area.py
@@ -1,0 +1,77 @@
+from c2corg_api.models.enums import area_type
+from sqlalchemy import (
+    Column,
+    Integer,
+    ForeignKey
+    )
+
+from colanderalchemy import SQLAlchemySchemaNode
+
+from c2corg_api.models import schema
+from c2corg_api.models.utils import copy_attributes
+from c2corg_api.models.document import (
+    ArchiveDocument, Document, get_update_schema, geometry_schema_overrides,
+    schema_document_locale, schema_attributes)
+
+AREA_TYPE = 'a'
+
+
+class _AreaMixin(object):
+    area_type = Column(area_type)
+
+    __mapper_args__ = {
+        'polymorphic_identity': AREA_TYPE
+    }
+
+attributes = ['area_type']
+
+
+class Area(_AreaMixin, Document):
+    """
+    """
+    __tablename__ = 'areas'
+
+    document_id = Column(
+        Integer,
+        ForeignKey(schema + '.documents.document_id'), primary_key=True)
+
+    def to_archive(self):
+        area = ArchiveArea()
+        super(Area, self)._to_archive(area)
+        copy_attributes(self, area, attributes)
+
+        return area
+
+    def update(self, other):
+        super(Area, self).update(other)
+        copy_attributes(other, self, attributes)
+
+
+class ArchiveArea(_AreaMixin, ArchiveDocument):
+    """
+    """
+    __tablename__ = 'areas_archives'
+
+    id = Column(
+        Integer,
+        ForeignKey(schema + '.documents_archives.id'), primary_key=True)
+
+
+schema_area = SQLAlchemySchemaNode(
+    Area,
+    # whitelisted attributes
+    includes=schema_attributes + attributes,
+    overrides={
+        'document_id': {
+            'missing': None
+        },
+        'version': {
+            'missing': None
+        },
+        'locales': {
+            'children': [schema_document_locale]
+        },
+        'geometry': geometry_schema_overrides
+    })
+
+schema_update_area = get_update_schema(schema_area)

--- a/c2corg_api/models/area.py
+++ b/c2corg_api/models/area.py
@@ -1,17 +1,17 @@
+from c2corg_api.models import schema
+from c2corg_api.models.document import (
+    ArchiveDocument, Document, get_update_schema, geometry_schema_overrides,
+    schema_document_locale, schema_attributes)
 from c2corg_api.models.enums import area_type
+from c2corg_api.models.schema_utils import restrict_schema
+from c2corg_api.models.utils import copy_attributes
+from c2corg_common.fields_area import fields_area
+from colanderalchemy import SQLAlchemySchemaNode
 from sqlalchemy import (
     Column,
     Integer,
     ForeignKey
     )
-
-from colanderalchemy import SQLAlchemySchemaNode
-
-from c2corg_api.models import schema
-from c2corg_api.models.utils import copy_attributes
-from c2corg_api.models.document import (
-    ArchiveDocument, Document, get_update_schema, geometry_schema_overrides,
-    schema_document_locale, schema_attributes)
 
 AREA_TYPE = 'a'
 
@@ -75,3 +75,5 @@ schema_area = SQLAlchemySchemaNode(
     })
 
 schema_update_area = get_update_schema(schema_area)
+schema_listing_area = restrict_schema(
+    schema_area, fields_area.get('listing'))

--- a/c2corg_api/models/area_association.py
+++ b/c2corg_api/models/area_association.py
@@ -1,0 +1,105 @@
+from c2corg_api.models import Base, schema, DBSession
+from c2corg_api.models.area import Area, AREA_TYPE
+from c2corg_api.models.document import Document, DocumentGeometry
+from sqlalchemy import (
+    Column,
+    Integer,
+    ForeignKey
+    )
+from sqlalchemy.orm import relationship
+from sqlalchemy.schema import PrimaryKeyConstraint
+from sqlalchemy.sql.elements import literal_column
+from sqlalchemy.sql.expression import and_
+
+
+class AreaAssociation(Base):
+    """Associations between documents and areas.
+
+    Used to cache which documents are within area. The entries in this table
+    are created automatically when an area is changed/added, when a document
+    is added or a document geometry changes.
+    """
+    __tablename__ = 'area_associations'
+
+    document_id = Column(
+        Integer, ForeignKey(schema + '.documents.document_id'),
+        nullable=False)
+    document = relationship(
+        Document, primaryjoin=document_id == Document.document_id)
+
+    area_id = Column(
+        Integer, ForeignKey(schema + '.areas.document_id'),
+        nullable=False)
+    area = relationship(
+        Area, primaryjoin=area_id == Area.document_id)
+
+    __table_args__ = (
+        PrimaryKeyConstraint(document_id, area_id),
+        Base.__table_args__
+    )
+
+
+def update_area(area, reset=False):
+    """Create associations for the given area with all intersecting documents.
+
+    If `reset` is True, all possible existing associations to this area are
+    dropped before creating new associations.
+    """
+    if reset:
+        DBSession.execute(
+            AreaAssociation.__table__.delete().where(
+                AreaAssociation.area_id == area.document_id)
+        )
+
+    intersecting_documents = DBSession. \
+        query(
+            DocumentGeometry.document_id,  # id of a document
+            literal_column(str(area.document_id))). \
+        join(
+            Document,
+            and_(
+                Document.document_id == DocumentGeometry.document_id,
+                Document.type != AREA_TYPE)). \
+        filter(
+            DocumentGeometry.geom.intersects(
+                DBSession.query(DocumentGeometry.geom).filter(
+                    DocumentGeometry.document_id == area.document_id)
+            ))
+
+    DBSession.execute(
+        AreaAssociation.__table__.insert().from_select(
+            [AreaAssociation.document_id, AreaAssociation.area_id],
+            intersecting_documents))
+
+
+def update_document(document, reset=False):
+    """Create associations for the given documents with all intersecting areas.
+
+    If `reset` is True, all possible existing associations to this document are
+    dropped before creating new associations.
+    """
+    if reset:
+        DBSession.execute(
+            AreaAssociation.__table__.delete().where(
+                AreaAssociation.document_id == document.document_id)
+        )
+
+    intersecting_areas = DBSession. \
+        query(
+            DocumentGeometry.document_id,  # id of an area
+            literal_column(str(document.document_id))). \
+        join(
+            # join on the table instead on `Area` to avoid that SQLA adds
+            # a join on "guidebook.documents"
+            Area.__table__,
+            Area.document_id == DocumentGeometry.document_id). \
+        filter(
+            DocumentGeometry.geom.intersects(
+                DBSession.query(DocumentGeometry.geom).filter(
+                    DocumentGeometry.document_id == document.document_id)
+            ))
+
+    DBSession.execute(
+        AreaAssociation.__table__.insert().from_select(
+            [AreaAssociation.area_id, AreaAssociation.document_id],
+            intersecting_areas))

--- a/c2corg_api/models/area_association.py
+++ b/c2corg_api/models/area_association.py
@@ -72,7 +72,7 @@ def update_area(area, reset=False):
             intersecting_documents))
 
 
-def update_document(document, reset=False):
+def update_areas_for_document(document, reset=False):
     """Create associations for the given documents with all intersecting areas.
 
     If `reset` is True, all possible existing associations to this document are

--- a/c2corg_api/models/area_association.py
+++ b/c2corg_api/models/area_association.py
@@ -27,7 +27,8 @@ class AreaAssociation(Base):
         Integer, ForeignKey(schema + '.documents.document_id'),
         nullable=False)
     document = relationship(
-        Document, primaryjoin=document_id == Document.document_id)
+        Document, primaryjoin=document_id == Document.document_id
+    )
 
     area_id = Column(
         Integer, ForeignKey(schema + '.areas.document_id'),
@@ -39,6 +40,13 @@ class AreaAssociation(Base):
         PrimaryKeyConstraint(document_id, area_id),
         Base.__table_args__
     )
+
+
+Document._areas = relationship(
+    Area,
+    secondary=AreaAssociation.__table__,
+    viewonly=True, cascade='expunge'
+)
 
 
 def update_area(area, reset=False):

--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -86,7 +86,7 @@ def get_associations(document, lang):
     """Load and return associated documents.
     """
     def limit_waypoint_fields(query):
-        return query.\
+        return query. \
             options(load_only(
                 Waypoint.waypoint_type, Waypoint.document_id,
                 Waypoint.elevation, Waypoint.version)). \

--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -1,3 +1,4 @@
+from colanderalchemy.schema import SQLAlchemySchemaNode
 from sqlalchemy import (
     Column,
     Integer,
@@ -239,7 +240,12 @@ class DocumentLocale(Base, _DocumentLocaleMixin):
         'summary'
     ]
 
-    def to_archive(self, locale):
+    def to_archive(self):
+        locale = ArchiveDocumentLocale()
+        self._to_archive(locale)
+        return locale
+
+    def _to_archive(self, locale):
         copy_attributes(self, locale, DocumentLocale._ATTRIBUTES)
         return locale
 
@@ -369,6 +375,16 @@ schema_attributes = [
 schema_locale_attributes = [
     'version', 'culture', 'title', 'description', 'summary'
 ]
+
+schema_document_locale = SQLAlchemySchemaNode(
+    DocumentLocale,
+    # whitelisted attributes
+    includes=schema_locale_attributes,
+    overrides={
+        'version': {
+            'missing': None
+        }
+    })
 
 geometry_schema_overrides = {
     # whitelisted attributes

--- a/c2corg_api/models/enums.py
+++ b/c2corg_api/models/enums.py
@@ -92,3 +92,5 @@ map_editor = enum(
     'map_editor', attributes.map_editors)
 map_scale = enum(
     'map_scale', attributes.map_scales)
+area_type = enum(
+    'area_type', attributes.area_types)

--- a/c2corg_api/models/enums.py
+++ b/c2corg_api/models/enums.py
@@ -88,3 +88,7 @@ mtb_up_rating = enum(
     'mtb_up_rating', attributes.mtb_up_ratings)
 mtb_down_rating = enum(
     'mtb_down_rating', attributes.mtb_down_ratings)
+map_editor = enum(
+    'map_editor', attributes.map_editors)
+map_scale = enum(
+    'map_scale', attributes.map_scales)

--- a/c2corg_api/models/image.py
+++ b/c2corg_api/models/image.py
@@ -11,8 +11,8 @@ from colanderalchemy import SQLAlchemySchemaNode
 from c2corg_api.models import schema
 from c2corg_api.models.utils import copy_attributes
 from c2corg_api.models.document import (
-    ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale,
-    get_update_schema, geometry_schema_overrides)
+    ArchiveDocument, Document, get_update_schema, geometry_schema_overrides,
+    schema_document_locale)
 from c2corg_common.attributes import activities
 
 IMAGE_TYPE = 'i'
@@ -63,57 +63,6 @@ class ArchiveImage(_ImageMixin, ArchiveDocument):
         ForeignKey(schema + '.documents_archives.id'), primary_key=True)
 
 
-class _ImageLocaleMixin(object):
-
-    __mapper_args__ = {
-        'polymorphic_identity': IMAGE_TYPE
-    }
-
-
-class ImageLocale(_ImageLocaleMixin, DocumentLocale):
-    """
-    """
-    __tablename__ = 'images_locales'
-
-    id = Column(
-                Integer,
-                ForeignKey(schema + '.documents_locales.id'), primary_key=True)
-
-    _ATTRIBUTES = []
-
-    def to_archive(self):
-        locale = ArchiveImageLocale()
-        super(ImageLocale, self).to_archive(locale)
-        copy_attributes(self, locale, ImageLocale._ATTRIBUTES)
-
-        return locale
-
-    def update(self, other):
-        super(ImageLocale, self).update(other)
-        copy_attributes(other, self, ImageLocale._ATTRIBUTES)
-
-
-class ArchiveImageLocale(_ImageLocaleMixin, ArchiveDocumentLocale):
-    """
-    """
-    __tablename__ = 'images_locales_archives'
-
-    id = Column(
-        Integer,
-        ForeignKey(schema + '.documents_locales_archives.id'),
-        primary_key=True)
-
-
-schema_image_locale = SQLAlchemySchemaNode(
-    ImageLocale,
-    # whitelisted attributes
-    includes=['version', 'culture', 'title', 'description'],
-    overrides={
-        'version': {
-            'missing': None
-        }
-    })
-
 schema_image = SQLAlchemySchemaNode(
     Image,
     # whitelisted attributes
@@ -128,7 +77,7 @@ schema_image = SQLAlchemySchemaNode(
             'missing': None
         },
         'locales': {
-            'children': [schema_image_locale]
+            'children': [schema_document_locale]
         },
         'geometry': geometry_schema_overrides
     })

--- a/c2corg_api/models/route.py
+++ b/c2corg_api/models/route.py
@@ -254,7 +254,7 @@ class RouteLocale(_RouteLocaleMixin, DocumentLocale):
 
     def to_archive(self):
         locale = ArchiveRouteLocale()
-        super(RouteLocale, self).to_archive(locale)
+        super(RouteLocale, self)._to_archive(locale)
         copy_attributes(self, locale, attributes_locales)
 
         return locale

--- a/c2corg_api/models/topo_map.py
+++ b/c2corg_api/models/topo_map.py
@@ -1,9 +1,9 @@
+from c2corg_api.models.enums import map_editor, map_scale
 from sqlalchemy import (
     Column,
     Integer,
-    SmallInteger,
     ForeignKey,
-    Enum
+    String
     )
 
 from colanderalchemy import SQLAlchemySchemaNode
@@ -13,59 +13,57 @@ from c2corg_api.models.utils import copy_attributes
 from c2corg_api.models.document import (
     ArchiveDocument, Document, get_update_schema, geometry_schema_overrides,
     schema_document_locale, schema_attributes)
-from c2corg_common.attributes import activities
 
-IMAGE_TYPE = 'i'
+MAP_TYPE = 'm'
 
 
-class _ImageMixin(object):
-    activities = Column(
-        Enum(name='activities', inherit_schema=True, *activities),
-        nullable=False)
-
-    height = Column(SmallInteger)
+class _MapMixin(object):
+    editor = Column(map_editor)
+    scale = Column(map_scale)
+    code = Column(String)
 
     __mapper_args__ = {
-        'polymorphic_identity': IMAGE_TYPE
+        'polymorphic_identity': MAP_TYPE
     }
 
+attributes = [
+    'editor', 'scale', 'code'
+]
 
-attributes = ['activities', 'height']
 
-
-class Image(_ImageMixin, Document):
+class TopoMap(_MapMixin, Document):
     """
     """
-    __tablename__ = 'images'
+    __tablename__ = 'maps'
 
     document_id = Column(
         Integer,
         ForeignKey(schema + '.documents.document_id'), primary_key=True)
 
     def to_archive(self):
-        image = ArchiveImage()
-        super(Image, self)._to_archive(image)
-        copy_attributes(self, image, attributes)
+        m = ArchiveTopoMap()
+        super(TopoMap, self)._to_archive(m)
+        copy_attributes(self, m, attributes)
 
-        return image
+        return m
 
     def update(self, other):
-        super(Image, self).update(other)
+        super(TopoMap, self).update(other)
         copy_attributes(other, self, attributes)
 
 
-class ArchiveImage(_ImageMixin, ArchiveDocument):
+class ArchiveTopoMap(_MapMixin, ArchiveDocument):
     """
     """
-    __tablename__ = 'images_archives'
+    __tablename__ = 'maps_archives'
 
     id = Column(
         Integer,
         ForeignKey(schema + '.documents_archives.id'), primary_key=True)
 
 
-schema_image = SQLAlchemySchemaNode(
-    Image,
+schema_topo_map = SQLAlchemySchemaNode(
+    TopoMap,
     # whitelisted attributes
     includes=schema_attributes + attributes,
     overrides={
@@ -81,4 +79,4 @@ schema_image = SQLAlchemySchemaNode(
         'geometry': geometry_schema_overrides
     })
 
-schema_update_image = get_update_schema(schema_image)
+schema_update_topo_map = get_update_schema(schema_topo_map)

--- a/c2corg_api/models/waypoint.py
+++ b/c2corg_api/models/waypoint.py
@@ -247,7 +247,7 @@ class WaypointLocale(_WaypointLocaleMixin, DocumentLocale):
 
     def to_archive(self):
         locale = ArchiveWaypointLocale()
-        super(WaypointLocale, self).to_archive(locale)
+        super(WaypointLocale, self)._to_archive(locale)
         copy_attributes(self, locale, attributes_locales)
 
         return locale

--- a/c2corg_api/scripts/migration/area_associations.py
+++ b/c2corg_api/scripts/migration/area_associations.py
@@ -1,0 +1,40 @@
+import transaction
+import zope
+
+from c2corg_api.scripts.migration.migrate_base import MigrateBase
+
+
+class MigrateAreaAssociations(MigrateBase):
+    """Initialize associations between areas and documents.
+    """
+
+    def migrate(self):
+        self.start('area associations')
+
+        with transaction.manager:
+            self.session_target.execute(SQL_CREATE_AREA_ASSOCIATIONS)
+            zope.sqlalchemy.mark_changed(self.session_target)
+
+        # run vacuum on the table (must be outside a transaction)
+        engine = self.session_target.bind
+        conn = engine.connect()
+        old_lvl = conn.connection.isolation_level
+        conn.connection.set_isolation_level(0)
+        conn.execute('vacuum analyze guidebook.area_associations;')
+        conn.connection.set_isolation_level(old_lvl)
+        conn.close()
+
+        self.stop()
+
+
+SQL_CREATE_AREA_ASSOCIATIONS = """
+insert into guidebook.area_associations (document_id, area_id) (
+  select d.document_id, a.document_id as area_document_id
+  from (select g.document_id, g.geom from
+    guidebook.documents_geometries g join guidebook.documents d
+    on g.document_id = d.document_id and d.type <> 'a') d
+  join (select ga.document_id, ga.geom from
+    guidebook.areas a join guidebook.documents_geometries ga
+    on ga.document_id = a.document_id) a
+  on ST_Intersects(d.geom, a.geom));
+"""

--- a/c2corg_api/scripts/migration/documents/area.py
+++ b/c2corg_api/scripts/migration/documents/area.py
@@ -1,5 +1,6 @@
-from c2corg_api.models.area import Area, ArchiveArea
-from c2corg_api.models.document import DocumentLocale, ArchiveDocumentLocale
+from c2corg_api.models.area import Area, ArchiveArea, AREA_TYPE
+from c2corg_api.models.document import DocumentLocale, ArchiveDocumentLocale, \
+    DOCUMENT_TYPE
 from c2corg_api.scripts.migration.documents.document import MigrateDocuments
 
 
@@ -55,7 +56,7 @@ class MigrateAreas(MigrateDocuments):
     def get_document(self, document_in, version):
         return dict(
             document_id=document_in.id,
-            type='m',
+            type=AREA_TYPE,
             version=version,
             protected=document_in.is_protected,
             redirects_to=document_in.redirects_to,
@@ -68,7 +69,7 @@ class MigrateAreas(MigrateDocuments):
         return dict(
             document_id=document_in.id,
             id=document_in.document_i18n_archive_id,
-            type='m',
+            type=DOCUMENT_TYPE,
             version=version,
             culture=document_in.culture,
             title=document_in.name,

--- a/c2corg_api/scripts/migration/documents/area.py
+++ b/c2corg_api/scripts/migration/documents/area.py
@@ -1,0 +1,83 @@
+from c2corg_api.models.area import Area, ArchiveArea
+from c2corg_api.models.document import DocumentLocale, ArchiveDocumentLocale
+from c2corg_api.scripts.migration.documents.document import MigrateDocuments
+
+
+class MigrateAreas(MigrateDocuments):
+
+    def get_name(self):
+        return 'areas'
+
+    def get_model_document(self, locales):
+        return DocumentLocale if locales else Area
+
+    def get_model_archive_document(self, locales):
+        return ArchiveDocumentLocale if locales else ArchiveArea
+
+    def get_document_geometry(self, document_in, version):
+        return dict(
+            document_id=document_in.id,
+            id=document_in.id,
+            version=version,
+            geom=document_in.geom
+        )
+
+    def get_count_query(self):
+        return (
+            'select count(*) from app_areas_archives;'
+        )
+
+    def get_query(self):
+        return (
+            'select '
+            '   id, document_archive_id, is_latest_version, '
+            '   is_protected, redirects_to, '
+            '   ST_Force2D(ST_SetSRID(geom, 3857)) geom, '
+            '   area_type '
+            'from app_areas_archives '
+            'order by id, document_archive_id;'
+        )
+
+    def get_count_query_locales(self):
+        return (
+            'select count(*) from app_areas_i18n_archives;'
+        )
+
+    def get_query_locales(self):
+        return (
+            'select '
+            '   id, document_i18n_archive_id, is_latest_version, culture, '
+            '   name, description '
+            'from app_areas_i18n_archives '
+            'order by id, document_i18n_archive_id;'
+        )
+
+    def get_document(self, document_in, version):
+        return dict(
+            document_id=document_in.id,
+            type='m',
+            version=version,
+            protected=document_in.is_protected,
+            redirects_to=document_in.redirects_to,
+            area_type=self.convert_type(
+                document_in.area_type, MigrateAreas.area_types),
+        )
+
+    def get_document_locale(self, document_in, version):
+        description, summary = self.extract_summary(document_in.description)
+        return dict(
+            document_id=document_in.id,
+            id=document_in.document_i18n_archive_id,
+            type='m',
+            version=version,
+            culture=document_in.culture,
+            title=document_in.name,
+            description=description,
+            summary=summary
+        )
+
+    area_types = {
+        '1': 'range',
+        '2': 'country',
+        '3': 'admin_limits',
+    }

--- a/c2corg_api/scripts/migration/documents/maps.py
+++ b/c2corg_api/scripts/migration/documents/maps.py
@@ -1,0 +1,90 @@
+from c2corg_api.models.document import DocumentLocale, ArchiveDocumentLocale
+from c2corg_api.models.topo_map import TopoMap, ArchiveTopoMap
+from c2corg_api.scripts.migration.documents.document import MigrateDocuments
+
+
+class MigrateMaps(MigrateDocuments):
+
+    def get_name(self):
+        return 'maps'
+
+    def get_model_document(self, locales):
+        return DocumentLocale if locales else TopoMap
+
+    def get_model_archive_document(self, locales):
+        return ArchiveDocumentLocale if locales else ArchiveTopoMap
+
+    def get_document_geometry(self, document_in, version):
+        return dict(
+            document_id=document_in.id,
+            id=document_in.id,
+            version=version,
+            geom=document_in.geom
+        )
+
+    def get_count_query(self):
+        return (
+            'select count(*) from app_maps_archives;'
+        )
+
+    def get_query(self):
+        return (
+            'select '
+            '   id, document_archive_id, is_latest_version, '
+            '   is_protected, redirects_to, '
+            '   ST_Force2D(ST_SetSRID(geom, 3857)) geom, '
+            '   editor, scale, code '
+            'from app_maps_archives '
+            'order by id, document_archive_id;'
+        )
+
+    def get_count_query_locales(self):
+        return (
+            'select count(*) from app_maps_i18n_archives;'
+        )
+
+    def get_query_locales(self):
+        return (
+            'select '
+            '   id, document_i18n_archive_id, is_latest_version, culture, '
+            '   name, description '
+            'from app_maps_i18n_archives '
+            'order by id, document_i18n_archive_id;'
+        )
+
+    def get_document(self, document_in, version):
+        return dict(
+            document_id=document_in.id,
+            type='m',
+            version=version,
+            protected=document_in.is_protected,
+            redirects_to=document_in.redirects_to,
+            code=document_in.code,
+            editor=self.convert_type(document_in.editor, MigrateMaps.editors),
+            scale=self.convert_type(document_in.scale, MigrateMaps.scales),
+        )
+
+    def get_document_locale(self, document_in, version):
+        description, summary = self.extract_summary(document_in.description)
+        return dict(
+            document_id=document_in.id,
+            id=document_in.document_i18n_archive_id,
+            type='m',
+            version=version,
+            culture=document_in.culture,
+            title=document_in.name,
+            description=description,
+            summary=summary
+        )
+
+    scales = {
+        '1': '25000',
+        '2': '50000',
+        '3': '100000',
+    }
+
+    editors = {
+        '1': 'ign',
+        '2': 'swisstopo',
+        '3': 'escursionista',
+    }

--- a/c2corg_api/scripts/migration/documents/maps.py
+++ b/c2corg_api/scripts/migration/documents/maps.py
@@ -1,5 +1,6 @@
-from c2corg_api.models.document import DocumentLocale, ArchiveDocumentLocale
-from c2corg_api.models.topo_map import TopoMap, ArchiveTopoMap
+from c2corg_api.models.document import DocumentLocale, ArchiveDocumentLocale, \
+    DOCUMENT_TYPE
+from c2corg_api.models.topo_map import TopoMap, ArchiveTopoMap, MAP_TYPE
 from c2corg_api.scripts.migration.documents.document import MigrateDocuments
 
 
@@ -55,7 +56,7 @@ class MigrateMaps(MigrateDocuments):
     def get_document(self, document_in, version):
         return dict(
             document_id=document_in.id,
-            type='m',
+            type=MAP_TYPE,
             version=version,
             protected=document_in.is_protected,
             redirects_to=document_in.redirects_to,
@@ -69,7 +70,7 @@ class MigrateMaps(MigrateDocuments):
         return dict(
             document_id=document_in.id,
             id=document_in.document_i18n_archive_id,
-            type='m',
+            type=DOCUMENT_TYPE,
             version=version,
             culture=document_in.culture,
             title=document_in.name,

--- a/c2corg_api/scripts/migration/documents/routes.py
+++ b/c2corg_api/scripts/migration/documents/routes.py
@@ -1,5 +1,5 @@
 from c2corg_api.models.route import Route, RouteLocale, ArchiveRoute, \
-    ArchiveRouteLocale
+    ArchiveRouteLocale, ROUTE_TYPE
 from c2corg_api.scripts.migration.documents.document import MigrateDocuments
 
 
@@ -108,7 +108,7 @@ class MigrateRoutes(MigrateDocuments):
 
         return dict(
             document_id=document_in.id,
-            type='r',
+            type=ROUTE_TYPE,
             version=version,
             protected=document_in.is_protected,
             redirects_to=document_in.redirects_to,
@@ -184,7 +184,7 @@ class MigrateRoutes(MigrateDocuments):
         return dict(
             document_id=document_in.id,
             id=document_in.document_i18n_archive_id,
-            type='r',
+            type=ROUTE_TYPE,
             version=version,
             culture=document_in.culture,
             title=document_in.name,

--- a/c2corg_api/scripts/migration/documents/versions.py
+++ b/c2corg_api/scripts/migration/documents/versions.py
@@ -6,10 +6,11 @@ from c2corg_api.models.document_history import HistoryMetaData, DocumentVersion
 from c2corg_api.scripts.migration.batch import SimpleBatch
 from c2corg_api.scripts.migration.migrate_base import MigrateBase
 
-# TODO only importing the versions of waypoints and routes
+# TODO only importing the versions of waypoints, routes, areas and maps
 tables = [
     'app_huts_archives', 'app_parkings_archives', 'app_products_archives',
-    'app_sites_archives', 'app_summits_archives', 'app_routes_archives'
+    'app_sites_archives', 'app_summits_archives', 'app_routes_archives',
+    'app_maps_archives', 'app_areas_archives'
 ]
 tables_union = ' union '.join(['select id from ' + t for t in tables])
 

--- a/c2corg_api/scripts/migration/documents/waypoints/huts.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/huts.py
@@ -1,3 +1,4 @@
+from c2corg_api.models.waypoint import WAYPOINT_TYPE
 from c2corg_api.scripts.migration.documents.waypoints.waypoint import \
     MigrateWaypoints
 
@@ -47,7 +48,7 @@ class MigrateHuts(MigrateWaypoints):
 
         return dict(
             document_id=document_in.id,
-            type='w',
+            type=WAYPOINT_TYPE,
             version=version,
             waypoint_type=waypoint_type,
             protected=document_in.is_protected,
@@ -73,7 +74,7 @@ class MigrateHuts(MigrateWaypoints):
         return dict(
             document_id=document_in.id,
             id=document_in.document_i18n_archive_id,
-            type='w',
+            type=WAYPOINT_TYPE,
             version=version,
             culture=document_in.culture,
             title=document_in.name,

--- a/c2corg_api/scripts/migration/documents/waypoints/parking.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/parking.py
@@ -1,3 +1,4 @@
+from c2corg_api.models.waypoint import WAYPOINT_TYPE
 from c2corg_api.scripts.migration.documents.waypoints.waypoint import \
     MigrateWaypoints
 
@@ -42,7 +43,7 @@ class MigrateParkings(MigrateWaypoints):
     def get_document(self, document_in, version):
         return dict(
             document_id=document_in.id,
-            type='w',
+            type=WAYPOINT_TYPE,
             version=version,
             waypoint_type='access',
             protected=document_in.is_protected,
@@ -66,7 +67,7 @@ class MigrateParkings(MigrateWaypoints):
         return dict(
             document_id=document_in.id,
             id=document_in.document_i18n_archive_id,
-            type='w',
+            type=WAYPOINT_TYPE,
             version=version,
             culture=document_in.culture,
             title=document_in.name,

--- a/c2corg_api/scripts/migration/documents/waypoints/products.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/products.py
@@ -1,3 +1,4 @@
+from c2corg_api.models.waypoint import WAYPOINT_TYPE
 from c2corg_api.scripts.migration.documents.waypoints.waypoint import \
     MigrateWaypoints
 
@@ -40,7 +41,7 @@ class MigrateProducts(MigrateWaypoints):
     def get_document(self, document_in, version):
         return dict(
             document_id=document_in.id,
-            type='w',
+            type=WAYPOINT_TYPE,
             version=version,
             waypoint_type='local_product',
             protected=document_in.is_protected,
@@ -57,7 +58,7 @@ class MigrateProducts(MigrateWaypoints):
         return dict(
             document_id=document_in.id,
             id=document_in.document_i18n_archive_id,
-            type='w',
+            type=WAYPOINT_TYPE,
             version=version,
             culture=document_in.culture,
             title=document_in.name,

--- a/c2corg_api/scripts/migration/documents/waypoints/sites.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/sites.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from c2corg_api.models.waypoint import WAYPOINT_TYPE
 from c2corg_api.scripts.migration.documents.waypoints.waypoint import \
     MigrateWaypoints
 
@@ -46,7 +47,7 @@ class MigrateSites(MigrateWaypoints):
         indoor_types, outdoor_types = self.get_climbing_types(document_in)
         return dict(
             document_id=document_in.id,
-            type='w',
+            type=WAYPOINT_TYPE,
             version=version,
             waypoint_type='climbing_indoor' if indoor_types
                           else 'climbing_outdoor',
@@ -88,7 +89,7 @@ class MigrateSites(MigrateWaypoints):
         return dict(
             document_id=document_in.id,
             id=document_in.document_i18n_archive_id,
-            type='w',
+            type=WAYPOINT_TYPE,
             version=version,
             culture=document_in.culture,
             title=document_in.name,

--- a/c2corg_api/scripts/migration/documents/waypoints/summit.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/summit.py
@@ -1,3 +1,4 @@
+from c2corg_api.models.waypoint import WAYPOINT_TYPE
 from c2corg_api.scripts.migration.documents.waypoints.waypoint import \
     MigrateWaypoints
 
@@ -37,7 +38,7 @@ class MigrateSummits(MigrateWaypoints):
     def get_document(self, document_in, version):
         return dict(
             document_id=document_in.id,
-            type='w',
+            type=WAYPOINT_TYPE,
             version=version,
             waypoint_type=self.convert_type(
                 document_in.summit_type, MigrateSummits.summit_types),
@@ -52,7 +53,7 @@ class MigrateSummits(MigrateWaypoints):
         return dict(
             document_id=document_in.id,
             id=document_in.document_i18n_archive_id,
-            type='w',
+            type=WAYPOINT_TYPE,
             version=version,
             culture=document_in.culture,
             title=document_in.name,

--- a/c2corg_api/scripts/migration/migrate.py
+++ b/c2corg_api/scripts/migration/migrate.py
@@ -1,8 +1,10 @@
 import sys
 import logging
 
+from c2corg_api.scripts.migration.documents.area import MigrateAreas
 from c2corg_api.scripts.migration.documents.associations import \
     MigrateAssociations
+from c2corg_api.scripts.migration.documents.maps import MigrateMaps
 from sqlalchemy import engine_from_config
 
 import os
@@ -59,6 +61,8 @@ def main(argv=sys.argv):
     MigrateProducts(connection_source, session, batch_size).migrate()
     MigrateHuts(connection_source, session, batch_size).migrate()
     MigrateRoutes(connection_source, session, batch_size).migrate()
+    MigrateMaps(connection_source, session, batch_size).migrate()
+    MigrateAreas(connection_source, session, batch_size).migrate()
     MigrateVersions(connection_source, session, batch_size).migrate()
     MigrateAssociations(connection_source, session, batch_size).migrate()
     UpdateSequences(connection_source, session, batch_size).migrate()

--- a/c2corg_api/scripts/migration/migrate.py
+++ b/c2corg_api/scripts/migration/migrate.py
@@ -1,6 +1,8 @@
 import sys
 import logging
 
+from c2corg_api.scripts.migration.area_associations import \
+    MigrateAreaAssociations
 from c2corg_api.scripts.migration.documents.area import MigrateAreas
 from c2corg_api.scripts.migration.documents.associations import \
     MigrateAssociations
@@ -65,6 +67,7 @@ def main(argv=sys.argv):
     MigrateAreas(connection_source, session, batch_size).migrate()
     MigrateVersions(connection_source, session, batch_size).migrate()
     MigrateAssociations(connection_source, session, batch_size).migrate()
+    MigrateAreaAssociations(connection_source, session, batch_size).migrate()
     UpdateSequences(connection_source, session, batch_size).migrate()
 
 if __name__ == "__main__":

--- a/c2corg_api/security/roles.py
+++ b/c2corg_api/security/roles.py
@@ -25,7 +25,7 @@ def extract_token(request):
 
 def groupfinder(userid, request):
     is_moderator = DBSession.query(User). \
-        filter(User.id == userid and User.moderator is True). \
+        filter(User.id == userid, User.moderator). \
         count() > 0
     return ['group:moderators'] if is_moderator else [Authenticated]
 
@@ -33,12 +33,12 @@ def groupfinder(userid, request):
 def is_valid_token(token):
     now = datetime.datetime.utcnow()
     return DBSession.query(Token). \
-        filter(Token.value == token and Token.expire > now).count() == 1
+        filter(Token.value == token, Token.expire > now).count() == 1
 
 
 def add_or_retrieve_token(value, expire, userid):
     token = DBSession.query(Token). \
-        filter(Token.value == value and User.id == userid).first()
+        filter(Token.value == value, User.id == userid).first()
     if not token:
         token = Token(value=value, expire=expire, userid=userid)
         DBSession.add(token)

--- a/c2corg_api/tests/models/test_area.py
+++ b/c2corg_api/tests/models/test_area.py
@@ -1,0 +1,34 @@
+from c2corg_api.models.area import Area
+from c2corg_api.models.document import DocumentLocale
+
+from c2corg_api.tests import BaseTestCase
+
+
+class TestArea(BaseTestCase):
+
+    def test_to_archive(self):
+        area = Area(
+            document_id=1, area_type='range',
+            locales=[
+                DocumentLocale(
+                    id=2, culture='en', title='Chartreuse', summary='...'),
+                DocumentLocale(
+                    id=3, culture='fr', title='Chartreuse', summary='...'),
+            ]
+        )
+
+        area_archive = area.to_archive()
+
+        self.assertIsNone(area_archive.id)
+        self.assertEqual(area_archive.document_id, area.document_id)
+        self.assertEqual(area_archive.area_type, area.area_type)
+
+        archive_locals = area.get_archive_locales()
+
+        self.assertEqual(len(archive_locals), 2)
+        locale = area.locales[0]
+        locale_archive = archive_locals[0]
+        self.assertIsNot(locale_archive, locale)
+        self.assertIsNone(locale_archive.id)
+        self.assertEqual(locale_archive.culture, locale.culture)
+        self.assertEqual(locale_archive.title, locale.title)

--- a/c2corg_api/tests/models/test_area_associations.py
+++ b/c2corg_api/tests/models/test_area_associations.py
@@ -1,0 +1,113 @@
+from c2corg_api.models.area import Area
+from c2corg_api.models.area_association import update_area, AreaAssociation, \
+    update_document
+from c2corg_api.models.document import DocumentGeometry
+from c2corg_api.models.waypoint import Waypoint
+
+from c2corg_api.tests import BaseTestCase
+
+
+class TestAreaAssociation(BaseTestCase):
+
+    def setUp(self):  # noqa
+        BaseTestCase.setUp(self)
+
+        self.area = Area(
+            area_type='range',
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POLYGON((668518.249382151 5728802.39591739,668518.249382151 5745465.66808356,689156.247019149 5745465.66808356,689156.247019149 5728802.39591739,668518.249382151 5728802.39591739))')  # noqa
+        )
+        # wp inside the area
+        self.waypoint1 = Waypoint(
+            waypoint_type='summit',
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POINT(677461.381691516 5740879.44638645)')
+        )
+        # wp outside the area
+        self.waypoint2 = Waypoint(
+            waypoint_type='summit',
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POINT(693666.031687976 5741108.7574713)')
+        )
+        # wp without geometry
+        self.waypoint3 = Waypoint(
+            waypoint_type='summit'
+        )
+        # wp with empty geometry
+        self.waypoint4 = Waypoint(
+            waypoint_type='summit',
+            geometry=DocumentGeometry()
+        )
+        self.session.add_all([
+            self.area, self.waypoint1, self.waypoint2, self.waypoint3,
+            self.waypoint4])
+        self.session.flush()
+
+    def test_update_area(self):
+        update_area(self.area)
+
+        added_links = self.session.query(AreaAssociation). \
+            filter(AreaAssociation.area_id == self.area.document_id).all()
+        self.assertEqual(len(added_links), 1)
+        self.assertEqual(
+            added_links[0].document_id, self.waypoint1.document_id)
+
+    def test_update_area_reset_first(self):
+        # add an association with wp2, which should be removed after the update
+        self.session.add(AreaAssociation(
+            document_id=self.waypoint2.document_id,
+            area_id=self.area.document_id))
+        self.session.flush()
+
+        update_area(self.area, reset=True)
+
+        updated_links = self.session.query(AreaAssociation). \
+            filter(AreaAssociation.area_id == self.area.document_id).all()
+        self.assertEqual(len(updated_links), 1)
+        self.assertEqual(
+            updated_links[0].document_id, self.waypoint1.document_id)
+
+    def test_update_document(self):
+        # waypoint inside the area
+        update_document(self.waypoint1)
+
+        added_links = self._get_links_for_document(self.waypoint1)
+        self.assertEqual(len(added_links), 1)
+        self.assertEqual(
+            added_links[0].area_id, self.area.document_id)
+
+        # wp outside the area
+        update_document(self.waypoint2)
+
+        added_links = self._get_links_for_document(self.waypoint2)
+        self.assertEqual(len(added_links), 0)
+
+        # wp without geometry
+        update_document(self.waypoint3)
+
+        added_links = self._get_links_for_document(self.waypoint3)
+        self.assertEqual(len(added_links), 0)
+
+        # wp with empty geometry
+        update_document(self.waypoint4)
+
+        added_links = self._get_links_for_document(self.waypoint4)
+        self.assertEqual(len(added_links), 0)
+
+    def test_update_document_reset_first(self):
+        # add an association with wp2, which should be removed after the update
+        self.session.add(AreaAssociation(
+            document_id=self.waypoint2.document_id,
+            area_id=self.area.document_id))
+        self.session.flush()
+
+        update_document(self.waypoint2, reset=True)
+
+        updated_links = self._get_links_for_document(self.waypoint2)
+        self.assertEqual(len(updated_links), 0)
+
+    def _get_links_for_document(self, doc):
+        return self.session.query(AreaAssociation). \
+            filter(
+                AreaAssociation.document_id == doc.document_id). \
+            all()

--- a/c2corg_api/tests/models/test_area_associations.py
+++ b/c2corg_api/tests/models/test_area_associations.py
@@ -1,6 +1,6 @@
 from c2corg_api.models.area import Area
 from c2corg_api.models.area_association import update_area, AreaAssociation, \
-    update_document
+    update_areas_for_document
 from c2corg_api.models.document import DocumentGeometry
 from c2corg_api.models.waypoint import Waypoint
 
@@ -69,7 +69,7 @@ class TestAreaAssociation(BaseTestCase):
 
     def test_update_document(self):
         # waypoint inside the area
-        update_document(self.waypoint1)
+        update_areas_for_document(self.waypoint1)
 
         added_links = self._get_links_for_document(self.waypoint1)
         self.assertEqual(len(added_links), 1)
@@ -77,19 +77,19 @@ class TestAreaAssociation(BaseTestCase):
             added_links[0].area_id, self.area.document_id)
 
         # wp outside the area
-        update_document(self.waypoint2)
+        update_areas_for_document(self.waypoint2)
 
         added_links = self._get_links_for_document(self.waypoint2)
         self.assertEqual(len(added_links), 0)
 
         # wp without geometry
-        update_document(self.waypoint3)
+        update_areas_for_document(self.waypoint3)
 
         added_links = self._get_links_for_document(self.waypoint3)
         self.assertEqual(len(added_links), 0)
 
         # wp with empty geometry
-        update_document(self.waypoint4)
+        update_areas_for_document(self.waypoint4)
 
         added_links = self._get_links_for_document(self.waypoint4)
         self.assertEqual(len(added_links), 0)
@@ -101,7 +101,7 @@ class TestAreaAssociation(BaseTestCase):
             area_id=self.area.document_id))
         self.session.flush()
 
-        update_document(self.waypoint2, reset=True)
+        update_areas_for_document(self.waypoint2, reset=True)
 
         updated_links = self._get_links_for_document(self.waypoint2)
         self.assertEqual(len(updated_links), 0)

--- a/c2corg_api/tests/models/test_area_associations.py
+++ b/c2corg_api/tests/models/test_area_associations.py
@@ -1,6 +1,6 @@
 from c2corg_api.models.area import Area
 from c2corg_api.models.area_association import update_area, AreaAssociation, \
-    update_areas_for_document
+    update_areas_for_document, get_areas
 from c2corg_api.models.document import DocumentGeometry
 from c2corg_api.models.waypoint import Waypoint
 
@@ -105,6 +105,14 @@ class TestAreaAssociation(BaseTestCase):
 
         updated_links = self._get_links_for_document(self.waypoint2)
         self.assertEqual(len(updated_links), 0)
+
+    def test_get_areas(self):
+        update_area(self.area)
+        areas = get_areas(self.waypoint1, 'en')
+
+        self.assertEqual(len(areas), 1)
+        self.assertEqual(
+            areas[0].document_id, self.area.document_id)
 
     def _get_links_for_document(self, doc):
         return self.session.query(AreaAssociation). \

--- a/c2corg_api/tests/models/test_image.py
+++ b/c2corg_api/tests/models/test_image.py
@@ -1,4 +1,5 @@
-from c2corg_api.models.image import Image, ImageLocale
+from c2corg_api.models.document import DocumentLocale
+from c2corg_api.models.image import Image
 
 from c2corg_api.tests import BaseTestCase
 
@@ -9,9 +10,9 @@ class TestImage(BaseTestCase):
         image = Image(
             document_id=1, activities='skitouring', height=1200,
             locales=[
-                ImageLocale(
+                DocumentLocale(
                     id=2, culture='en', title='A', description='abc'),
-                ImageLocale(
+                DocumentLocale(
                     id=3, culture='fr', title='B', description='bcd'),
             ]
         )

--- a/c2corg_api/tests/models/test_map.py
+++ b/c2corg_api/tests/models/test_map.py
@@ -1,0 +1,37 @@
+from c2corg_api.models.document import DocumentLocale
+from c2corg_api.models.topo_map import TopoMap
+
+from c2corg_api.tests import BaseTestCase
+
+
+class TestRoute(BaseTestCase):
+
+    def test_to_archive(self):
+        m = TopoMap(
+            document_id=1, editor='ign', scale='20000', code='3431OT',
+            locales=[
+                DocumentLocale(
+                    id=2, culture='en', title='Lac d\'Annecy'),
+                DocumentLocale(
+                    id=3, culture='fr', title='Lac d\'Annecy'),
+            ]
+        )
+
+        map_archive = m.to_archive()
+
+        self.assertIsNone(map_archive.id)
+        self.assertEqual(map_archive.document_id, m.document_id)
+        self.assertEqual(
+            map_archive.editor, m.editor)
+        self.assertEqual(map_archive.scale, m.scale)
+        self.assertEqual(map_archive.code, m.code)
+
+        archive_locals = m.get_archive_locales()
+
+        self.assertEqual(len(archive_locals), 2)
+        locale = m.locales[0]
+        locale_archive = archive_locals[0]
+        self.assertIsNot(locale_archive, locale)
+        self.assertIsNone(locale_archive.id)
+        self.assertEqual(locale_archive.culture, locale.culture)
+        self.assertEqual(locale_archive.title, locale.title)

--- a/c2corg_api/tests/models/test_map.py
+++ b/c2corg_api/tests/models/test_map.py
@@ -1,10 +1,11 @@
-from c2corg_api.models.document import DocumentLocale
-from c2corg_api.models.topo_map import TopoMap
+from c2corg_api.models.document import DocumentLocale, DocumentGeometry
+from c2corg_api.models.topo_map import TopoMap, get_maps
+from c2corg_api.models.waypoint import Waypoint
 
 from c2corg_api.tests import BaseTestCase
 
 
-class TestRoute(BaseTestCase):
+class TestMap(BaseTestCase):
 
     def test_to_archive(self):
         m = TopoMap(
@@ -35,3 +36,45 @@ class TestRoute(BaseTestCase):
         self.assertIsNone(locale_archive.id)
         self.assertEqual(locale_archive.culture, locale.culture)
         self.assertEqual(locale_archive.title, locale.title)
+
+    def test_get_maps(self):
+        map1 = TopoMap(
+            locales=[
+                DocumentLocale(culture='en', title='Passo del Maloja'),
+                DocumentLocale(culture='fr', title='Passo del Maloja')
+            ],
+            geometry=DocumentGeometry(geom='SRID=3857;POLYGON((1060345.67641127 5869598.161661,1161884.8271513 5866294.47946546,1159243.3608776 5796747.98963817,1058506.68785187 5800000.03655724,1060345.67641127 5869598.161661))')  # noqa
+        )
+        map2 = TopoMap(
+            locales=[
+                DocumentLocale(culture='fr', title='Monte Disgrazia')
+            ],
+            geometry=DocumentGeometry(geom='SRID=3857;POLYGON((1059422.5474971 5834730.45170096,1110000.12573506 5833238.36363707,1108884.30979916 5798519.62445622,1058506.68785187 5800000.03655724,1059422.5474971 5834730.45170096))')  # noqa
+        )
+        map3 = TopoMap(
+            locales=[
+                DocumentLocale(culture='fr', title='Sciora')
+            ],
+            geometry=DocumentGeometry(geom='SRID=3857;POLYGON((1059422.5474971 5834730.45170096,1084713.47958582 5834021.11961652,1084204.54539729 5816641.60293193,1058963.71520182 5817348.14989301,1059422.5474971 5834730.45170096))')  # noqa
+        )
+        map4 = TopoMap(
+            locales=[
+                DocumentLocale(culture='fr', title='...')
+            ],
+            geometry=DocumentGeometry(geom='SRID=3857;POLYGON((753678.422528324 6084684.82967302,857818.351438369 6084952.58494753,857577.289072432 6013614.93425228,754282.556732048 6013351.52692378,753678.422528324 6084684.82967302))')  # noqa
+        )
+        waypoint = Waypoint(
+            waypoint_type='summit',
+            geometry=DocumentGeometry(geom='SRID=3857;POINT(1069913.22199537 5830556.39234855)')  # noqa
+        )
+        self.session.add_all([waypoint, map1, map2, map3, map4])
+        self.session.flush()
+
+        maps = get_maps(waypoint, 'en')
+        self.assertEqual(
+            set([m.document_id for m in maps]),
+            set([map1.document_id, map2.document_id, map3.document_id]))
+
+        for m in maps:
+            # check that the "best" locale is set
+            self.assertEqual(len(m.locales), 1)

--- a/c2corg_api/tests/security/__init__.py
+++ b/c2corg_api/tests/security/__init__.py
@@ -1,0 +1,1 @@
+# package

--- a/c2corg_api/tests/security/test_roles.py
+++ b/c2corg_api/tests/security/test_roles.py
@@ -1,0 +1,16 @@
+from c2corg_api.security.roles import groupfinder
+from c2corg_api.tests import BaseTestCase
+from pyramid.security import Authenticated
+
+
+class RolesTest(BaseTestCase):
+
+    def test_groupfinder(self):
+        self.assertEqual(
+            [Authenticated],
+            groupfinder(self.global_userids['contributor'], None)
+        )
+        self.assertEqual(
+            ['group:moderators'],
+            groupfinder(self.global_userids['moderator'], None)
+        )

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -187,11 +187,11 @@ class BaseDocumentTestRest(BaseTestRest):
         self.app.get(self._prefix + '/-9999', status=404)
         self.app.get(self._prefix + '/-9999?l=es', status=404)
 
-    def post_error(self, request_body):
+    def post_error(self, request_body, user='contributor'):
         response = self.app.post_json(self._prefix, request_body,
                                       expect_errors=True, status=403)
 
-        headers = self.add_authorization_header(username='contributor')
+        headers = self.add_authorization_header(username=user)
         response = self.app.post_json(self._prefix, request_body,
                                       headers=headers, expect_errors=True,
                                       status=400)
@@ -202,11 +202,11 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertGreater(len(errors), 0)
         return body
 
-    def post_missing_title(self, request_body):
+    def post_missing_title(self, request_body, user='contributor'):
         response = self.app.post_json(self._prefix, request_body,
                                       expect_errors=True, status=403)
 
-        headers = self.add_authorization_header(username='contributor')
+        headers = self.add_authorization_header(username=user)
         response = self.app.post_json(self._prefix, request_body,
                                       headers=headers,
                                       expect_errors=True, status=400)
@@ -301,13 +301,13 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(errors[0].get('name'), field)
         return body
 
-    def post_non_whitelisted_attribute(self, request_body):
+    def post_non_whitelisted_attribute(self, request_body, user='contributor'):
         """`protected` is a non-whitelisted attribute, which is ignored when
         given in a request.
         """
         response = self.app.post_json(self._prefix, request_body, status=403)
 
-        headers = self.add_authorization_header(username='contributor')
+        headers = self.add_authorization_header(username=user)
         response = self.app.post_json(
             self._prefix, request_body, headers=headers, status=200)
 
@@ -330,10 +330,10 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(errors[0].get('name'), 'Content-Type')
         return body
 
-    def post_success(self, request_body):
+    def post_success(self, request_body, user='contributor'):
         response = self.app.post_json(self._prefix, request_body, status=403)
 
-        headers = self.add_authorization_header(username='contributor')
+        headers = self.add_authorization_header(username=user)
         response = self.app.post_json(self._prefix, request_body,
                                       headers=headers, status=200)
 
@@ -385,11 +385,11 @@ class BaseDocumentTestRest(BaseTestRest):
 
         return (body, doc)
 
-    def put_wrong_document_id(self, request_body):
+    def put_wrong_document_id(self, request_body, user='contributor'):
         response = self.app.put_json(
             self._prefix + '/-9999', request_body, status=403)
 
-        headers = self.add_authorization_header(username='contributor')
+        headers = self.add_authorization_header(username=user)
         response = self.app.put_json(
             self._prefix + '/-9999', request_body, headers=headers, status=404)
 
@@ -397,11 +397,11 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(body['status'], 'error')
         self.assertEqual(body['errors'][0]['name'], 'Not Found')
 
-    def put_wrong_version(self, request_body, id):
+    def put_wrong_version(self, request_body, id, user='contributor'):
         response = self.app.put_json(
             self._prefix + '/' + str(id), request_body, status=403)
 
-        headers = self.add_authorization_header(username='contributor')
+        headers = self.add_authorization_header(username=user)
         response = self.app.put_json(
             self._prefix + '/' + str(id), request_body, headers=headers,
             status=409)
@@ -410,14 +410,14 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(body['status'], 'error')
         self.assertEqual(body['errors'][0]['name'], 'Conflict')
 
-    def put_wrong_ids(self, request_body, id):
+    def put_wrong_ids(self, request_body, id, user='contributor'):
         """The id given in the URL does not equal the document_id in the
         request body.
         """
         response = self.app.put_json(
             self._prefix + '/' + str(id + 1), request_body, status=403)
 
-        headers = self.add_authorization_header(username='contributor')
+        headers = self.add_authorization_header(username=user)
         response = self.app.put_json(
             self._prefix + '/' + str(id + 1), request_body, headers=headers,
             status=400)
@@ -425,14 +425,14 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(body['status'], 'error')
         self.assertEqual(body['errors'][0]['name'], 'Bad Request')
 
-    def put_put_no_document(self, id):
+    def put_put_no_document(self, id, user='contributor'):
         request_body = {
             'message': '...'
         }
         response = self.app.put_json(
             self._prefix + '/' + str(id), request_body, status=403)
 
-        headers = self.add_authorization_header(username='contributor')
+        headers = self.add_authorization_header(username=user)
         response = self.app.put_json(
             self._prefix + '/' + str(id), request_body, headers=headers,
             status=400)
@@ -442,12 +442,13 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(
             body['errors'][0]['description'], 'document is missing')
 
-    def put_missing_field(self, request_body, document, field):
+    def put_missing_field(
+            self, request_body, document, field, user='contributor'):
         response = self.app.put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             status=403)
 
-        headers = self.add_authorization_header(username='contributor')
+        headers = self.add_authorization_header(username=user)
         response = self.app.put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             headers=headers, status=400)
@@ -458,14 +459,14 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(len(errors), 1)
         self.assertCorniceRequired(errors[0], field)
 
-    def put_success_all(self, request_body, document):
+    def put_success_all(self, request_body, document, user='contributor'):
         """Test updating a document with changes to the figures and locales.
         """
         response = self.app.put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             status=403)
 
-        headers = self.add_authorization_header(username='contributor')
+        headers = self.add_authorization_header(username=user)
         response = self.app.put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             headers=headers, status=200)
@@ -551,14 +552,15 @@ class BaseDocumentTestRest(BaseTestRest):
 
         return (body, document)
 
-    def put_success_figures_only(self, request_body, document):
+    def put_success_figures_only(
+            self, request_body, document, user='contributor'):
         """Test updating a document with changes to the figures only.
         """
         response = self.app.put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             status=403)
 
-        headers = self.add_authorization_header(username='contributor')
+        headers = self.add_authorization_header(username=user)
         response = self.app.put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             headers=headers, status=200)
@@ -639,14 +641,15 @@ class BaseDocumentTestRest(BaseTestRest):
 
         return (body, document)
 
-    def put_success_lang_only(self, request_body, document):
+    def put_success_lang_only(
+            self, request_body, document, user='contributor'):
         """Test updating a document with only changes to a locale.
         """
         response = self.app.put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             status=403)
 
-        headers = self.add_authorization_header(username='contributor')
+        headers = self.add_authorization_header(username=user)
         response = self.app.put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             headers=headers, status=200)
@@ -717,14 +720,14 @@ class BaseDocumentTestRest(BaseTestRest):
 
         return (body, document)
 
-    def put_success_new_lang(self, request_body, document):
+    def put_success_new_lang(self, request_body, document, user='contributor'):
         """Test updating a document by adding a new locale.
         """
         response = self.app.put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             status=403)
 
-        headers = self.add_authorization_header(username='contributor')
+        headers = self.add_authorization_header(username=user)
         response = self.app.put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             headers=headers, status=200)

--- a/c2corg_api/tests/views/test_area.py
+++ b/c2corg_api/tests/views/test_area.py
@@ -63,7 +63,7 @@ class TestAreaRest(BaseDocumentTestRest):
         self.get_404()
 
     def test_post_error(self):
-        body = self.post_error({})
+        body = self.post_error({}, user='moderator')
         errors = body.get('errors')
         self.assertEqual(len(errors), 3)
         self.assertCorniceRequired(errors[0], 'locales')
@@ -80,7 +80,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 {'culture': 'en'}
             ]
         }
-        body = self.post_missing_title(body_post)
+        body = self.post_missing_title(body_post, user='moderator')
         errors = body.get('errors')
         self.assertEqual(len(errors), 2)
         self.assertCorniceRequired(errors[0], 'locales.0.title')
@@ -98,7 +98,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 {'culture': 'en', 'title': 'Chartreuse'}
             ]
         }
-        self.post_non_whitelisted_attribute(body)
+        self.post_non_whitelisted_attribute(body, user='moderator')
 
     def test_post_missing_content_type(self):
         self.post_missing_content_type({})
@@ -114,7 +114,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 {'culture': 'en', 'title': 'Chartreuse'}
             ]
         }
-        body, doc = self.post_success(body)
+        body, doc = self.post_success(body, user='moderator')
         self._assert_geometry(body)
 
         version = doc.versions[0]

--- a/c2corg_api/tests/views/test_area.py
+++ b/c2corg_api/tests/views/test_area.py
@@ -21,7 +21,9 @@ class TestAreaRest(BaseDocumentTestRest):
         self._add_test_data()
 
     def test_get_collection(self):
-        self.get_collection()
+        body = self.get_collection()
+        doc = body['documents'][0]
+        self.assertNotIn('areas', doc)
 
     def test_get_collection_paginated(self):
         self.app.get("/areas?offset=invalid", status=400)

--- a/c2corg_api/tests/views/test_area.py
+++ b/c2corg_api/tests/views/test_area.py
@@ -1,0 +1,321 @@
+import json
+
+from c2corg_api.models.area import Area, ArchiveArea
+from shapely.geometry import shape, Point
+
+from c2corg_api.models.document import (
+    DocumentGeometry, ArchiveDocumentLocale, DocumentLocale)
+from c2corg_api.views.document import DocumentRest
+
+from c2corg_api.tests.views import BaseDocumentTestRest
+
+
+class TestAreaRest(BaseDocumentTestRest):
+
+    def setUp(self):  # noqa
+        self.set_prefix_and_model(
+            "/areas", Area, ArchiveArea, ArchiveDocumentLocale)
+        BaseDocumentTestRest.setUp(self)
+        self._add_test_data()
+
+    def test_get_collection(self):
+        self.get_collection()
+
+    def test_get_collection_paginated(self):
+        self.app.get("/areas?offset=invalid", status=400)
+
+        self.assertResultsEqual(
+            self.get_collection({'offset': 0, 'limit': 0}), [], 4)
+
+        self.assertResultsEqual(
+            self.get_collection({'offset': 0, 'limit': 1}),
+            [self.area4.document_id], 4)
+        self.assertResultsEqual(
+            self.get_collection({'offset': 0, 'limit': 2}),
+            [self.area4.document_id, self.area3.document_id], 4)
+        self.assertResultsEqual(
+            self.get_collection({'offset': 1, 'limit': 2}),
+            [self.area3.document_id, self.area2.document_id], 4)
+
+        self.assertResultsEqual(
+            self.get_collection(
+                {'after': self.area3.document_id, 'limit': 1}),
+            [self.area2.document_id], -1)
+
+    def test_get_collection_lang(self):
+        self.get_collection_lang()
+
+    def test_get(self):
+        body = self.get(self.area1)
+        self._assert_geometry(body)
+
+    def test_get_lang(self):
+        self.get_lang(self.area1)
+
+    def test_get_new_lang(self):
+        self.get_new_lang(self.area1)
+
+    def test_get_404(self):
+        self.get_404()
+
+    def test_post_error(self):
+        body = self.post_error({})
+        errors = body.get('errors')
+        self.assertEqual(len(errors), 3)
+        self.assertCorniceRequired(errors[0], 'locales')
+        self.assertCorniceRequired(errors[1], 'geometry')
+        self.assertCorniceRequired(errors[2], 'area_type')
+
+    def test_post_missing_title(self):
+        body_post = {
+            'area_type': 'range',
+            'geometry': {
+                'geom': '{"type": "Point", "coordinates": [635956, 5723604]}'
+            },
+            'locales': [
+                {'culture': 'en'}
+            ]
+        }
+        body = self.post_missing_title(body_post)
+        errors = body.get('errors')
+        self.assertEqual(len(errors), 2)
+        self.assertCorniceRequired(errors[0], 'locales.0.title')
+        self.assertCorniceRequired(errors[1], 'locales')
+
+    def test_post_non_whitelisted_attribute(self):
+        body = {
+            'area_type': 'range',
+            'protected': True,
+            'geometry': {
+                'id': 5678, 'version': 6789,
+                'geom': '{"type": "Point", "coordinates": [635956, 5723604]}'
+            },
+            'locales': [
+                {'culture': 'en', 'title': 'Chartreuse'}
+            ]
+        }
+        self.post_non_whitelisted_attribute(body)
+
+    def test_post_missing_content_type(self):
+        self.post_missing_content_type({})
+
+    def test_post_success(self):
+        body = {
+            'area_type': 'range',
+            'geometry': {
+                'id': 5678, 'version': 6789,
+                'geom': '{"type": "Point", "coordinates": [635956, 5723604]}'
+            },
+            'locales': [
+                {'culture': 'en', 'title': 'Chartreuse'}
+            ]
+        }
+        body, doc = self.post_success(body)
+        self._assert_geometry(body)
+
+        version = doc.versions[0]
+
+        archive_map = version.document_archive
+        self.assertEqual(archive_map.area_type, 'range')
+
+        archive_locale = version.document_locales_archive
+        self.assertEqual(archive_locale.culture, 'en')
+        self.assertEqual(archive_locale.title, 'Chartreuse')
+
+        archive_geometry = version.document_geometry_archive
+        self.assertEqual(archive_geometry.version, doc.geometry.version)
+        self.assertIsNotNone(archive_geometry.geom)
+
+    def test_put_wrong_document_id(self):
+        body = {
+            'document': {
+                'document_id': '-9999',
+                'version': self.area1.version,
+                'area_type': 'range',
+                'locales': [
+                    {'culture': 'en', 'title': 'Chartreuse',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        self.put_wrong_document_id(body)
+
+    def test_put_wrong_document_version(self):
+        body = {
+            'document': {
+                'document_id': self.area1.document_id,
+                'version': -9999,
+                'area_type': 'range',
+                'locales': [
+                    {'culture': 'en', 'title': 'Chartreuse',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        self.put_wrong_version(body, self.area1.document_id)
+
+    def test_put_wrong_locale_version(self):
+        body = {
+            'document': {
+                'document_id': self.area1.document_id,
+                'version': self.area1.version,
+                'area_type': 'range',
+                'locales': [
+                    {'culture': 'en', 'title': 'Chartreuse',
+                     'version': -9999}
+                ]
+            }
+        }
+        self.put_wrong_version(body, self.area1.document_id)
+
+    def test_put_wrong_ids(self):
+        body = {
+            'document': {
+                'document_id': self.area1.document_id,
+                'version': self.area1.version,
+                'area_type': 'range',
+                'locales': [
+                    {'culture': 'en', 'title': 'Chartreuse',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        self.put_wrong_ids(body, self.area1.document_id)
+
+    def test_put_no_document(self):
+        self.put_put_no_document(self.area1.document_id)
+
+    def test_put_success_all(self):
+        body = {
+            'message': 'Update',
+            'document': {
+                'document_id': self.area1.document_id,
+                'version': self.area1.version,
+                'area_type': 'admin_limits',
+                'geometry': {
+                    'version': self.area1.geometry.version,
+                    'geom': '{"type": "Point", "coordinates": [1, 2]}'
+                },
+                'locales': [
+                    {'culture': 'en', 'title': 'New title',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        (body, map1) = self.put_success_all(body, self.area1)
+
+        self.assertEquals(map1.area_type, 'admin_limits')
+        locale_en = map1.get_locale('en')
+        self.assertEquals(locale_en.title, 'New title')
+
+        # version with culture 'en'
+        versions = map1.versions
+        version_en = versions[2]
+        archive_locale = version_en.document_locales_archive
+        self.assertEqual(archive_locale.title, 'New title')
+
+        archive_document_en = version_en.document_archive
+        self.assertEqual(archive_document_en.area_type, 'admin_limits')
+
+        archive_geometry_en = version_en.document_geometry_archive
+        self.assertEqual(archive_geometry_en.version, 2)
+
+        # version with culture 'fr'
+        version_fr = versions[3]
+        archive_locale = version_fr.document_locales_archive
+        self.assertEqual(archive_locale.title, 'Chartreuse')
+
+    def test_put_success_figures_only(self):
+        body = {
+            'message': 'Changing figures',
+            'document': {
+                'document_id': self.area1.document_id,
+                'version': self.area1.version,
+                'area_type': 'admin_limits',
+                'locales': [
+                    {'culture': 'en', 'title': 'Chartreuse',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        (body, area) = self.put_success_figures_only(body, self.area1)
+
+        self.assertEquals(area.area_type, 'admin_limits')
+
+    def test_put_success_lang_only(self):
+        body = {
+            'message': 'Changing lang',
+            'document': {
+                'document_id': self.area1.document_id,
+                'version': self.area1.version,
+                'area_type': 'range',
+                'locales': [
+                    {'culture': 'en', 'title': 'New title',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        (body, area) = self.put_success_lang_only(body, self.area1)
+
+        self.assertEquals(
+            area.get_locale('en').title, 'New title')
+
+    def test_put_success_new_lang(self):
+        """Test updating a document by adding a new locale.
+        """
+        body = {
+            'message': 'Adding lang',
+            'document': {
+                'document_id': self.area1.document_id,
+                'version': self.area1.version,
+                'area_type': 'range',
+                'locales': [
+                    {'culture': 'es', 'title': 'Chartreuse'}
+                ]
+            }
+        }
+        (body, area) = self.put_success_new_lang(body, self.area1)
+
+        self.assertEquals(area.get_locale('es').title, 'Chartreuse')
+
+    def _assert_geometry(self, body):
+        self.assertIsNotNone(body.get('geometry'))
+        geometry = body.get('geometry')
+        self.assertIsNotNone(geometry.get('version'))
+        self.assertIsNotNone(geometry.get('geom'))
+
+        geom = geometry.get('geom')
+        point = shape(json.loads(geom))
+        self.assertIsInstance(point, Point)
+        self.assertAlmostEqual(point.x, 635956)
+        self.assertAlmostEqual(point.y, 5723604)
+
+    def _add_test_data(self):
+        self.area1 = Area(area_type='range')
+
+        self.locale_en = DocumentLocale(culture='en', title='Chartreuse')
+        self.locale_fr = DocumentLocale(culture='fr', title='Chartreuse')
+
+        self.area1.locales.append(self.locale_en)
+        self.area1.locales.append(self.locale_fr)
+
+        self.area1.geometry = DocumentGeometry(
+            geom='SRID=3857;POINT(635956 5723604)')
+
+        self.session.add(self.area1)
+        self.session.flush()
+
+        user_id = self.global_userids['contributor']
+        DocumentRest(None)._create_new_version(self.area1, user_id)
+
+        self.area2 = Area(area_type='range')
+        self.session.add(self.area2)
+        self.area3 = Area(area_type='range')
+        self.session.add(self.area3)
+        self.area4 = Area(area_type='admin_limits')
+        self.area4.locales.append(DocumentLocale(
+            culture='en', title='Isère'))
+        self.area4.locales.append(DocumentLocale(
+            culture='fr', title='Isère'))
+        self.session.add(self.area4)
+        self.session.flush()

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -1,9 +1,9 @@
 import json
 from shapely.geometry import shape, Point
 
-from c2corg_api.models.image import (
-    Image, ImageLocale, ArchiveImage, ArchiveImageLocale)
-from c2corg_api.models.document import DocumentGeometry
+from c2corg_api.models.image import Image, ArchiveImage
+from c2corg_api.models.document import (
+    DocumentGeometry, ArchiveDocumentLocale, DocumentLocale)
 from c2corg_api.views.document import DocumentRest
 
 from c2corg_api.tests.views import BaseDocumentTestRest
@@ -13,7 +13,7 @@ class TestImageRest(BaseDocumentTestRest):
 
     def setUp(self):  # noqa
         self.set_prefix_and_model(
-            "/images", Image, ArchiveImage, ArchiveImageLocale)
+            "/images", Image, ArchiveImage, ArchiveDocumentLocale)
         BaseDocumentTestRest.setUp(self)
         self._add_test_data()
 
@@ -303,10 +303,10 @@ class TestImageRest(BaseDocumentTestRest):
         self.image = Image(
             activities='paragliding', height=2000)
 
-        self.locale_en = ImageLocale(
+        self.locale_en = DocumentLocale(
             culture='en', title='Mont Blanc from the air', description='...')
 
-        self.locale_fr = ImageLocale(
+        self.locale_fr = DocumentLocale(
             culture='fr', title='Mont Blanc du ciel', description='...')
 
         self.image.locales.append(self.locale_en)
@@ -329,9 +329,9 @@ class TestImageRest(BaseDocumentTestRest):
         self.session.add(self.image3)
         self.image4 = Image(
             activities='paragliding', height=2000)
-        self.image4.locales.append(ImageLocale(
+        self.image4.locales.append(DocumentLocale(
             culture='en', title='Mont Blanc from the air', description='...'))
-        self.image4.locales.append(ImageLocale(
+        self.image4.locales.append(DocumentLocale(
             culture='fr', title='Mont Blanc du ciel', description='...'))
         self.session.add(self.image4)
         self.session.flush()

--- a/c2corg_api/tests/views/test_topo_map.py
+++ b/c2corg_api/tests/views/test_topo_map.py
@@ -58,8 +58,14 @@ class TestTopoMapRest(BaseDocumentTestRest):
     def test_get_404(self):
         self.get_404()
 
+    def test_post_not_moderator(self):
+        headers = self.add_authorization_header(username='contributor')
+        self.app.post_json(
+            self._prefix, {}, headers=headers,
+            expect_errors=True, status=403)
+
     def test_post_error(self):
-        body = self.post_error({})
+        body = self.post_error({}, user='moderator')
         errors = body.get('errors')
         self.assertEqual(len(errors), 2)
         self.assertCorniceRequired(errors[0], 'locales')
@@ -78,7 +84,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 {'culture': 'en'}
             ]
         }
-        body = self.post_missing_title(body_post)
+        body = self.post_missing_title(body_post, user='moderator')
         errors = body.get('errors')
         self.assertEqual(len(errors), 2)
         self.assertCorniceRequired(errors[0], 'locales.0.title')
@@ -98,7 +104,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 {'culture': 'en', 'title': 'Lac d\'Annecy'}
             ]
         }
-        self.post_non_whitelisted_attribute(body)
+        self.post_non_whitelisted_attribute(body, user='moderator')
 
     def test_post_missing_content_type(self):
         self.post_missing_content_type({})
@@ -116,7 +122,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 {'culture': 'en', 'title': 'Lac d\'Annecy'}
             ]
         }
-        body, doc = self.post_success(body)
+        body, doc = self.post_success(body, user='moderator')
         self._assert_geometry(body)
 
         version = doc.versions[0]
@@ -148,7 +154,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 ]
             }
         }
-        self.put_wrong_document_id(body)
+        self.put_wrong_document_id(body, user='moderator')
 
     def test_put_wrong_document_version(self):
         body = {
@@ -164,7 +170,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 ]
             }
         }
-        self.put_wrong_version(body, self.map1.document_id)
+        self.put_wrong_version(body, self.map1.document_id, user='moderator')
 
     def test_put_wrong_locale_version(self):
         body = {
@@ -180,7 +186,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 ]
             }
         }
-        self.put_wrong_version(body, self.map1.document_id)
+        self.put_wrong_version(body, self.map1.document_id, user='moderator')
 
     def test_put_wrong_ids(self):
         body = {
@@ -196,10 +202,10 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 ]
             }
         }
-        self.put_wrong_ids(body, self.map1.document_id)
+        self.put_wrong_ids(body, self.map1.document_id, user='moderator')
 
     def test_put_no_document(self):
-        self.put_put_no_document(self.map1.document_id)
+        self.put_put_no_document(self.map1.document_id, user='moderator')
 
     def test_put_success_all(self):
         body = {
@@ -220,7 +226,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 ]
             }
         }
-        (body, map1) = self.put_success_all(body, self.map1)
+        (body, map1) = self.put_success_all(body, self.map1, user='moderator')
 
         self.assertEquals(map1.code, '3433OT')
         locale_en = map1.get_locale('en')
@@ -259,7 +265,8 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 ]
             }
         }
-        (body, map1) = self.put_success_figures_only(body, self.map1)
+        (body, map1) = self.put_success_figures_only(
+            body, self.map1, user='moderator')
 
         self.assertEquals(map1.code, '3433OT')
 
@@ -278,7 +285,8 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 ]
             }
         }
-        (body, map1) = self.put_success_lang_only(body, self.map1)
+        (body, map1) = self.put_success_lang_only(
+            body, self.map1, user='moderator')
 
         self.assertEquals(
             map1.get_locale('en').title, 'New title')
@@ -299,7 +307,8 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 ]
             }
         }
-        (body, map1) = self.put_success_new_lang(body, self.map1)
+        (body, map1) = self.put_success_new_lang(
+            body, self.map1, user='moderator')
 
         self.assertEquals(map1.get_locale('es').title, 'Lac d\'Annecy')
 

--- a/c2corg_api/tests/views/test_topo_map.py
+++ b/c2corg_api/tests/views/test_topo_map.py
@@ -1,0 +1,349 @@
+import json
+
+from c2corg_api.models.topo_map import ArchiveTopoMap, TopoMap
+from shapely.geometry import shape, Point
+
+from c2corg_api.models.document import (
+    DocumentGeometry, ArchiveDocumentLocale, DocumentLocale)
+from c2corg_api.views.document import DocumentRest
+
+from c2corg_api.tests.views import BaseDocumentTestRest
+
+
+class TestTopoMapRest(BaseDocumentTestRest):
+
+    def setUp(self):  # noqa
+        self.set_prefix_and_model(
+            "/maps", TopoMap, ArchiveTopoMap, ArchiveDocumentLocale)
+        BaseDocumentTestRest.setUp(self)
+        self._add_test_data()
+
+    def test_get_collection(self):
+        self.get_collection()
+
+    def test_get_collection_paginated(self):
+        self.app.get("/maps?offset=invalid", status=400)
+
+        self.assertResultsEqual(
+            self.get_collection({'offset': 0, 'limit': 0}), [], 4)
+
+        self.assertResultsEqual(
+            self.get_collection({'offset': 0, 'limit': 1}),
+            [self.map4.document_id], 4)
+        self.assertResultsEqual(
+            self.get_collection({'offset': 0, 'limit': 2}),
+            [self.map4.document_id, self.map3.document_id], 4)
+        self.assertResultsEqual(
+            self.get_collection({'offset': 1, 'limit': 2}),
+            [self.map3.document_id, self.map2.document_id], 4)
+
+        self.assertResultsEqual(
+            self.get_collection(
+                {'after': self.map3.document_id, 'limit': 1}),
+            [self.map2.document_id], -1)
+
+    def test_get_collection_lang(self):
+        self.get_collection_lang()
+
+    def test_get(self):
+        body = self.get(self.map1)
+        self._assert_geometry(body)
+
+    def test_get_lang(self):
+        self.get_lang(self.map1)
+
+    def test_get_new_lang(self):
+        self.get_new_lang(self.map1)
+
+    def test_get_404(self):
+        self.get_404()
+
+    def test_post_error(self):
+        body = self.post_error({})
+        errors = body.get('errors')
+        self.assertEqual(len(errors), 2)
+        self.assertCorniceRequired(errors[0], 'locales')
+        self.assertCorniceRequired(errors[1], 'geometry')
+
+    def test_post_missing_title(self):
+        body_post = {
+            'editor': 'ign',
+            'scale': '25000',
+            'code': '3432OT',
+            'geometry': {
+                'id': 5678, 'version': 6789,
+                'geom': '{"type": "Point", "coordinates": [635956, 5723604]}'
+            },
+            'locales': [
+                {'culture': 'en'}
+            ]
+        }
+        body = self.post_missing_title(body_post)
+        errors = body.get('errors')
+        self.assertEqual(len(errors), 2)
+        self.assertCorniceRequired(errors[0], 'locales.0.title')
+        self.assertCorniceRequired(errors[1], 'locales')
+
+    def test_post_non_whitelisted_attribute(self):
+        body = {
+            'editor': 'ign',
+            'scale': '25000',
+            'code': '3432OT',
+            'protected': True,
+            'geometry': {
+                'id': 5678, 'version': 6789,
+                'geom': '{"type": "Point", "coordinates": [635956, 5723604]}'
+            },
+            'locales': [
+                {'culture': 'en', 'title': 'Lac d\'Annecy'}
+            ]
+        }
+        self.post_non_whitelisted_attribute(body)
+
+    def test_post_missing_content_type(self):
+        self.post_missing_content_type({})
+
+    def test_post_success(self):
+        body = {
+            'editor': 'ign',
+            'scale': '25000',
+            'code': '3432OT',
+            'geometry': {
+                'id': 5678, 'version': 6789,
+                'geom': '{"type": "Point", "coordinates": [635956, 5723604]}'
+            },
+            'locales': [
+                {'culture': 'en', 'title': 'Lac d\'Annecy'}
+            ]
+        }
+        body, doc = self.post_success(body)
+        self._assert_geometry(body)
+
+        version = doc.versions[0]
+
+        archive_map = version.document_archive
+        self.assertEqual(archive_map.editor, 'ign')
+        self.assertEqual(archive_map.scale, '25000')
+        self.assertEqual(archive_map.code, '3432OT')
+
+        archive_locale = version.document_locales_archive
+        self.assertEqual(archive_locale.culture, 'en')
+        self.assertEqual(archive_locale.title, 'Lac d\'Annecy')
+
+        archive_geometry = version.document_geometry_archive
+        self.assertEqual(archive_geometry.version, doc.geometry.version)
+        self.assertIsNotNone(archive_geometry.geom)
+
+    def test_put_wrong_document_id(self):
+        body = {
+            'document': {
+                'document_id': '-9999',
+                'version': self.map1.version,
+                'editor': 'ign',
+                'scale': '25000',
+                'code': '3432OT',
+                'locales': [
+                    {'culture': 'en', 'title': 'Lac d\'Annecy',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        self.put_wrong_document_id(body)
+
+    def test_put_wrong_document_version(self):
+        body = {
+            'document': {
+                'document_id': self.map1.document_id,
+                'version': -9999,
+                'editor': 'ign',
+                'scale': '25000',
+                'code': '3432OT',
+                'locales': [
+                    {'culture': 'en', 'title': 'Lac d\'Annecy',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        self.put_wrong_version(body, self.map1.document_id)
+
+    def test_put_wrong_locale_version(self):
+        body = {
+            'document': {
+                'document_id': self.map1.document_id,
+                'version': self.map1.version,
+                'editor': 'ign',
+                'scale': '25000',
+                'code': '3432OT',
+                'locales': [
+                    {'culture': 'en', 'title': 'Lac d\'Annecy',
+                     'version': -9999}
+                ]
+            }
+        }
+        self.put_wrong_version(body, self.map1.document_id)
+
+    def test_put_wrong_ids(self):
+        body = {
+            'document': {
+                'document_id': self.map1.document_id,
+                'version': self.map1.version,
+                'editor': 'ign',
+                'scale': '25000',
+                'code': '3432OT',
+                'locales': [
+                    {'culture': 'en', 'title': 'Lac d\'Annecy',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        self.put_wrong_ids(body, self.map1.document_id)
+
+    def test_put_no_document(self):
+        self.put_put_no_document(self.map1.document_id)
+
+    def test_put_success_all(self):
+        body = {
+            'message': 'Update',
+            'document': {
+                'document_id': self.map1.document_id,
+                'version': self.map1.version,
+                'editor': 'ign',
+                'scale': '25000',
+                'code': '3433OT',
+                'geometry': {
+                    'version': self.map1.geometry.version,
+                    'geom': '{"type": "Point", "coordinates": [1, 2]}'
+                },
+                'locales': [
+                    {'culture': 'en', 'title': 'New title',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        (body, map1) = self.put_success_all(body, self.map1)
+
+        self.assertEquals(map1.code, '3433OT')
+        locale_en = map1.get_locale('en')
+        self.assertEquals(locale_en.title, 'New title')
+
+        # version with culture 'en'
+        versions = map1.versions
+        version_en = versions[2]
+        archive_locale = version_en.document_locales_archive
+        self.assertEqual(archive_locale.title, 'New title')
+
+        archive_document_en = version_en.document_archive
+        self.assertEqual(archive_document_en.scale, '25000')
+        self.assertEqual(archive_document_en.code, '3433OT')
+
+        archive_geometry_en = version_en.document_geometry_archive
+        self.assertEqual(archive_geometry_en.version, 2)
+
+        # version with culture 'fr'
+        version_fr = versions[3]
+        archive_locale = version_fr.document_locales_archive
+        self.assertEqual(archive_locale.title, 'Lac d\'Annecy')
+
+    def test_put_success_figures_only(self):
+        body = {
+            'message': 'Changing figures',
+            'document': {
+                'document_id': self.map1.document_id,
+                'version': self.map1.version,
+                'editor': 'ign',
+                'scale': '25000',
+                'code': '3433OT',
+                'locales': [
+                    {'culture': 'en', 'title': 'Lac d\'Annecy',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        (body, map1) = self.put_success_figures_only(body, self.map1)
+
+        self.assertEquals(map1.code, '3433OT')
+
+    def test_put_success_lang_only(self):
+        body = {
+            'message': 'Changing lang',
+            'document': {
+                'document_id': self.map1.document_id,
+                'version': self.map1.version,
+                'editor': 'ign',
+                'scale': '25000',
+                'code': '3431OT',
+                'locales': [
+                    {'culture': 'en', 'title': 'New title',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        (body, map1) = self.put_success_lang_only(body, self.map1)
+
+        self.assertEquals(
+            map1.get_locale('en').title, 'New title')
+
+    def test_put_success_new_lang(self):
+        """Test updating a document by adding a new locale.
+        """
+        body = {
+            'message': 'Adding lang',
+            'document': {
+                'document_id': self.map1.document_id,
+                'version': self.map1.version,
+                'editor': 'ign',
+                'scale': '25000',
+                'code': '3431OT',
+                'locales': [
+                    {'culture': 'es', 'title': 'Lac d\'Annecy'}
+                ]
+            }
+        }
+        (body, map1) = self.put_success_new_lang(body, self.map1)
+
+        self.assertEquals(map1.get_locale('es').title, 'Lac d\'Annecy')
+
+    def _assert_geometry(self, body):
+        self.assertIsNotNone(body.get('geometry'))
+        geometry = body.get('geometry')
+        self.assertIsNotNone(geometry.get('version'))
+        self.assertIsNotNone(geometry.get('geom'))
+
+        geom = geometry.get('geom')
+        point = shape(json.loads(geom))
+        self.assertIsInstance(point, Point)
+        self.assertAlmostEqual(point.x, 635956)
+        self.assertAlmostEqual(point.y, 5723604)
+
+    def _add_test_data(self):
+        self.map1 = TopoMap(editor='ign', scale='25000', code='3431OT')
+
+        self.locale_en = DocumentLocale(culture='en', title='Lac d\'Annecy')
+        self.locale_fr = DocumentLocale(culture='fr', title='Lac d\'Annecy')
+
+        self.map1.locales.append(self.locale_en)
+        self.map1.locales.append(self.locale_fr)
+
+        self.map1.geometry = DocumentGeometry(
+            geom='SRID=3857;POINT(635956 5723604)')
+
+        self.session.add(self.map1)
+        self.session.flush()
+
+        user_id = self.global_userids['contributor']
+        DocumentRest(None)._create_new_version(self.map1, user_id)
+
+        self.map2 = TopoMap(
+            editor='ign', scale='25000', code='3432OT')
+        self.session.add(self.map2)
+        self.map3 = TopoMap(
+            editor='ign', scale='25000', code='3433OT')
+        self.session.add(self.map3)
+        self.map4 = TopoMap(
+            editor='ign', scale='25000', code='3434OT')
+        self.map4.locales.append(DocumentLocale(
+            culture='en', title='Lac d\'Annecy'))
+        self.map4.locales.append(DocumentLocale(
+            culture='fr', title='Lac d\'Annecy'))
+        self.session.add(self.map4)
+        self.session.flush()

--- a/c2corg_api/tests/views/test_user.py
+++ b/c2corg_api/tests/views/test_user.py
@@ -143,5 +143,9 @@ class TestUserRest(BaseTestRest):
         body = self.get_json_with_contributor(url, status=200)
         self.assertBodyEqual(body, 'username', 'contributor')
 
+    def test_restricted_request_unauthenticated(self):
+        url = '/users/' + str(self.global_userids['contributor'])
+        self.app.get(url, status=403)
+
     def _add_test_data(self):
         pass

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -38,6 +38,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.assertIn('title', locale)
         self.assertIn('summary', locale)
         self.assertNotIn('description', locale)
+        self.assertIn('areas', doc)
 
     def test_get_collection_lang(self):
         self.get_collection_lang()

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -87,6 +87,11 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.assertEqual(topo_map.get('code'), '3232ET')
         self.assertEqual(topo_map.get('locales')[0].get('title'), 'Belley')
 
+        self.assertIn('areas', body)
+        area = body.get('areas')[0]
+        self.assertEqual(area.get('area_type'), 'range')
+        self.assertEqual(area.get('locales')[0].get('title'), 'France')
+
     def test_get_version(self):
         self.get_version(self.waypoint, self.waypoint_version)
 
@@ -745,7 +750,10 @@ class TestWaypointRest(BaseDocumentTestRest):
             )
         )
         self.area2 = Area(
-            area_type='range'
+            area_type='range',
+            locales=[
+                DocumentLocale(culture='fr', title='France')
+            ]
         )
 
         self.session.add_all([self.area1, self.area2])

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -115,7 +115,7 @@ def to_seconds(date):
     return int((date - datetime.datetime(1970, 1, 1)).total_seconds())
 
 
-def set_best_locale(documents, preferred_lang):
+def set_best_locale(documents, preferred_lang, expunge=True):
     """Sets the "best" locale on the given documents. The "best" locale is
     the locale in the given "preferred language" if available. Otherwise
     it is the "most relevant" translation according to `cultures_priority`.
@@ -126,7 +126,8 @@ def set_best_locale(documents, preferred_lang):
     for document in documents:
         # need to detach the document from the session, so that the
         # following change to `document.locales` is not persisted
-        DBSession.expunge(document)
+        if expunge:
+            DBSession.expunge(document)
 
         if document.locales:
             available_locales = {

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -76,7 +76,9 @@ def to_json_dict(obj, schema):
     # manually copy certain attributes that were set on the object (it would be
     # cleaner to add the field to the schema, but ColanderAlchemy doesn't like
     # it because it's not a real column)
-    special_attributes = ['available_cultures', 'associations', 'maps']
+    special_attributes = [
+        'available_cultures', 'associations', 'maps', 'areas'
+    ]
     for attr in special_attributes:
         if hasattr(obj, attr):
             obj_dict[attr] = getattr(obj, attr)

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -73,13 +73,13 @@ def restricted_view(**kw):
 def to_json_dict(obj, schema):
     obj_dict = serialize(schema.dictify(obj))
 
-    # manually copy `available_cultures` and `associations` (it would be
+    # manually copy certain attributes that were set on the object (it would be
     # cleaner to add the field to the schema, but ColanderAlchemy doesn't like
     # it because it's not a real column)
-    if hasattr(obj, 'available_cultures'):
-        obj_dict['available_cultures'] = getattr(obj, 'available_cultures')
-    if hasattr(obj, 'associations'):
-        obj_dict['associations'] = getattr(obj, 'associations')
+    special_attributes = ['available_cultures', 'associations', 'maps']
+    for attr in special_attributes:
+        if hasattr(obj, attr):
+            obj_dict[attr] = getattr(obj, attr)
 
     return obj_dict
 

--- a/c2corg_api/views/area.py
+++ b/c2corg_api/views/area.py
@@ -1,0 +1,39 @@
+from c2corg_api.models.area import schema_area, Area, schema_update_area
+from c2corg_common.fields_area import fields_area
+from cornice.resource import resource, view
+
+from c2corg_api.views.document import DocumentRest, make_validator_create, \
+    make_validator_update
+from c2corg_api.views import cors_policy, restricted_json_view
+from c2corg_api.views.validation import validate_id, validate_pagination, \
+    validate_lang_param, validate_preferred_lang_param
+
+
+validate_area_create = make_validator_create(fields_area.get('required'))
+validate_area_update = make_validator_update(fields_area.get('required'))
+
+
+@resource(collection_path='/areas', path='/areas/{id}',
+          cors_policy=cors_policy)
+class AreaRest(DocumentRest):
+
+    @view(validators=[validate_pagination, validate_preferred_lang_param])
+    def collection_get(self):
+        return self._collection_get(Area, schema_area)
+
+    @view(validators=[validate_id, validate_lang_param])
+    def get(self):
+        return self._get(Area, schema_area)
+
+    @restricted_json_view(
+            schema=schema_area, validators=validate_area_create)
+    def collection_post(self):
+        # TODO limit to moderators
+        return self._collection_post(Area, schema_area)
+
+    @restricted_json_view(
+            schema=schema_update_area,
+            validators=[validate_id, validate_area_update])
+    def put(self):
+        # TODO limit to moderators
+        return self._put(Area, schema_area)

--- a/c2corg_api/views/area.py
+++ b/c2corg_api/views/area.py
@@ -25,7 +25,7 @@ class AreaRest(DocumentRest):
 
     @view(validators=[validate_id, validate_lang_param])
     def get(self):
-        return self._get(Area, schema_area)
+        return self._get(Area, schema_area, include_areas=False)
 
     @restricted_json_view(
             schema=schema_area, validators=validate_area_create)

--- a/c2corg_api/views/area.py
+++ b/c2corg_api/views/area.py
@@ -28,9 +28,9 @@ class AreaRest(DocumentRest):
         return self._get(Area, schema_area, include_areas=False)
 
     @restricted_json_view(
-            schema=schema_area, validators=validate_area_create)
+            schema=schema_area, validators=validate_area_create,
+            permission='moderator')
     def collection_post(self):
-        # TODO limit to moderators
         return self._collection_post(
             Area, schema_area, after_add=insert_associations)
 

--- a/c2corg_api/views/area.py
+++ b/c2corg_api/views/area.py
@@ -21,7 +21,7 @@ class AreaRest(DocumentRest):
 
     @view(validators=[validate_pagination, validate_preferred_lang_param])
     def collection_get(self):
-        return self._collection_get(Area, schema_area)
+        return self._collection_get(Area, schema_area, include_areas=False)
 
     @view(validators=[validate_id, validate_lang_param])
     def get(self):

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -1,4 +1,6 @@
 from c2corg_api.models import DBSession
+from c2corg_api.models.area import AREA_TYPE
+from c2corg_api.models.area_association import update_areas_for_document
 from c2corg_api.models.association import get_associations
 from c2corg_api.models.document import (
     UpdateType, DocumentLocale, ArchiveDocumentLocale, ArchiveDocument,
@@ -151,6 +153,9 @@ class DocumentRest(object):
         user_id = self.request.authenticated_userid
         self._create_new_version(document, user_id)
 
+        if document.type != AREA_TYPE:
+            update_areas_for_document(document, reset=False)
+
         if after_add:
             after_add(document)
 
@@ -194,6 +199,9 @@ class DocumentRest(object):
             self._update_version(
                 document, user_id, self.request.validated['message'],
                 update_types,  changed_langs)
+
+            if document.type != AREA_TYPE and UpdateType.GEOM in update_types:
+                update_areas_for_document(document, reset=True)
 
             if after_update:
                 after_update(document, update_types)

--- a/c2corg_api/views/topo_map.py
+++ b/c2corg_api/views/topo_map.py
@@ -1,0 +1,40 @@
+from c2corg_api.models.topo_map import (
+    TopoMap, schema_topo_map, schema_update_topo_map)
+from c2corg_common.fields_topo_map import fields_topo_map
+from cornice.resource import resource, view
+
+from c2corg_api.views.document import DocumentRest, make_validator_create, \
+    make_validator_update
+from c2corg_api.views import cors_policy, restricted_json_view
+from c2corg_api.views.validation import validate_id, validate_pagination, \
+    validate_lang_param, validate_preferred_lang_param
+
+
+validate_map_create = make_validator_create(fields_topo_map.get('required'))
+validate_map_update = make_validator_update(fields_topo_map.get('required'))
+
+
+@resource(collection_path='/maps', path='/maps/{id}',
+          cors_policy=cors_policy)
+class TopoMapRest(DocumentRest):
+
+    @view(validators=[validate_pagination, validate_preferred_lang_param])
+    def collection_get(self):
+        return self._collection_get(TopoMap, schema_topo_map)
+
+    @view(validators=[validate_id, validate_lang_param])
+    def get(self):
+        return self._get(TopoMap, schema_topo_map)
+
+    @restricted_json_view(
+            schema=schema_topo_map, validators=validate_map_create)
+    def collection_post(self):
+        # TODO limit to moderators
+        return self._collection_post(TopoMap, schema_topo_map)
+
+    @restricted_json_view(
+            schema=schema_update_topo_map,
+            validators=[validate_id, validate_map_update])
+    def put(self):
+        # TODO limit to moderators
+        return self._put(TopoMap, schema_topo_map)

--- a/c2corg_api/views/topo_map.py
+++ b/c2corg_api/views/topo_map.py
@@ -24,7 +24,7 @@ class TopoMapRest(DocumentRest):
 
     @view(validators=[validate_id, validate_lang_param])
     def get(self):
-        return self._get(TopoMap, schema_topo_map)
+        return self._get(TopoMap, schema_topo_map, include_maps=False)
 
     @restricted_json_view(
             schema=schema_topo_map, validators=validate_map_create)

--- a/c2corg_api/views/topo_map.py
+++ b/c2corg_api/views/topo_map.py
@@ -27,14 +27,14 @@ class TopoMapRest(DocumentRest):
         return self._get(TopoMap, schema_topo_map, include_maps=False)
 
     @restricted_json_view(
-            schema=schema_topo_map, validators=validate_map_create)
+            schema=schema_topo_map, validators=validate_map_create,
+            permission='moderator')
     def collection_post(self):
-        # TODO limit to moderators
         return self._collection_post(TopoMap, schema_topo_map)
 
     @restricted_json_view(
             schema=schema_update_topo_map,
-            validators=[validate_id, validate_map_update])
+            validators=[validate_id, validate_map_update],
+            permission='moderator')
     def put(self):
-        # TODO limit to moderators
         return self._put(TopoMap, schema_topo_map)


### PR DESCRIPTION
This PR deals with geo-associations, the associations between maps, areas/regions and documents:

 * Adds the model classes for maps and areas, updates the migration script and adds web-services
 * The associations between maps and documents are not persisted. When requesting a document, the relevant maps are retrieved with a spatial query.
 * On the contrary, the associations between areas and documents are persisted in a table `area_associations`, because this information is needed also in listings. This table is updated when a new area or document is added, or the geometry of an area or document is updated.
 * Maps and associations are returned when requesting a single document.

TODO

 * [x] Include areas in listing views
 * [x] Everybody can edit title and description of an area, currently the geometry should not be editable. (-> only moderators can edit geometries)
 * [x] Currently no new areas can be created ( -> limited to moderators).

See https://github.com/c2corg/v6_api/issues/128