### PR TITLE
Upgrade v6_common to get title_prefix in routes lists

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ git+https://github.com/tsauerwein/ColanderAlchemy.git@c2corg
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@d809fa18521bd5489e0b0ee82249659dc0a6a92a
+git+https://github.com/c2corg/v6_common.git@46bd43eea4e095b614cfaeb2021ca1b8987dbc2c
 
 # Discourse API client
 git+https://github.com/c2corg/pydiscourse.git@65e398343bbbc74fdb71cca4637c9f808e5adfb2


### PR DESCRIPTION
Needed for https://github.com/c2corg/v6_ui/issues/108

Will most likely confict with https://github.com/c2corg/v6_api/commit/35077b72e1cebab2efff527efef422a5ad152c8e in https://github.com/c2corg/v6_api/pull/136