### PR TITLE
Use common sso_secret

### DIFF
--- a/config/default
+++ b/config/default
@@ -46,5 +46,5 @@ export migration_db_name = c2corg
 export logging_level = WARNING
 
 # FIXME
-export discourse_sso_secret = some secret string
+export discourse_sso_secret = d836444a9e4084d5b224a60c208dce14
 export discourse_api_key = c1706802dbf1152c91492a9dbd5dc6e1480a1de57c25089401b3f2416d8f6a1a

--- a/config/gberaudo
+++ b/config/gberaudo
@@ -9,4 +9,3 @@ export elasticsearch_index = c2corg_gberaudo
 export tests_elasticsearch_index = c2corg_gberaudo_tests
 export discourse_url = http://localhost:3000
 export discourse_api_key = c1706802dbf1152c91492a9dbd5dc6e1480a1de57c25089401b3f2416d8f6a1a
-export discourse_sso_secret = d836444a9e4084d5b224a60c208dce14

--- a/config/travis
+++ b/config/travis
@@ -8,4 +8,3 @@ export elasticsearch_port = 9200
 export elasticsearch_index = c2corg_travis_tests
 export tests_elasticsearch_port = 9200
 export tests_elasticsearch_index = c2corg_travis_tests
-export discourse_sso_secret = d836444a9e4084d5b224a60c208dce14


### PR DESCRIPTION
Secret taken from Discourse examples.
Can be revisited when the sso_secret is no more stored in git.