### PR TITLE
Simplify route title building

### DIFF
--- a/c2corg_api/scripts/es/fill_index.py
+++ b/c2corg_api/scripts/es/fill_index.py
@@ -91,7 +91,7 @@ def fill_index(db_session):
                 }
 
             search_document['title_' + culture] = get_title(
-                title, title_prefix, culture)
+                title, title_prefix)
             search_document['summary_' + culture] = strip_bbcodes(summary)
             search_document['description_' + culture] = \
                 strip_bbcodes(description)

--- a/c2corg_api/search/sync.py
+++ b/c2corg_api/search/sync.py
@@ -52,7 +52,7 @@ def sync_search_index(document):
 
         # set the title prefix (name of the main waypoint) for routes
         title_prefix = locale.title_prefix if has_title_prefix else None
-        title = get_title(locale.title, title_prefix, culture)
+        title = get_title(locale.title, title_prefix)
 
         doc['title_' + culture] = title
         doc['summary_' + culture] = strip_bbcodes(locale.summary)

--- a/c2corg_api/search/utils.py
+++ b/c2corg_api/search/utils.py
@@ -29,8 +29,5 @@ def strip_bbcodes(s):
         return BBCODE_REGEX_ALL.sub(' ', s)
 
 
-def get_title(title, title_prefix, culture):
-    if title_prefix:
-        return title_prefix + (' : ' if culture == 'fr' else ': ') + title
-    else:
-        return title
+def get_title(title, title_prefix):
+    return title_prefix + ' : ' + title if title_prefix else title

--- a/c2corg_api/tests/scripts/es/test_fill_index.py
+++ b/c2corg_api/tests/scripts/es/test_fill_index.py
@@ -69,6 +69,6 @@ class FillIndexTest(BaseTestCase):
 
         route = SearchDocument.get(id=71173)
         self.assertIsNotNone(route)
-        self.assertEqual(route.title_en, 'Mont Blanc: Face N')
+        self.assertEqual(route.title_en, 'Mont Blanc : Face N')
         self.assertEqual(route.title_fr, '')
         self.assertEqual(route.doc_type, 'r')

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -377,7 +377,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(search_doc['doc_type'], doc.type)
 
         if isinstance(doc, Route):
-            title = waypoint_locale_en.title_prefix + ': ' + \
+            title = waypoint_locale_en.title_prefix + ' : ' + \
                 waypoint_locale_en.title
             self.assertEqual(search_doc['title_en'], title)
         else:
@@ -625,7 +625,7 @@ class BaseDocumentTestRest(BaseTestRest):
 
         if isinstance(document, Route) and document.main_waypoint_id:
             locale_en = document.get_locale('en')
-            title = locale_en.title_prefix + ': ' + locale_en.title
+            title = locale_en.title_prefix + ' : ' + locale_en.title
             self.assertEqual(search_doc['title_en'], title)
 
             locale_fr = document.get_locale('fr')

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -382,7 +382,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             id=route.document_id,
             index=elasticsearch_config['index'])
         self.assertEqual(
-            search_doc['title_en'], 'Mont Granier!: Mont Blanc from the air')
+            search_doc['title_en'], 'Mont Granier! : Mont Blanc from the air')
 
     def test_put_success_figures_and_lang_only(self):
         body_put = {


### PR DESCRIPTION
We can assume that the separator between ``title_prefix`` and ``title`` is always `` : `` whatever the language.