### PR TITLE
Add missing title parameter to set_title_prefix_for_ids()

### DIFF
--- a/c2corg_api/views/route.py
+++ b/c2corg_api/views/route.py
@@ -115,7 +115,7 @@ def set_title_prefix(route, title):
     """Set the given title as `prefix_title` for all locales of the given
     route.
     """
-    set_title_prefix_for_ids([l.id for l in route.locales])
+    set_title_prefix_for_ids([l.id for l in route.locales], title)
 
 
 def set_title_prefix_for_ids(ids, title):


### PR DESCRIPTION
Else one gets a 500 error when modifying a WP, because parameter ``title`` is missing when calling ``set_title_prefix_for_ids()``.