### PR TITLE
Rename culture to lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ Insert a waypoint:
 
     curl -X POST -v \
     -H "Content-Type: application/json" \
-    -d '{"waypoint_type": "summit", "elevation": 3779, "geometry": {"geom": "{\"type\": \"Point\", \"coordinates\": [635956, 5723604]}"},"locales": [{"culture": "fr", "title": "Mont Pourri"}]}' \
+    -d '{"waypoint_type": "summit", "elevation": 3779, "geometry": {"geom": "{\"type\": \"Point\", \"coordinates\": [635956, 5723604]}"},"locales": [{"lang": "fr", "title": "Mont Pourri"}]}' \
     http://localhost:6543/waypoints
 
 Updating a waypoint:
 
     curl -X PUT -v \
     -H "Content-Type: application/json" \
-    -d '{"message": "Comment about change", "document": {"elevation": 4633, "maps_info": null, "version": 1, "document_id": 1, "waypoint_type": "summit", "locales": [{"culture": "fr", "version": 1, "title": "Mont Rose", "access": null, "description": null}]}}' \
+    -d '{"message": "Comment about change", "document": {"elevation": 4633, "maps_info": null, "version": 1, "document_id": 1, "waypoint_type": "summit", "locales": [{"lang": "fr", "version": 1, "title": "Mont Rose", "access": null, "description": null}]}}' \
     http://localhost:6543/waypoints/1
 
 

--- a/c2corg_api/models/README.md
+++ b/c2corg_api/models/README.md
@@ -21,9 +21,9 @@ current version).
 For the versioning there are two more classes: `HistoryMetaData` and `DocumentVersion`.
 `HistoryMetaData` contains a change comment and the date. `DocumentVersion`
 is the list of actual versions of a document for a language. A *document version*
-for a language/culture references an entry in `ArchiveDocument`,
+for a language/lang references an entry in `ArchiveDocument`,
 `ArchiveDocumentLocale`, `ArchiveDocumentGeometry` and `HistoryMetaData`.
-It has the following fields: `document_id`, `culture`, `document_archive_id`,
+It has the following fields: `document_id`, `lang`, `document_archive_id`,
 `document_locales_archive_id`, `document_geometry_archive_id` and
 `history_metadata_id`.
 

--- a/c2corg_api/models/area_association.py
+++ b/c2corg_api/models/area_association.py
@@ -126,7 +126,7 @@ def get_areas(document, lang):
         options(load_only(
             Area.document_id, Area.area_type, Area.version)). \
         options(joinedload(Area.locales).load_only(
-            DocumentLocale.culture, DocumentLocale.title,
+            DocumentLocale.lang, DocumentLocale.title,
             DocumentLocale.version)). \
         filter(
             AreaAssociation.document_id == document.document_id

--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -91,7 +91,7 @@ def get_associations(document, lang):
                 Waypoint.waypoint_type, Waypoint.document_id,
                 Waypoint.elevation, Waypoint.version)). \
             options(joinedload(Waypoint.locales).load_only(
-                WaypointLocale.culture, WaypointLocale.title,
+                WaypointLocale.lang, WaypointLocale.title,
                 WaypointLocale.version))
 
     parent_waypoints = limit_waypoint_fields(
@@ -113,7 +113,7 @@ def get_associations(document, lang):
                 Route.document_id, Route.activities, Route.elevation_min,
                 Route.elevation_max, Route.version)). \
             options(joinedload(Waypoint.locales).load_only(
-                RouteLocale.culture, RouteLocale.title, RouteLocale.version))
+                RouteLocale.lang, RouteLocale.title, RouteLocale.version))
 
     parent_routes = limit_route_fields(
         DBSession.query(Route).

--- a/c2corg_api/models/document_history.py
+++ b/c2corg_api/models/document_history.py
@@ -38,8 +38,8 @@ class DocumentVersion(Base):
         Document, primaryjoin=document_id == Document.document_id,
         backref=backref('versions', viewonly=True))
 
-    culture = Column(
-        String(2), ForeignKey(schema + '.cultures.culture'),
+    lang = Column(
+        String(2), ForeignKey(schema + '.langs.lang'),
         nullable=False)
 
     document_archive_id = Column(

--- a/c2corg_api/models/schema_utils.py
+++ b/c2corg_api/models/schema_utils.py
@@ -1,5 +1,5 @@
 default_fields_doc = ['document_id', 'version', 'waypoint_type']
-default_fields_locale = ['version', 'culture']
+default_fields_locale = ['version', 'lang']
 default_fields_geometry = ['version']
 
 

--- a/c2corg_api/models/topo_map.py
+++ b/c2corg_api/models/topo_map.py
@@ -106,7 +106,7 @@ def get_maps(document, lang):
             TopoMap.document_id, TopoMap.editor, TopoMap.code,
             TopoMap.version)). \
         options(joinedload(TopoMap.locales).load_only(
-            DocumentLocale.culture, DocumentLocale.title,
+            DocumentLocale.lang, DocumentLocale.title,
             DocumentLocale.version)). \
         filter(
             DocumentGeometry.geom.intersects(

--- a/c2corg_api/scripts/es/fill_index.py
+++ b/c2corg_api/scripts/es/fill_index.py
@@ -56,12 +56,12 @@ def fill_index(db_session):
     q = DBSession.query(
             DocumentLocale.document_id, DocumentLocale.title,
             DocumentLocale.summary, DocumentLocale.description,
-            DocumentLocale.culture, DocumentLocale.type,
+            DocumentLocale.lang, DocumentLocale.type,
             RouteLocale.__table__.c.title_prefix). \
         outerjoin(
             RouteLocale.__table__,
             DocumentLocale.id == RouteLocale.__table__.c.id).\
-        order_by(DocumentLocale.document_id, DocumentLocale.culture)
+        order_by(DocumentLocale.document_id, DocumentLocale.lang)
 
     def progress(count, total_count):
         if status['last_progress_update'] is None or \
@@ -75,7 +75,7 @@ def fill_index(db_session):
     batch = ElasticBatch(client, batch_size)
     count = 0
     with batch:
-        for document_id, title, summary, description, culture, type, \
+        for document_id, title, summary, description, lang, type, \
                 title_prefix in q:
             if search_document is not None and document_id != last_id:
                 batch.add(search_document)
@@ -90,10 +90,10 @@ def fill_index(db_session):
                     'doc_type': type
                 }
 
-            search_document['title_' + culture] = get_title(
+            search_document['title_' + lang] = get_title(
                 title, title_prefix)
-            search_document['summary_' + culture] = strip_bbcodes(summary)
-            search_document['description_' + culture] = \
+            search_document['summary_' + lang] = strip_bbcodes(summary)
+            search_document['description_' + lang] = \
                 strip_bbcodes(description)
 
             last_id = document_id

--- a/c2corg_api/scripts/initializedb.py
+++ b/c2corg_api/scripts/initializedb.py
@@ -12,7 +12,7 @@ from pyramid.paster import (
 from pyramid.scripts.common import parse_vars
 
 from c2corg_api.models import *  # noqa
-from c2corg_common.attributes import default_cultures
+from c2corg_common.attributes import default_langs
 
 
 def usage(argv):
@@ -40,5 +40,5 @@ def setup_db(engine, session):
     with transaction.manager:
         # add default languages
         session.add_all([
-            document.Culture(culture=lang) for lang in default_cultures
+            document.Lang(lang=lang) for lang in default_langs
         ])

--- a/c2corg_api/scripts/migration/documents/area.py
+++ b/c2corg_api/scripts/migration/documents/area.py
@@ -71,7 +71,7 @@ class MigrateAreas(MigrateDocuments):
             id=document_in.document_i18n_archive_id,
             type=DOCUMENT_TYPE,
             version=version,
-            culture=document_in.culture,
+            lang=document_in.culture,
             title=document_in.name,
             description=description,
             summary=summary

--- a/c2corg_api/scripts/migration/documents/associations.py
+++ b/c2corg_api/scripts/migration/documents/associations.py
@@ -112,14 +112,14 @@ class MigrateAssociations(MigrateBase):
     def _set_route_locale_title_prefix(self):
         """Set the `title_prefix` field for all route locales that have a
         main waypoint. First set the field for route locales, where there is
-        a locale of the main waypoint in the same culture. Then with a 2nd
+        a locale of the main waypoint in the same lang. Then with a 2nd
         query set the remaining rows by selecting the "best" locale of the main
         waypoint.
         """
         with transaction.manager:
-            print('Set title prefix for route locales (same culture)')
+            print('Set title prefix for route locales (same lang)')
             self.session_target.execute(SQL_SET_TITLE_PREFIX_SAME_CULTURE)
-            print('Set title prefix for route locales (other culture)')
+            print('Set title prefix for route locales (other lang)')
             self.session_target.execute(SQL_SET_TITLE_PREFIX_OTHER_CULTURE)
             zope.sqlalchemy.mark_changed(self.session_target)
         print('Done')
@@ -156,7 +156,7 @@ with v as (select rl.id, l2.title
     on rl.id = l1.id
   join guidebook.routes r on l1.document_id = r.document_id
   join guidebook.documents_locales l2
-    on r.main_waypoint_id = l2.document_id and l2.culture = l1.culture)
+    on r.main_waypoint_id = l2.document_id and l2.lang = l1.lang)
 update guidebook.routes_locales l
   set title_prefix = v.title
 from v
@@ -168,12 +168,12 @@ with v as (select t.id, t.title
   from (select rl.id, l2.title, dense_rank() over(
     partition by rl.id
     order by
-      l2.culture != 'fr',
-      l2.culture != 'en',
-      l2.culture != 'it',
-      l2.culture != 'de',
-      l2.culture != 'es',
-      l2.culture != 'ca'
+      l2.lang != 'fr',
+      l2.lang != 'en',
+      l2.lang != 'it',
+      l2.lang != 'de',
+      l2.lang != 'es',
+      l2.lang != 'ca'
     ) as rank
     from guidebook.routes_locales rl join guidebook.documents_locales l1
       on rl.id = l1.id and rl.title_prefix is null

--- a/c2corg_api/scripts/migration/documents/maps.py
+++ b/c2corg_api/scripts/migration/documents/maps.py
@@ -72,7 +72,7 @@ class MigrateMaps(MigrateDocuments):
             id=document_in.document_i18n_archive_id,
             type=DOCUMENT_TYPE,
             version=version,
-            culture=document_in.culture,
+            lang=document_in.culture,
             title=document_in.name,
             description=description,
             summary=summary

--- a/c2corg_api/scripts/migration/documents/routes.py
+++ b/c2corg_api/scripts/migration/documents/routes.py
@@ -186,7 +186,7 @@ class MigrateRoutes(MigrateDocuments):
             id=document_in.document_i18n_archive_id,
             type=ROUTE_TYPE,
             version=version,
-            culture=document_in.culture,
+            lang=document_in.culture,
             title=document_in.name,
             description=description,
             summary=summary,

--- a/c2corg_api/scripts/migration/documents/versions.py
+++ b/c2corg_api/scripts/migration/documents/versions.py
@@ -77,7 +77,7 @@ class MigrateVersions(MigrateBase):
         return dict(
             id=row.documents_versions_id,
             document_id=row.document_id,
-            culture=row.culture,
+            lang=row.culture,
             document_archive_id=row.document_archive_id,
             document_locales_archive_id=row.document_i18n_archive_id,
             document_geometry_archive_id=row.document_archive_id,

--- a/c2corg_api/scripts/migration/documents/waypoints/huts.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/huts.py
@@ -76,7 +76,7 @@ class MigrateHuts(MigrateWaypoints):
             id=document_in.document_i18n_archive_id,
             type=WAYPOINT_TYPE,
             version=version,
-            culture=document_in.culture,
+            lang=document_in.culture,
             title=document_in.name,
             description=description,
             summary=summary,

--- a/c2corg_api/scripts/migration/documents/waypoints/parking.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/parking.py
@@ -69,7 +69,7 @@ class MigrateParkings(MigrateWaypoints):
             id=document_in.document_i18n_archive_id,
             type=WAYPOINT_TYPE,
             version=version,
-            culture=document_in.culture,
+            lang=document_in.culture,
             title=document_in.name,
             description=self.merge_text(
                 description, document_in.accommodation),

--- a/c2corg_api/scripts/migration/documents/waypoints/products.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/products.py
@@ -60,7 +60,7 @@ class MigrateProducts(MigrateWaypoints):
             id=document_in.document_i18n_archive_id,
             type=WAYPOINT_TYPE,
             version=version,
-            culture=document_in.culture,
+            lang=document_in.culture,
             title=document_in.name,
             description=description,
             summary=summary,

--- a/c2corg_api/scripts/migration/documents/waypoints/sites.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/sites.py
@@ -91,7 +91,7 @@ class MigrateSites(MigrateWaypoints):
             id=document_in.document_i18n_archive_id,
             type=WAYPOINT_TYPE,
             version=version,
-            culture=document_in.culture,
+            lang=document_in.culture,
             title=document_in.name,
             description=self.get_description(description, document_in),
             summary=summary,
@@ -154,8 +154,8 @@ class MigrateSites(MigrateWaypoints):
             section += text
             sections.append(section)
 
-    def translate(self, field, culture):
-        return MigrateSites.translations[field][culture]
+    def translate(self, field, lang):
+        return MigrateSites.translations[field][lang]
 
     translations = {
         'way_back': {

--- a/c2corg_api/scripts/migration/documents/waypoints/summit.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/summit.py
@@ -55,7 +55,7 @@ class MigrateSummits(MigrateWaypoints):
             id=document_in.document_i18n_archive_id,
             type=WAYPOINT_TYPE,
             version=version,
-            culture=document_in.culture,
+            lang=document_in.culture,
             title=document_in.name,
             description=description,
             summary=summary

--- a/c2corg_api/search/sync.py
+++ b/c2corg_api/search/sync.py
@@ -48,15 +48,15 @@ def sync_search_index(document):
 
     has_title_prefix = isinstance(document, Route)
     for locale in document.locales:
-        culture = locale.culture
+        lang = locale.lang
 
         # set the title prefix (name of the main waypoint) for routes
         title_prefix = locale.title_prefix if has_title_prefix else None
         title = get_title(locale.title, title_prefix)
 
-        doc['title_' + culture] = title
-        doc['summary_' + culture] = strip_bbcodes(locale.summary)
-        doc['description_' + culture] = strip_bbcodes(locale.description)
+        doc['title_' + lang] = title
+        doc['summary_' + lang] = strip_bbcodes(locale.summary)
+        doc['description_' + lang] = strip_bbcodes(locale.description)
 
     def sync_operation():
         client = elasticsearch_config['client']

--- a/c2corg_api/tests/models/test_area.py
+++ b/c2corg_api/tests/models/test_area.py
@@ -11,9 +11,9 @@ class TestArea(BaseTestCase):
             document_id=1, area_type='range',
             locales=[
                 DocumentLocale(
-                    id=2, culture='en', title='Chartreuse', summary='...'),
+                    id=2, lang='en', title='Chartreuse', summary='...'),
                 DocumentLocale(
-                    id=3, culture='fr', title='Chartreuse', summary='...'),
+                    id=3, lang='fr', title='Chartreuse', summary='...'),
             ]
         )
 
@@ -30,5 +30,5 @@ class TestArea(BaseTestCase):
         locale_archive = archive_locals[0]
         self.assertIsNot(locale_archive, locale)
         self.assertIsNone(locale_archive.id)
-        self.assertEqual(locale_archive.culture, locale.culture)
+        self.assertEqual(locale_archive.lang, locale.lang)
         self.assertEqual(locale_archive.title, locale.title)

--- a/c2corg_api/tests/models/test_image.py
+++ b/c2corg_api/tests/models/test_image.py
@@ -11,9 +11,9 @@ class TestImage(BaseTestCase):
             document_id=1, activities='skitouring', height=1200,
             locales=[
                 DocumentLocale(
-                    id=2, culture='en', title='A', description='abc'),
+                    id=2, lang='en', title='A', description='abc'),
                 DocumentLocale(
-                    id=3, culture='fr', title='B', description='bcd'),
+                    id=3, lang='fr', title='B', description='bcd'),
             ]
         )
 
@@ -32,6 +32,6 @@ class TestImage(BaseTestCase):
         locale_archive = archive_locals[0]
         self.assertIsNot(locale_archive, locale)
         self.assertIsNone(locale_archive.id)
-        self.assertEqual(locale_archive.culture, locale.culture)
+        self.assertEqual(locale_archive.lang, locale.lang)
         self.assertEqual(locale_archive.title, locale.title)
         self.assertEqual(locale_archive.description, locale.description)

--- a/c2corg_api/tests/models/test_map.py
+++ b/c2corg_api/tests/models/test_map.py
@@ -12,9 +12,9 @@ class TestMap(BaseTestCase):
             document_id=1, editor='ign', scale='20000', code='3431OT',
             locales=[
                 DocumentLocale(
-                    id=2, culture='en', title='Lac d\'Annecy'),
+                    id=2, lang='en', title='Lac d\'Annecy'),
                 DocumentLocale(
-                    id=3, culture='fr', title='Lac d\'Annecy'),
+                    id=3, lang='fr', title='Lac d\'Annecy'),
             ]
         )
 
@@ -34,32 +34,32 @@ class TestMap(BaseTestCase):
         locale_archive = archive_locals[0]
         self.assertIsNot(locale_archive, locale)
         self.assertIsNone(locale_archive.id)
-        self.assertEqual(locale_archive.culture, locale.culture)
+        self.assertEqual(locale_archive.lang, locale.lang)
         self.assertEqual(locale_archive.title, locale.title)
 
     def test_get_maps(self):
         map1 = TopoMap(
             locales=[
-                DocumentLocale(culture='en', title='Passo del Maloja'),
-                DocumentLocale(culture='fr', title='Passo del Maloja')
+                DocumentLocale(lang='en', title='Passo del Maloja'),
+                DocumentLocale(lang='fr', title='Passo del Maloja')
             ],
             geometry=DocumentGeometry(geom='SRID=3857;POLYGON((1060345.67641127 5869598.161661,1161884.8271513 5866294.47946546,1159243.3608776 5796747.98963817,1058506.68785187 5800000.03655724,1060345.67641127 5869598.161661))')  # noqa
         )
         map2 = TopoMap(
             locales=[
-                DocumentLocale(culture='fr', title='Monte Disgrazia')
+                DocumentLocale(lang='fr', title='Monte Disgrazia')
             ],
             geometry=DocumentGeometry(geom='SRID=3857;POLYGON((1059422.5474971 5834730.45170096,1110000.12573506 5833238.36363707,1108884.30979916 5798519.62445622,1058506.68785187 5800000.03655724,1059422.5474971 5834730.45170096))')  # noqa
         )
         map3 = TopoMap(
             locales=[
-                DocumentLocale(culture='fr', title='Sciora')
+                DocumentLocale(lang='fr', title='Sciora')
             ],
             geometry=DocumentGeometry(geom='SRID=3857;POLYGON((1059422.5474971 5834730.45170096,1084713.47958582 5834021.11961652,1084204.54539729 5816641.60293193,1058963.71520182 5817348.14989301,1059422.5474971 5834730.45170096))')  # noqa
         )
         map4 = TopoMap(
             locales=[
-                DocumentLocale(culture='fr', title='...')
+                DocumentLocale(lang='fr', title='...')
             ],
             geometry=DocumentGeometry(geom='SRID=3857;POLYGON((753678.422528324 6084684.82967302,857818.351438369 6084952.58494753,857577.289072432 6013614.93425228,754282.556732048 6013351.52692378,753678.422528324 6084684.82967302))')  # noqa
         )

--- a/c2corg_api/tests/models/test_route.py
+++ b/c2corg_api/tests/models/test_route.py
@@ -11,10 +11,10 @@ class TestRoute(BaseTestCase):
             elevation_max=1200,
             locales=[
                 RouteLocale(
-                    id=2, culture='en', title='A', description='abc',
+                    id=2, lang='en', title='A', description='abc',
                     gear='...'),
                 RouteLocale(
-                    id=3, culture='fr', title='B', description='bcd',
+                    id=3, lang='fr', title='B', description='bcd',
                     gear='...'),
             ]
         )
@@ -34,7 +34,7 @@ class TestRoute(BaseTestCase):
         locale_archive = archive_locals[0]
         self.assertIsNot(locale_archive, locale)
         self.assertIsNone(locale_archive.id)
-        self.assertEqual(locale_archive.culture, locale.culture)
+        self.assertEqual(locale_archive.lang, locale.lang)
         self.assertEqual(locale_archive.title, locale.title)
         self.assertEqual(locale_archive.description, locale.description)
         self.assertEqual(locale_archive.gear, locale.gear)

--- a/c2corg_api/tests/models/test_utils.py
+++ b/c2corg_api/tests/models/test_utils.py
@@ -23,7 +23,7 @@ class TestUtils(unittest.TestCase):
         locales_node = self.get_child_node(schema, 'locales')
         locale_node = locales_node.children[0]
         self.assertHasField(locale_node, 'version')
-        self.assertHasField(locale_node, 'culture')
+        self.assertHasField(locale_node, 'lang')
         self.assertHasField(locale_node, 'title')
         self.assertHasNotField(locale_node, 'access_period')
 

--- a/c2corg_api/tests/models/test_waypoint.py
+++ b/c2corg_api/tests/models/test_waypoint.py
@@ -4,7 +4,7 @@ from geoalchemy2.shape import from_shape
 
 from c2corg_api.models.waypoint import Waypoint, WaypointLocale
 from c2corg_api.models.document import (
-    UpdateType, DocumentGeometry, set_available_cultures)
+    UpdateType, DocumentGeometry, set_available_langs)
 from c2corg_api.tests import BaseTestCase
 
 
@@ -15,7 +15,7 @@ class TestWaypoint(BaseTestCase):
             waypoint_type='summit', elevation=2203,
             locales=[
                 WaypointLocale(
-                    culture='en', title='A', description='abc')
+                    lang='en', title='A', description='abc')
             ],
             geometry=DocumentGeometry(
                 geom=from_shape(Point(1, 1), srid=3857))
@@ -35,9 +35,9 @@ class TestWaypoint(BaseTestCase):
             document_id=1, waypoint_type='summit', elevation=2203,
             locales=[
                 WaypointLocale(
-                    id=2, culture='en', title='A', description='abc'),
+                    id=2, lang='en', title='A', description='abc'),
                 WaypointLocale(
-                    id=3, culture='fr', title='B', description='bcd'),
+                    id=3, lang='fr', title='B', description='bcd'),
             ],
             geometry=DocumentGeometry(
                 document_id=1, geom=from_shape(Point(1, 1), srid=3857))
@@ -58,7 +58,7 @@ class TestWaypoint(BaseTestCase):
         locale_archive = archive_locals[0]
         self.assertIsNot(locale_archive, locale)
         self.assertIsNone(locale_archive.id)
-        self.assertEqual(locale_archive.culture, locale.culture)
+        self.assertEqual(locale_archive.lang, locale.lang)
         self.assertEqual(locale_archive.title, locale.title)
         self.assertEqual(locale_archive.description, locale.description)
 
@@ -73,7 +73,7 @@ class TestWaypoint(BaseTestCase):
             document_id=1, waypoint_type='summit', elevation=2203,
             locales=[
                 WaypointLocale(
-                    id=2, culture='en', title='A', description='abc')
+                    id=2, lang='en', title='A', description='abc')
             ]
         )
         self.session.add(waypoint)
@@ -98,7 +98,7 @@ class TestWaypoint(BaseTestCase):
             document_id=1, waypoint_type='summit', elevation=2203,
             locales=[
                 WaypointLocale(
-                    id=2, culture='en', title='A', description='abc')
+                    id=2, lang='en', title='A', description='abc')
             ]
         )
 
@@ -197,10 +197,10 @@ class TestWaypoint(BaseTestCase):
             version=123,
             locales=[
                 WaypointLocale(
-                    id=2, culture='en', title='A', description='abc',
+                    id=2, lang='en', title='A', description='abc',
                     version=345),
                 WaypointLocale(
-                    id=3, culture='fr', title='B', description='bcd',
+                    id=3, lang='fr', title='B', description='bcd',
                     version=678),
             ],
             geometry=DocumentGeometry(
@@ -212,10 +212,10 @@ class TestWaypoint(BaseTestCase):
             version=123,
             locales=[
                 WaypointLocale(
-                    id=2, culture='en', title='C', description='abc',
+                    id=2, lang='en', title='C', description='abc',
                     version=345),
                 WaypointLocale(
-                    culture='es', title='D', description='efg'),
+                    lang='es', title='D', description='efg'),
             ],
             geometry=DocumentGeometry(geom='SRID=3857;POINT(3 4)')
         )
@@ -286,7 +286,7 @@ class TestWaypoint(BaseTestCase):
         versions = waypoint.get_versions()
 
         waypoint.locales.append(WaypointLocale(
-            culture='es', title='A', description='abc'))
+            lang='es', title='A', description='abc'))
         self.session.merge(waypoint)
         self.session.flush()
 
@@ -304,7 +304,7 @@ class TestWaypoint(BaseTestCase):
         waypoint.elevation = 1234
         waypoint.get_locale('en').description = 'abcd'
         waypoint.locales.append(WaypointLocale(
-            culture='es', title='A', description='abc'))
+            lang='es', title='A', description='abc'))
 
         self.session.merge(waypoint)
         self.session.flush()
@@ -335,25 +335,25 @@ class TestWaypoint(BaseTestCase):
         self.session.add(waypoint)
         self.session.flush()
 
-    def test_set_available_cultures(self):
+    def test_set_available_langs(self):
         waypoint = self._get_waypoint()
         waypoint.geometry = DocumentGeometry(
             geom='SRID=3857;POINT(635956.075332665 5723604.677994)')
         self.session.add(waypoint)
         self.session.flush()
 
-        set_available_cultures([waypoint])
-        self.assertEqual(waypoint.available_cultures, ['en', 'fr'])
+        set_available_langs([waypoint])
+        self.assertEqual(waypoint.available_langs, ['en', 'fr'])
 
     def _get_waypoint(self):
         return Waypoint(
             waypoint_type='summit', elevation=2203,
             locales=[
                 WaypointLocale(
-                    culture='en', title='A', description='abc',
+                    lang='en', title='A', description='abc',
                     access='y'),
                 WaypointLocale(
-                    culture='fr', title='B', description='bcd',
+                    lang='fr', title='B', description='bcd',
                     access='y')
             ],
             geometry=DocumentGeometry(

--- a/c2corg_api/tests/scripts/es/test_fill_index.py
+++ b/c2corg_api/tests/scripts/es/test_fill_index.py
@@ -18,11 +18,11 @@ class FillIndexTest(BaseTestCase):
                 geom='SRID=3857;POINT(635956 5723604)'),
             locales=[
                 WaypointLocale(
-                    culture='fr', title='Mont Granier',
+                    lang='fr', title='Mont Granier',
                     description='...',
                     summary='Le Mont [b]Granier[/b]'),
                 WaypointLocale(
-                    culture='en', title='Mont Granier',
+                    lang='en', title='Mont Granier',
                     description='...',
                     summary='The Mont Granier')
             ]))
@@ -33,7 +33,7 @@ class FillIndexTest(BaseTestCase):
                 geom='SRID=3857;POINT(635956 5723604)'),
             locales=[
                 WaypointLocale(
-                    culture='en', title='Mont Blanc',
+                    lang='en', title='Mont Blanc',
                     description='...',
                     summary='The heighest point in Europe')
             ]))
@@ -43,7 +43,7 @@ class FillIndexTest(BaseTestCase):
             height_diff_up=800, height_diff_down=800, durations='1',
             locales=[
                 RouteLocale(
-                    culture='en', title='Face N',
+                    lang='en', title='Face N',
                     description='...', gear='paraglider',
                     title_prefix='Mont Blanc'
                 )

--- a/c2corg_api/tests/search/test_search.py
+++ b/c2corg_api/tests/search/test_search.py
@@ -16,7 +16,7 @@ class SearchTest(BaseTestCase):
                 geom='SRID=3857;POINT(635956 5723604)'),
             locales=[
                 WaypointLocale(
-                    culture='fr', title='Mont Granier',
+                    lang='fr', title='Mont Granier',
                     description='...',
                     summary='Le Mont Granier')
             ]))
@@ -27,7 +27,7 @@ class SearchTest(BaseTestCase):
                 geom='SRID=3857;POINT(635956 5723604)'),
             locales=[
                 WaypointLocale(
-                    culture='en', title='Mont Blanc',
+                    lang='en', title='Mont Blanc',
                     description='...',
                     summary='The heighest point in Europe')
             ]))

--- a/c2corg_api/tests/search/test_sync.py
+++ b/c2corg_api/tests/search/test_sync.py
@@ -21,7 +21,7 @@ class SyncTest(BaseTestCase):
                 geom='SRID=3857;POINT(635956 5723604)'),
             locales=[
                 WaypointLocale(
-                    culture='fr', title='Mont Granier',
+                    lang='fr', title='Mont Granier',
                     description='...',
                     summary='Le Mont [b]Granier[/b]')
             ])
@@ -46,7 +46,7 @@ class SyncTest(BaseTestCase):
                 geom='SRID=3857;POINT(635956 5723604)'),
             locales=[
                 WaypointLocale(
-                    culture='fr', title='Mont Granier',
+                    lang='fr', title='Mont Granier',
                     description='...',
                     summary='Le Mont Granier')
             ])
@@ -64,11 +64,11 @@ class SyncTest(BaseTestCase):
                 geom='SRID=3857;POINT(635956 5723604)'),
             locales=[
                 WaypointLocale(
-                    culture='fr', title='Mont Granier',
+                    lang='fr', title='Mont Granier',
                     description='...',
                     summary='Le Mont Granier'),
                 WaypointLocale(
-                    culture='en', title='Mont Granier',
+                    lang='en', title='Mont Granier',
                     description='...',
                     summary='The Mont Granier')
             ])

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -85,8 +85,8 @@ class BaseDocumentTestRest(BaseTestRest):
 
         if params is None:
             doc = documents[0]
-            available_cultures = doc.get('available_cultures')
-            self.assertEqual(sorted(available_cultures), ['en', 'fr'])
+            available_langs = doc.get('available_langs')
+            self.assertEqual(sorted(available_langs), ['en', 'fr'])
 
         if limit is None:
             nb_docs = self.session.query(self._model).count()
@@ -108,7 +108,7 @@ class BaseDocumentTestRest(BaseTestRest):
         locales = doc.get('locales')
         self.assertEqual(len(locales), 1)
         locale = locales[0]
-        self.assertEqual('fr', locale['culture'])
+        self.assertEqual('fr', locale['lang'])
 
         return body
 
@@ -135,11 +135,11 @@ class BaseDocumentTestRest(BaseTestRest):
         locale_en = locales[0]
         self.assertNotIn('id', locale_en)
         self.assertIsNotNone(locale_en.get('version'))
-        self.assertEqual(locale_en.get('culture'), self.locale_en.culture)
+        self.assertEqual(locale_en.get('lang'), self.locale_en.lang)
         self.assertEqual(locale_en.get('title'), self.locale_en.title)
 
-        available_cultures = body.get('available_cultures')
-        self.assertEqual(available_cultures, ['en', 'fr'])
+        available_langs = body.get('available_langs')
+        self.assertEqual(available_langs, ['en', 'fr'])
         return body
 
     def get_version(self, reference, reference_version):
@@ -171,7 +171,7 @@ class BaseDocumentTestRest(BaseTestRest):
         locales = body.get('locales')
         self.assertEqual(len(locales), 1)
         locale_en = locales[0]
-        self.assertEqual(locale_en.get('culture'), self.locale_en.culture)
+        self.assertEqual(locale_en.get('lang'), self.locale_en.lang)
 
     def get_new_lang(self, reference):
         response = self.app.get(self._prefix + '/' +
@@ -280,7 +280,7 @@ class BaseDocumentTestRest(BaseTestRest):
         errors = body.get('errors')
         self.assertEqual(len(errors), 1)
         self.assertEqual(
-            errors[0].get('description'), 'culture "en" is given twice')
+            errors[0].get('description'), 'lang "en" is given twice')
         self.assertEqual(errors[0].get('name'), 'locales')
         return body
 
@@ -349,8 +349,8 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(len(versions), 1)
         version = versions[0]
 
-        culture = body.get('locales')[0].get('culture')
-        self.assertEqual(version.culture, culture)
+        lang = body.get('locales')[0].get('lang')
+        self.assertEqual(version.lang, lang)
 
         meta_data = version.history_metadata
         self.assertEqual(meta_data.comment, 'creation')
@@ -366,7 +366,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(
             archive_locale.version, waypoint_locale_en.version)
         self.assertEqual(archive_locale.document_id, document_id)
-        self.assertEqual(archive_locale.culture, culture)
+        self.assertEqual(archive_locale.lang, lang)
 
         # check updates to the search index
         search_doc = SearchDocument.get(
@@ -505,10 +505,10 @@ class BaseDocumentTestRest(BaseTestRest):
         versions = document.versions
         self.assertEqual(len(versions), 4)
 
-        # version with culture 'en'
+        # version with lang 'en'
         version_en = versions[2]
 
-        self.assertEqual(version_en.culture, 'en')
+        self.assertEqual(version_en.lang, 'en')
 
         meta_data_en = version_en.history_metadata
         self.assertEqual(meta_data_en.comment, 'Update')
@@ -522,12 +522,12 @@ class BaseDocumentTestRest(BaseTestRest):
         archive_locale = version_en.document_locales_archive
         self.assertEqual(archive_locale.document_id, document_id)
         self.assertEqual(archive_locale.version, locale_en.version)
-        self.assertEqual(archive_locale.culture, 'en')
+        self.assertEqual(archive_locale.lang, 'en')
 
-        # version with culture 'fr'
+        # version with lang 'fr'
         version_fr = versions[3]
 
-        self.assertEqual(version_fr.culture, 'fr')
+        self.assertEqual(version_fr.lang, 'fr')
 
         meta_data_fr = version_fr.history_metadata
         self.assertIs(meta_data_en, meta_data_fr)
@@ -539,7 +539,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(archive_locale_fr.document_id, document_id)
         self.assertEqual(
             archive_locale_fr.version, self.locale_fr.version)
-        self.assertEqual(archive_locale_fr.culture, 'fr')
+        self.assertEqual(archive_locale_fr.lang, 'fr')
 
         # check updates to the search index
         search_doc = SearchDocument.get(
@@ -597,19 +597,19 @@ class BaseDocumentTestRest(BaseTestRest):
         versions = document.versions
         self.assertEqual(len(versions), 4)
 
-        # version with culture 'en'
+        # version with lang 'en'
         version_en = versions[2]
 
-        self.assertEqual(version_en.culture, 'en')
+        self.assertEqual(version_en.lang, 'en')
 
         meta_data_en = version_en.history_metadata
         self.assertEqual(meta_data_en.comment, 'Changing figures')
         self.assertIsNotNone(meta_data_en.written_at)
 
-        # version with culture 'fr'
+        # version with lang 'fr'
         version_fr = versions[3]
 
-        self.assertEqual(version_fr.culture, 'fr')
+        self.assertEqual(version_fr.lang, 'fr')
 
         meta_data_fr = version_fr.history_metadata
         self.assertIs(meta_data_en, meta_data_fr)
@@ -686,19 +686,19 @@ class BaseDocumentTestRest(BaseTestRest):
         versions = document.versions
         self.assertEqual(len(versions), 3)
 
-        # version with culture 'en'
+        # version with lang 'en'
         version_en = versions[2]
 
-        self.assertEqual(version_en.culture, 'en')
+        self.assertEqual(version_en.lang, 'en')
 
         meta_data_en = version_en.history_metadata
         self.assertEqual(meta_data_en.comment, 'Changing lang')
         self.assertIsNotNone(meta_data_en.written_at)
 
-        # version with culture 'fr'
+        # version with lang 'fr'
         version_fr = versions[1]
 
-        self.assertEqual(version_fr.culture, 'fr')
+        self.assertEqual(version_fr.lang, 'fr')
 
         meta_data_fr = version_fr.history_metadata
         self.assertIsNot(meta_data_en, meta_data_fr)
@@ -765,17 +765,17 @@ class BaseDocumentTestRest(BaseTestRest):
         versions = document.versions
         self.assertEqual(len(versions), 3)
 
-        # version with culture 'en'
+        # version with lang 'en'
         version_en = versions[0]
 
-        self.assertEqual(version_en.culture, 'en')
+        self.assertEqual(version_en.lang, 'en')
 
         meta_data_en = version_en.history_metadata
 
-        # version with culture 'fr'
+        # version with lang 'fr'
         version_fr = versions[1]
 
-        self.assertEqual(version_fr.culture, 'fr')
+        self.assertEqual(version_fr.lang, 'fr')
 
         meta_data_fr = version_fr.history_metadata
         self.assertIs(meta_data_en, meta_data_fr)
@@ -784,10 +784,10 @@ class BaseDocumentTestRest(BaseTestRest):
         archive_document_fr = version_fr.document_archive
         self.assertIs(archive_document_en, archive_document_fr)
 
-        # version with culture 'es'
+        # version with lang 'es'
         version_es = versions[2]
 
-        self.assertEqual(version_es.culture, 'es')
+        self.assertEqual(version_es.lang, 'es')
 
         meta_data_es = version_es.history_metadata
         self.assertIsNot(meta_data_en, meta_data_es)

--- a/c2corg_api/tests/views/test_area.py
+++ b/c2corg_api/tests/views/test_area.py
@@ -77,7 +77,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'geom': '{"type": "Point", "coordinates": [635956, 5723604]}'
             },
             'locales': [
-                {'culture': 'en'}
+                {'lang': 'en'}
             ]
         }
         body = self.post_missing_title(body_post, user='moderator')
@@ -95,7 +95,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'geom': '{"type": "Point", "coordinates": [635956, 5723604]}'
             },
             'locales': [
-                {'culture': 'en', 'title': 'Chartreuse'}
+                {'lang': 'en', 'title': 'Chartreuse'}
             ]
         }
         self.post_non_whitelisted_attribute(body, user='moderator')
@@ -111,7 +111,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'geom': '{"type":"Polygon","coordinates":[[[668518.249382151,5728802.39591739],[668518.249382151,5745465.66808356],[689156.247019149,5745465.66808356],[689156.247019149,5728802.39591739],[668518.249382151,5728802.39591739]]]}'  # noqa
             },
             'locales': [
-                {'culture': 'en', 'title': 'Chartreuse'}
+                {'lang': 'en', 'title': 'Chartreuse'}
             ]
         }
         body, doc = self.post_success(body, user='moderator')
@@ -123,7 +123,7 @@ class TestAreaRest(BaseDocumentTestRest):
         self.assertEqual(archive_map.area_type, 'range')
 
         archive_locale = version.document_locales_archive
-        self.assertEqual(archive_locale.culture, 'en')
+        self.assertEqual(archive_locale.lang, 'en')
         self.assertEqual(archive_locale.title, 'Chartreuse')
 
         archive_geometry = version.document_geometry_archive
@@ -145,7 +145,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'version': self.area1.version,
                 'area_type': 'range',
                 'locales': [
-                    {'culture': 'en', 'title': 'Chartreuse',
+                    {'lang': 'en', 'title': 'Chartreuse',
                      'version': self.locale_en.version}
                 ]
             }
@@ -159,7 +159,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'version': -9999,
                 'area_type': 'range',
                 'locales': [
-                    {'culture': 'en', 'title': 'Chartreuse',
+                    {'lang': 'en', 'title': 'Chartreuse',
                      'version': self.locale_en.version}
                 ]
             }
@@ -173,7 +173,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'version': self.area1.version,
                 'area_type': 'range',
                 'locales': [
-                    {'culture': 'en', 'title': 'Chartreuse',
+                    {'lang': 'en', 'title': 'Chartreuse',
                      'version': -9999}
                 ]
             }
@@ -187,7 +187,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'version': self.area1.version,
                 'area_type': 'range',
                 'locales': [
-                    {'culture': 'en', 'title': 'Chartreuse',
+                    {'lang': 'en', 'title': 'Chartreuse',
                      'version': self.locale_en.version}
                 ]
             }
@@ -209,7 +209,7 @@ class TestAreaRest(BaseDocumentTestRest):
                     'geom': '{"type":"Polygon","coordinates":[[[668519.249382151,5728802.39591739],[668518.249382151,5745465.66808356],[689156.247019149,5745465.66808356],[689156.247019149,5728802.39591739],[668519.249382151,5728802.39591739]]]}'  # noqa
                 },
                 'locales': [
-                    {'culture': 'en', 'title': 'New title',
+                    {'lang': 'en', 'title': 'New title',
                      'version': self.locale_en.version}
                 ]
             }
@@ -234,7 +234,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'version': self.area1.version,
                 'area_type': 'admin_limits',
                 'locales': [
-                    {'culture': 'en', 'title': 'New title',
+                    {'lang': 'en', 'title': 'New title',
                      'version': self.locale_en.version}
                 ]
             }
@@ -245,7 +245,7 @@ class TestAreaRest(BaseDocumentTestRest):
         locale_en = map1.get_locale('en')
         self.assertEquals(locale_en.title, 'New title')
 
-        # version with culture 'en'
+        # version with lang 'en'
         versions = map1.versions
         version_en = versions[2]
         archive_locale = version_en.document_locales_archive
@@ -259,7 +259,7 @@ class TestAreaRest(BaseDocumentTestRest):
         archive_geometry_en = version_en.document_geometry_archive
         self.assertEqual(archive_geometry_en.version, 1)
 
-        # version with culture 'fr'
+        # version with lang 'fr'
         version_fr = versions[3]
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Chartreuse')
@@ -276,14 +276,14 @@ class TestAreaRest(BaseDocumentTestRest):
                     'geom': '{"type":"Polygon","coordinates":[[[668519.249382151,5728802.39591739],[668518.249382151,5745465.66808356],[689156.247019149,5745465.66808356],[689156.247019149,5728802.39591739],[668519.249382151,5728802.39591739]]]}'  # noqa
                 },
                 'locales': [
-                    {'culture': 'en', 'title': 'New title',
+                    {'lang': 'en', 'title': 'New title',
                      'version': self.locale_en.version}
                 ]
             }
         }
         (body, map1) = self.put_success_all(body, self.area1, user='moderator')
 
-        # version with culture 'en'
+        # version with lang 'en'
         version_en = map1.versions[2]
 
         # geometry has been changed because the user is a moderator
@@ -306,7 +306,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'version': self.area1.version,
                 'area_type': 'admin_limits',
                 'locales': [
-                    {'culture': 'en', 'title': 'Chartreuse',
+                    {'lang': 'en', 'title': 'Chartreuse',
                      'version': self.locale_en.version}
                 ]
             }
@@ -332,7 +332,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'version': self.area1.version,
                 'area_type': 'range',
                 'locales': [
-                    {'culture': 'en', 'title': 'New title',
+                    {'lang': 'en', 'title': 'New title',
                      'version': self.locale_en.version}
                 ]
             }
@@ -361,7 +361,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'version': self.area1.version,
                 'area_type': 'range',
                 'locales': [
-                    {'culture': 'es', 'title': 'Chartreuse'}
+                    {'lang': 'es', 'title': 'Chartreuse'}
                 ]
             }
         }
@@ -382,8 +382,8 @@ class TestAreaRest(BaseDocumentTestRest):
     def _add_test_data(self):
         self.area1 = Area(area_type='range')
 
-        self.locale_en = DocumentLocale(culture='en', title='Chartreuse')
-        self.locale_fr = DocumentLocale(culture='fr', title='Chartreuse')
+        self.locale_en = DocumentLocale(lang='en', title='Chartreuse')
+        self.locale_fr = DocumentLocale(lang='fr', title='Chartreuse')
 
         self.area1.locales.append(self.locale_en)
         self.area1.locales.append(self.locale_fr)
@@ -404,9 +404,9 @@ class TestAreaRest(BaseDocumentTestRest):
         self.session.add(self.area3)
         self.area4 = Area(area_type='admin_limits')
         self.area4.locales.append(DocumentLocale(
-            culture='en', title='Isère'))
+            lang='en', title='Isère'))
         self.area4.locales.append(DocumentLocale(
-            culture='fr', title='Isère'))
+            lang='fr', title='Isère'))
         self.session.add(self.area4)
 
         self.waypoint1 = Waypoint(

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -68,7 +68,7 @@ class TestImageRest(BaseDocumentTestRest):
             'activities': 'skitouring',
             'height': 1200,
             'locales': [
-                {'culture': 'en'}
+                {'lang': 'en'}
             ]
         }
         body = self.post_missing_title(body_post)
@@ -81,7 +81,7 @@ class TestImageRest(BaseDocumentTestRest):
             'height': 750,
             'protected': True,
             'locales': [
-                {'culture': 'en', 'title': 'Some nice loop'}
+                {'lang': 'en', 'title': 'Some nice loop'}
             ]
         }
         self.post_non_whitelisted_attribute(body)
@@ -98,7 +98,7 @@ class TestImageRest(BaseDocumentTestRest):
                 'geom': '{"type": "Point", "coordinates": [635956, 5723604]}'
             },
             'locales': [
-                {'culture': 'en', 'title': 'Some nice loop'}
+                {'lang': 'en', 'title': 'Some nice loop'}
             ]
         }
         body, doc = self.post_success(body)
@@ -111,7 +111,7 @@ class TestImageRest(BaseDocumentTestRest):
         self.assertEqual(archive_image.height, 750)
 
         archive_locale = version.document_locales_archive
-        self.assertEqual(archive_locale.culture, 'en')
+        self.assertEqual(archive_locale.lang, 'en')
         self.assertEqual(archive_locale.title, 'Some nice loop')
 
         archive_geometry = version.document_geometry_archive
@@ -126,7 +126,7 @@ class TestImageRest(BaseDocumentTestRest):
                 'activities': 'paragliding',
                 'height': 1500,
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...',
                      'version': self.locale_en.version}
                 ]
@@ -142,7 +142,7 @@ class TestImageRest(BaseDocumentTestRest):
                 'activities': 'paragliding',
                 'height': 1500,
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...',
                      'version': self.locale_en.version}
                 ]
@@ -158,7 +158,7 @@ class TestImageRest(BaseDocumentTestRest):
                 'activities': 'paragliding',
                 'height': 1500,
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...',
                      'version': -9999}
                 ]
@@ -174,7 +174,7 @@ class TestImageRest(BaseDocumentTestRest):
                 'activities': 'paragliding',
                 'height': 1500,
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...',
                      'version': self.locale_en.version}
                 ]
@@ -198,7 +198,7 @@ class TestImageRest(BaseDocumentTestRest):
                     'geom': '{"type": "Point", "coordinates": [1, 2]}'
                 },
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': 'New description',
                      'version': self.locale_en.version}
                 ]
@@ -210,7 +210,7 @@ class TestImageRest(BaseDocumentTestRest):
         locale_en = image.get_locale('en')
         self.assertEquals(locale_en.description, 'New description')
 
-        # version with culture 'en'
+        # version with lang 'en'
         versions = image.versions
         version_en = versions[2]
         archive_locale = version_en.document_locales_archive
@@ -223,7 +223,7 @@ class TestImageRest(BaseDocumentTestRest):
         archive_geometry_en = version_en.document_geometry_archive
         self.assertEqual(archive_geometry_en.version, 2)
 
-        # version with culture 'fr'
+        # version with lang 'fr'
         version_fr = versions[3]
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Blanc du ciel')
@@ -237,7 +237,7 @@ class TestImageRest(BaseDocumentTestRest):
                 'activities': 'paragliding',
                 'height': 1500,
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...',
                      'version': self.locale_en.version}
                 ]
@@ -256,7 +256,7 @@ class TestImageRest(BaseDocumentTestRest):
                 'activities': 'paragliding',
                 'height': 2000,
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': 'New description',
                      'version': self.locale_en.version}
                 ]
@@ -278,7 +278,7 @@ class TestImageRest(BaseDocumentTestRest):
                 'activities': 'paragliding',
                 'height': 2000,
                 'locales': [
-                    {'culture': 'es', 'title': 'Mont Blanc del cielo',
+                    {'lang': 'es', 'title': 'Mont Blanc del cielo',
                      'description': '...'}
                 ]
             }
@@ -304,10 +304,10 @@ class TestImageRest(BaseDocumentTestRest):
             activities='paragliding', height=2000)
 
         self.locale_en = DocumentLocale(
-            culture='en', title='Mont Blanc from the air', description='...')
+            lang='en', title='Mont Blanc from the air', description='...')
 
         self.locale_fr = DocumentLocale(
-            culture='fr', title='Mont Blanc du ciel', description='...')
+            lang='fr', title='Mont Blanc du ciel', description='...')
 
         self.image.locales.append(self.locale_en)
         self.image.locales.append(self.locale_fr)
@@ -330,8 +330,8 @@ class TestImageRest(BaseDocumentTestRest):
         self.image4 = Image(
             activities='paragliding', height=2000)
         self.image4.locales.append(DocumentLocale(
-            culture='en', title='Mont Blanc from the air', description='...'))
+            lang='en', title='Mont Blanc from the air', description='...'))
         self.image4.locales.append(DocumentLocale(
-            culture='fr', title='Mont Blanc du ciel', description='...'))
+            lang='fr', title='Mont Blanc du ciel', description='...'))
         self.session.add(self.image4)
         self.session.flush()

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -120,7 +120,7 @@ class TestRouteRest(BaseDocumentTestRest):
                         '[[635956, 5723604], [635966, 5723644]]}'
             },
             'locales': [
-                {'culture': 'en', 'title': 'Some nice loop'}
+                {'lang': 'en', 'title': 'Some nice loop'}
             ]
         }
         body = self.post_error(body_post)
@@ -144,7 +144,7 @@ class TestRouteRest(BaseDocumentTestRest):
                         '[[635956, 5723604], [635966, 5723644]]}'
             },
             'locales': [
-                {'culture': 'en'}
+                {'lang': 'en'}
             ]
         }
         body = self.post_missing_title(body_post)
@@ -167,7 +167,7 @@ class TestRouteRest(BaseDocumentTestRest):
                         '[[635956, 5723604], [635966, 5723644]]}'
             },
             'locales': [
-                {'culture': 'en', 'title': 'Some nice loop',
+                {'lang': 'en', 'title': 'Some nice loop',
                  'gear': 'shoes'}
             ]
         }
@@ -191,7 +191,7 @@ class TestRouteRest(BaseDocumentTestRest):
                         '[[635956, 5723604], [635966, 5723644]]}'
             },
             'locales': [
-                {'culture': 'en', 'title': 'Some nice loop',
+                {'lang': 'en', 'title': 'Some nice loop',
                  'gear': 'shoes'}
             ]
         }
@@ -205,7 +205,7 @@ class TestRouteRest(BaseDocumentTestRest):
         self.assertEqual(archive_route.elevation_max, 1500)
 
         archive_locale = version.document_locales_archive
-        self.assertEqual(archive_locale.culture, 'en')
+        self.assertEqual(archive_locale.lang, 'en')
         self.assertEqual(archive_locale.title, 'Some nice loop')
 
         archive_geometry = version.document_geometry_archive
@@ -233,7 +233,7 @@ class TestRouteRest(BaseDocumentTestRest):
                 'height_diff_down': 800,
                 'durations': ['1'],
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'none',
                      'version': self.locale_en.version}
                 ]
@@ -253,7 +253,7 @@ class TestRouteRest(BaseDocumentTestRest):
                 'height_diff_down': 800,
                 'durations': ['1'],
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'none',
                      'version': self.locale_en.version}
                 ]
@@ -273,7 +273,7 @@ class TestRouteRest(BaseDocumentTestRest):
                 'height_diff_down': 800,
                 'durations': ['1'],
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'none',
                      'version': -9999}
                 ]
@@ -293,7 +293,7 @@ class TestRouteRest(BaseDocumentTestRest):
                 'height_diff_down': 800,
                 'durations': ['1'],
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'none',
                      'version': self.locale_en.version}
                 ]
@@ -317,7 +317,7 @@ class TestRouteRest(BaseDocumentTestRest):
                 'height_diff_down': 800,
                 'durations': ['1'],
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'none',
                      'version': self.locale_en.version}
                 ],
@@ -335,7 +335,7 @@ class TestRouteRest(BaseDocumentTestRest):
         self.assertEquals(locale_en.description, '...')
         self.assertEquals(locale_en.gear, 'none')
 
-        # version with culture 'en'
+        # version with lang 'en'
         versions = route.versions
         version_en = versions[2]
         archive_locale = version_en.document_locales_archive
@@ -349,7 +349,7 @@ class TestRouteRest(BaseDocumentTestRest):
         archive_geometry_en = version_en.document_geometry_archive
         self.assertEqual(archive_geometry_en.version, 2)
 
-        # version with culture 'fr'
+        # version with lang 'fr'
         version_fr = versions[3]
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Blanc du ciel')
@@ -368,7 +368,7 @@ class TestRouteRest(BaseDocumentTestRest):
                 'height_diff_down': 800,
                 'durations': ['1'],
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'paraglider',
                      'version': self.locale_en.version,
                      'title_prefix': 'Should be ignored'}
@@ -393,7 +393,7 @@ class TestRouteRest(BaseDocumentTestRest):
                 'height_diff_down': 800,
                 'durations': ['1'],
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'paraglider',
                      'version': self.locale_en.version}
                 ]
@@ -419,7 +419,7 @@ class TestRouteRest(BaseDocumentTestRest):
                 'height_diff_down': 800,
                 'durations': ['1'],
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'none',
                      'version': self.locale_en.version}
                 ]
@@ -444,7 +444,7 @@ class TestRouteRest(BaseDocumentTestRest):
                 'height_diff_down': 800,
                 'durations': ['1'],
                 'locales': [
-                    {'culture': 'es', 'title': 'Mont Blanc del cielo',
+                    {'lang': 'es', 'title': 'Mont Blanc del cielo',
                      'description': '...', 'gear': 'si'}
                 ]
             }
@@ -455,8 +455,8 @@ class TestRouteRest(BaseDocumentTestRest):
 
     def test_history(self):
         id = self.route.document_id
-        cultures = ['fr', 'en']
-        for lang in cultures:
+        langs = ['fr', 'en']
+        for lang in langs:
             body = self.app.get('/document/%d/history/%s' % (id, lang))
             username = 'contributor'
             user_id = self.global_userids[username]
@@ -494,7 +494,7 @@ class TestRouteRest(BaseDocumentTestRest):
 
     def test_update_prefix_title(self):
         self.route.locales.append(RouteLocale(
-            culture='es', title='Mont Blanc del cielo', description='...',
+            lang='es', title='Mont Blanc del cielo', description='...',
             gear='paraglider'))
         self.route.main_waypoint_id = self.waypoint.document_id
         self.session.flush()
@@ -522,11 +522,11 @@ class TestRouteRest(BaseDocumentTestRest):
             height_diff_up=800, height_diff_down=800, durations='1')
 
         self.locale_en = RouteLocale(
-            culture='en', title='Mont Blanc from the air', description='...',
+            lang='en', title='Mont Blanc from the air', description='...',
             gear='paraglider', title_prefix='Main waypoint title')
 
         self.locale_fr = RouteLocale(
-            culture='fr', title='Mont Blanc du ciel', description='...',
+            lang='fr', title='Mont Blanc du ciel', description='...',
             gear='paraglider')
 
         self.route.locales.append(self.locale_en)
@@ -542,7 +542,7 @@ class TestRouteRest(BaseDocumentTestRest):
         DocumentRest(None)._create_new_version(self.route, user_id)
         self.route_version = self.session.query(DocumentVersion). \
             filter(DocumentVersion.document_id == self.route.document_id). \
-            filter(DocumentVersion.culture == 'en').first()
+            filter(DocumentVersion.lang == 'en').first()
 
         self.route2 = Route(
             activities=['skitouring'], elevation_max=1500, elevation_min=700,
@@ -556,10 +556,10 @@ class TestRouteRest(BaseDocumentTestRest):
             activities=['skitouring'], elevation_max=1500, elevation_min=700,
             height_diff_up=800, height_diff_down=800, durations='1')
         self.route4.locales.append(RouteLocale(
-            culture='en', title='Mont Blanc from the air', description='...',
+            lang='en', title='Mont Blanc from the air', description='...',
             gear='paraglider'))
         self.route4.locales.append(RouteLocale(
-            culture='fr', title='Mont Blanc du ciel', description='...',
+            lang='fr', title='Mont Blanc du ciel', description='...',
             gear='paraglider'))
         self.session.add(self.route4)
 
@@ -569,10 +569,10 @@ class TestRouteRest(BaseDocumentTestRest):
             geometry=DocumentGeometry(
                 geom='SRID=3857;POINT(635956 5723604)'))
         self.waypoint.locales.append(WaypointLocale(
-            culture='en', title='Mont Granier (en)', description='...',
+            lang='en', title='Mont Granier (en)', description='...',
             access='yep'))
         self.waypoint.locales.append(WaypointLocale(
-            culture='fr', title='Mont Granier (fr)', description='...',
+            lang='fr', title='Mont Granier (fr)', description='...',
             access='ouai'))
         self.session.add(self.waypoint)
         self.session.flush()

--- a/c2corg_api/tests/views/test_search.py
+++ b/c2corg_api/tests/views/test_search.py
@@ -19,11 +19,11 @@ class TestSearchRest(BaseTestRest):
                 geom='SRID=3857;POINT(635956 5723604)'),
             locales=[
                 WaypointLocale(
-                    culture='fr', title='Dent de Crolles',
+                    lang='fr', title='Dent de Crolles',
                     description='...',
                     summary='La Dent de Crolles'),
                 WaypointLocale(
-                    culture='en', title='Dent de Crolles',
+                    lang='en', title='Dent de Crolles',
                     description='...',
                     summary='The Dent de Crolles')
             ]))
@@ -34,7 +34,7 @@ class TestSearchRest(BaseTestRest):
                 geom='SRID=3857;POINT(635956 5723604)'),
             locales=[
                 WaypointLocale(
-                    culture='en', title='Mont Blanc',
+                    lang='en', title='Mont Blanc',
                     description='...',
                     summary='The heighest point in Europe')
             ]))
@@ -43,7 +43,7 @@ class TestSearchRest(BaseTestRest):
             activities=['skitouring'], elevation_max=1500, elevation_min=700,
             locales=[
                 RouteLocale(
-                    culture='fr', title='Mont Blanc du ciel',
+                    lang='fr', title='Mont Blanc du ciel',
                     description='...', summary='Ski')
             ]))
         self.session.flush()

--- a/c2corg_api/tests/views/test_topo_map.py
+++ b/c2corg_api/tests/views/test_topo_map.py
@@ -81,7 +81,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 'geom': '{"type": "Point", "coordinates": [635956, 5723604]}'
             },
             'locales': [
-                {'culture': 'en'}
+                {'lang': 'en'}
             ]
         }
         body = self.post_missing_title(body_post, user='moderator')
@@ -101,7 +101,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 'geom': '{"type": "Point", "coordinates": [635956, 5723604]}'
             },
             'locales': [
-                {'culture': 'en', 'title': 'Lac d\'Annecy'}
+                {'lang': 'en', 'title': 'Lac d\'Annecy'}
             ]
         }
         self.post_non_whitelisted_attribute(body, user='moderator')
@@ -119,7 +119,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 'geom': '{"type": "Point", "coordinates": [635956, 5723604]}'
             },
             'locales': [
-                {'culture': 'en', 'title': 'Lac d\'Annecy'}
+                {'lang': 'en', 'title': 'Lac d\'Annecy'}
             ]
         }
         body, doc = self.post_success(body, user='moderator')
@@ -133,7 +133,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
         self.assertEqual(archive_map.code, '3432OT')
 
         archive_locale = version.document_locales_archive
-        self.assertEqual(archive_locale.culture, 'en')
+        self.assertEqual(archive_locale.lang, 'en')
         self.assertEqual(archive_locale.title, 'Lac d\'Annecy')
 
         archive_geometry = version.document_geometry_archive
@@ -149,7 +149,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 'scale': '25000',
                 'code': '3432OT',
                 'locales': [
-                    {'culture': 'en', 'title': 'Lac d\'Annecy',
+                    {'lang': 'en', 'title': 'Lac d\'Annecy',
                      'version': self.locale_en.version}
                 ]
             }
@@ -165,7 +165,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 'scale': '25000',
                 'code': '3432OT',
                 'locales': [
-                    {'culture': 'en', 'title': 'Lac d\'Annecy',
+                    {'lang': 'en', 'title': 'Lac d\'Annecy',
                      'version': self.locale_en.version}
                 ]
             }
@@ -181,7 +181,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 'scale': '25000',
                 'code': '3432OT',
                 'locales': [
-                    {'culture': 'en', 'title': 'Lac d\'Annecy',
+                    {'lang': 'en', 'title': 'Lac d\'Annecy',
                      'version': -9999}
                 ]
             }
@@ -197,7 +197,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 'scale': '25000',
                 'code': '3432OT',
                 'locales': [
-                    {'culture': 'en', 'title': 'Lac d\'Annecy',
+                    {'lang': 'en', 'title': 'Lac d\'Annecy',
                      'version': self.locale_en.version}
                 ]
             }
@@ -221,7 +221,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                     'geom': '{"type": "Point", "coordinates": [1, 2]}'
                 },
                 'locales': [
-                    {'culture': 'en', 'title': 'New title',
+                    {'lang': 'en', 'title': 'New title',
                      'version': self.locale_en.version}
                 ]
             }
@@ -232,7 +232,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
         locale_en = map1.get_locale('en')
         self.assertEquals(locale_en.title, 'New title')
 
-        # version with culture 'en'
+        # version with lang 'en'
         versions = map1.versions
         version_en = versions[2]
         archive_locale = version_en.document_locales_archive
@@ -245,7 +245,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
         archive_geometry_en = version_en.document_geometry_archive
         self.assertEqual(archive_geometry_en.version, 2)
 
-        # version with culture 'fr'
+        # version with lang 'fr'
         version_fr = versions[3]
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Lac d\'Annecy')
@@ -260,7 +260,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 'scale': '25000',
                 'code': '3433OT',
                 'locales': [
-                    {'culture': 'en', 'title': 'Lac d\'Annecy',
+                    {'lang': 'en', 'title': 'Lac d\'Annecy',
                      'version': self.locale_en.version}
                 ]
             }
@@ -280,7 +280,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 'scale': '25000',
                 'code': '3431OT',
                 'locales': [
-                    {'culture': 'en', 'title': 'New title',
+                    {'lang': 'en', 'title': 'New title',
                      'version': self.locale_en.version}
                 ]
             }
@@ -303,7 +303,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
                 'scale': '25000',
                 'code': '3431OT',
                 'locales': [
-                    {'culture': 'es', 'title': 'Lac d\'Annecy'}
+                    {'lang': 'es', 'title': 'Lac d\'Annecy'}
                 ]
             }
         }
@@ -327,8 +327,8 @@ class TestTopoMapRest(BaseDocumentTestRest):
     def _add_test_data(self):
         self.map1 = TopoMap(editor='ign', scale='25000', code='3431OT')
 
-        self.locale_en = DocumentLocale(culture='en', title='Lac d\'Annecy')
-        self.locale_fr = DocumentLocale(culture='fr', title='Lac d\'Annecy')
+        self.locale_en = DocumentLocale(lang='en', title='Lac d\'Annecy')
+        self.locale_fr = DocumentLocale(lang='fr', title='Lac d\'Annecy')
 
         self.map1.locales.append(self.locale_en)
         self.map1.locales.append(self.locale_fr)
@@ -351,8 +351,8 @@ class TestTopoMapRest(BaseDocumentTestRest):
         self.map4 = TopoMap(
             editor='ign', scale='25000', code='3434OT')
         self.map4.locales.append(DocumentLocale(
-            culture='en', title='Lac d\'Annecy'))
+            lang='en', title='Lac d\'Annecy'))
         self.map4.locales.append(DocumentLocale(
-            culture='fr', title='Lac d\'Annecy'))
+            lang='fr', title='Lac d\'Annecy'))
         self.session.add(self.map4)
         self.session.flush()

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -117,7 +117,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'elevation': 3200,
             'geometry': {'geom': '{"type": "Point", "coordinates": [1, 1]}'},
             'locales': [
-                {'culture': 'en'}
+                {'lang': 'en'}
             ]
         }
         body = self.post_missing_title(body)
@@ -130,7 +130,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'waypoint_type': 'summit',
             'elevation': 3200,
             'locales': [
-                {'culture': 'en', 'title': 'Mont Pourri',
+                {'lang': 'en', 'title': 'Mont Pourri',
                  'access': 'y'}
             ]
         }
@@ -142,7 +142,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'elevation': 3200,
             'geometry': {},
             'locales': [
-                {'culture': 'en', 'title': 'Mont Pourri',
+                {'lang': 'en', 'title': 'Mont Pourri',
                  'access': 'y'}
             ]
         }
@@ -163,8 +163,8 @@ class TestWaypointRest(BaseDocumentTestRest):
             'elevation': 3200,
             'geometry': {'geom': '{"type": "Point", "coordinates": [1, 1]}'},
             'locales': [
-                {'culture': 'en', 'title': 'Mont Pourri', 'access': 'y'},
-                {'culture': 'en', 'title': 'Mont Pourri', 'access': 'y'}
+                {'lang': 'en', 'title': 'Mont Pourri', 'access': 'y'},
+                {'lang': 'en', 'title': 'Mont Pourri', 'access': 'y'}
             ]
         }
         self.post_same_locale_twice(body)
@@ -174,7 +174,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'waypoint_type': 'summit',
             'geometry': {'geom': '{"type": "Point", "coordinates": [1, 1]}'},
             'locales': [
-                {'culture': 'en', 'title': 'Mont Pourri',
+                {'lang': 'en', 'title': 'Mont Pourri',
                  'access': 'y'}
             ]
         }
@@ -187,7 +187,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'geometry': {'geom': '{"type": "Point", "coordinates": [1, 1]}'},
             'protected': True,
             'locales': [
-                {'culture': 'en', 'title': 'Mont Pourri',
+                {'lang': 'en', 'title': 'Mont Pourri',
                  'access': 'y'}
             ]
         }
@@ -206,7 +206,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'waypoint_type': 'swimming-pool',
             'elevation': 3779,
             'locales': [
-                {'culture': 'en', 'title': 'Mont Pourri'}
+                {'lang': 'en', 'title': 'Mont Pourri'}
             ]
         }
         body = self.post_error(body_post)
@@ -230,7 +230,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'elevation': 3779,
             'locales': [
                 {'id': 3456, 'version': 4567,
-                 'culture': 'en', 'title': 'Mont Pourri',
+                 'lang': 'en', 'title': 'Mont Pourri',
                  'access': 'y'}
             ]
         }
@@ -252,7 +252,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.assertEqual(archive_waypoint.elevation, 3779)
 
         archive_locale = version.document_locales_archive
-        self.assertEqual(archive_locale.culture, 'en')
+        self.assertEqual(archive_locale.lang, 'en')
         self.assertEqual(archive_locale.title, 'Mont Pourri')
         self.assertEqual(archive_locale.access, 'y')
 
@@ -279,7 +279,7 @@ class TestWaypointRest(BaseDocumentTestRest):
                 'waypoint_type': 'summit',
                 'elevation': 1234,
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Granier',
+                    {'lang': 'en', 'title': 'Mont Granier',
                      'description': '...', 'access': 'n'}
                 ]
             }
@@ -294,7 +294,7 @@ class TestWaypointRest(BaseDocumentTestRest):
                 'waypoint_type': 'summit',
                 'elevation': 1234,
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Granier',
+                    {'lang': 'en', 'title': 'Mont Granier',
                      'description': '...', 'access': 'n'}
                 ]
             }
@@ -309,7 +309,7 @@ class TestWaypointRest(BaseDocumentTestRest):
                 'waypoint_type': 'summit',
                 'elevation': 1234,
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Granier',
+                    {'lang': 'en', 'title': 'Mont Granier',
                      'description': '...', 'access': 'n',
                      'version': -9999}
                 ]
@@ -325,7 +325,7 @@ class TestWaypointRest(BaseDocumentTestRest):
                 'waypoint_type': 'summit',
                 'elevation': 1234,
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Granier',
+                    {'lang': 'en', 'title': 'Mont Granier',
                      'description': 'A.', 'access': 'n',
                      'version': self.locale_en.version}
                 ]
@@ -356,7 +356,7 @@ class TestWaypointRest(BaseDocumentTestRest):
                 'waypoint_type': 'summit',
                 'elevation': 1234,
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Granier!',
+                    {'lang': 'en', 'title': 'Mont Granier!',
                      'description': 'A.', 'access': 'n',
                      'version': self.locale_en.version}
                 ],
@@ -373,7 +373,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.assertEquals(locale_en.description, 'A.')
         self.assertEquals(locale_en.access, 'n')
 
-        # version with culture 'en'
+        # version with lang 'en'
         versions = waypoint.versions
         version_en = versions[2]
         archive_locale = version_en.document_locales_archive
@@ -387,7 +387,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         archive_geometry_en = version_en.document_geometry_archive
         self.assertEqual(archive_geometry_en.version, 2)
 
-        # version with culture 'fr'
+        # version with lang 'fr'
         version_fr = versions[3]
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Granier')
@@ -423,7 +423,7 @@ class TestWaypointRest(BaseDocumentTestRest):
                 'waypoint_type': 'summit',
                 'elevation': 1234,
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Granier',
+                    {'lang': 'en', 'title': 'Mont Granier',
                      'description': 'A.', 'access': 'n',
                      'version': self.locale_en.version}
                 ]
@@ -463,7 +463,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.assertEquals(locale_en.description, 'A.')
         self.assertEquals(locale_en.access, 'n')
 
-        # version with culture 'en'
+        # version with lang 'en'
         versions = waypoint.versions
         version_en = versions[2]
         archive_locale = version_en.document_locales_archive
@@ -477,7 +477,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         archive_geometry_en = version_en.document_geometry_archive
         self.assertEqual(archive_geometry_en.version, 1)
 
-        # version with culture 'fr'
+        # version with lang 'fr'
         version_fr = versions[3]
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Granier')
@@ -520,7 +520,7 @@ class TestWaypointRest(BaseDocumentTestRest):
                 'waypoint_type': 'summit',
                 'elevation': 2203,
                 'locales': [
-                    {'culture': 'en', 'title': 'Mont Granier',
+                    {'lang': 'en', 'title': 'Mont Granier',
                      'description': '...', 'access': 'no',
                      'version': self.locale_en.version}
                 ]
@@ -542,7 +542,7 @@ class TestWaypointRest(BaseDocumentTestRest):
                 'elevation': 2203,
                 'locales': [
                     {'id': 1234, 'version': 2345,
-                     'culture': 'es', 'title': 'Mont Granier',
+                     'lang': 'es', 'title': 'Mont Granier',
                      'description': '...', 'access': 'si'}
                 ]
             }
@@ -561,7 +561,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             waypoint_type='summit', elevation=3779)
 
         locale_en = WaypointLocale(
-            culture='en', title='Mont Pourri', access='y')
+            lang='en', title='Mont Pourri', access='y')
         waypoint.locales.append(locale_en)
 
         self.session.add(waypoint)
@@ -630,10 +630,10 @@ class TestWaypointRest(BaseDocumentTestRest):
         versions = document.versions
         self.assertEqual(len(versions), 2)
 
-        # version with culture 'en'
+        # version with lang 'en'
         version_en = versions[1]
 
-        self.assertEqual(version_en.culture, 'en')
+        self.assertEqual(version_en.lang, 'en')
 
         meta_data_en = version_en.history_metadata
         self.assertEqual(meta_data_en.comment, 'Adding geom')
@@ -653,8 +653,8 @@ class TestWaypointRest(BaseDocumentTestRest):
 
     def test_history(self):
         id = self.waypoint.document_id
-        cultures = ['fr', 'en']
-        for lang in cultures:
+        langs = ['fr', 'en']
+        for lang in langs:
             body = self.app.get('/document/%d/history/%s' % (id, lang))
             username = 'contributor'
             user_id = self.global_userids[username]
@@ -674,11 +674,11 @@ class TestWaypointRest(BaseDocumentTestRest):
             waypoint_type='summit', elevation=2203)
 
         self.locale_en = WaypointLocale(
-            culture='en', title='Mont Granier', description='...',
+            lang='en', title='Mont Granier', description='...',
             access='yep')
 
         self.locale_fr = WaypointLocale(
-            culture='fr', title='Mont Granier', description='...',
+            lang='fr', title='Mont Granier', description='...',
             access='ouai')
 
         self.waypoint.locales.append(self.locale_en)
@@ -692,7 +692,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         DocumentRest(None)._create_new_version(self.waypoint, user_id)
         self.waypoint_version = self.session.query(DocumentVersion). \
             filter(DocumentVersion.document_id == self.waypoint.document_id). \
-            filter(DocumentVersion.culture == 'en').first()
+            filter(DocumentVersion.lang == 'en').first()
 
         self.waypoint2 = Waypoint(
             waypoint_type='summit', elevation=2,
@@ -709,10 +709,10 @@ class TestWaypointRest(BaseDocumentTestRest):
             geometry=DocumentGeometry(
                 geom='SRID=3857;POINT(635956 5723604)'))
         self.waypoint4.locales.append(WaypointLocale(
-            culture='en', title='Mont Granier', description='...',
+            lang='en', title='Mont Granier', description='...',
             access='yep'))
         self.waypoint4.locales.append(WaypointLocale(
-            culture='fr', title='Mont Granier', description='...',
+            lang='fr', title='Mont Granier', description='...',
             access='ouai'))
         self.session.add(self.waypoint4)
 
@@ -723,7 +723,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             main_waypoint_id=self.waypoint.document_id
         )
         self.route.locales.append(RouteLocale(
-            culture='en', title='Mont Blanc from the air', description='...',
+            lang='en', title='Mont Blanc from the air', description='...',
             gear='paraglider'))
         self.session.add(self.route)
         self.session.flush()
@@ -738,7 +738,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.session.add(TopoMap(
             code='3232ET', editor='ign', scale='25000',
             locales=[
-                DocumentLocale(culture='fr', title='Belley')
+                DocumentLocale(lang='fr', title='Belley')
             ],
             geometry=DocumentGeometry(geom='SRID=3857;POLYGON((611774.917032556 5706934.10657514,611774.917032556 5744215.5846397,642834.402570357 5744215.5846397,642834.402570357 5706934.10657514,611774.917032556 5706934.10657514))')  # noqa
         ))
@@ -753,7 +753,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.area2 = Area(
             area_type='range',
             locales=[
-                DocumentLocale(culture='fr', title='France')
+                DocumentLocale(lang='fr', title='France')
             ]
         )
 

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -2,7 +2,7 @@ import collections
 import datetime
 
 from c2corg_api.models import DBSession
-from c2corg_common.attributes import cultures_priority
+from c2corg_common.attributes import langs_priority
 from colander import null
 from pyramid.httpexceptions import HTTPError, HTTPNotFound
 from pyramid.view import view_config
@@ -77,7 +77,7 @@ def to_json_dict(obj, schema):
     # cleaner to add the field to the schema, but ColanderAlchemy doesn't like
     # it because it's not a real column)
     special_attributes = [
-        'available_cultures', 'associations', 'maps', 'areas'
+        'available_langs', 'associations', 'maps', 'areas'
     ]
     for attr in special_attributes:
         if hasattr(obj, attr):
@@ -118,7 +118,7 @@ def to_seconds(date):
 def set_best_locale(documents, preferred_lang, expunge=True):
     """Sets the "best" locale on the given documents. The "best" locale is
     the locale in the given "preferred language" if available. Otherwise
-    it is the "most relevant" translation according to `cultures_priority`.
+    it is the "most relevant" translation according to `langs_priority`.
     """
     if preferred_lang is None:
         return
@@ -131,7 +131,7 @@ def set_best_locale(documents, preferred_lang, expunge=True):
 
         if document.locales:
             available_locales = {
-                locale.culture: locale for locale in document.locales}
+                locale.lang: locale for locale in document.locales}
             best_locale = get_best_locale(available_locales, preferred_lang)
             if best_locale:
                 document.locales = [best_locale]
@@ -142,6 +142,6 @@ def get_best_locale(available_locales, preferred_lang):
         best_locale = available_locales[preferred_lang]
     else:
         best_locale = next(
-                (available_locales[lang] for lang in cultures_priority
+                (available_locales[lang] for lang in langs_priority
                  if lang in available_locales), None)
     return best_locale

--- a/c2corg_api/views/route.py
+++ b/c2corg_api/views/route.py
@@ -88,10 +88,10 @@ def update_title_prefix(route, create=False):
         # "next" locale).
         waypoint_locales = DBSession.query(DocumentLocale). \
             filter(DocumentLocale.document_id == route.main_waypoint_id). \
-            options(load_only(DocumentLocale.culture, DocumentLocale.title)). \
+            options(load_only(DocumentLocale.lang, DocumentLocale.title)). \
             all()
         waypoint_locales_index = {
-            locale.culture: locale for locale in waypoint_locales}
+            locale.lang: locale for locale in waypoint_locales}
 
         set_route_title_prefix(route, waypoint_locales, waypoint_locales_index)
 
@@ -105,7 +105,7 @@ def set_route_title_prefix(route, waypoint_locales, waypoint_locales_index):
     else:
         for locale in route.locales:
             waypoint_locale = get_best_locale(
-                waypoint_locales_index, locale.culture)
+                waypoint_locales_index, locale.lang)
             set_title_prefix_for_ids(
                 [locale.id],
                 waypoint_locale.title if waypoint_locale else '')

--- a/c2corg_api/views/validation.py
+++ b/c2corg_api/views/validation.py
@@ -1,4 +1,4 @@
-from c2corg_common.attributes import default_cultures
+from c2corg_common.attributes import default_langs
 from colander import null
 
 # Validation functions
@@ -20,7 +20,7 @@ def validate_lang_(lang, request):
     """Checks if a given lang is one of the available langs.
     """
     if lang is not None:
-        if lang in default_cultures:
+        if lang in default_langs:
             request.validated['lang'] = lang
         else:
             request.errors.add('querystring', 'lang', 'invalid lang')
@@ -80,19 +80,19 @@ def check_required_fields(document, fields, request, updating):
 
 
 def check_duplicate_locales(document, request):
-    """Check that there is only one entry for each culture.
+    """Check that there is only one entry for each lang.
     """
     locales = document.get('locales')
     if locales:
-        cultures = set()
+        langs = set()
         for locale in locales:
-            culture = locale.get('culture')
-            if culture in cultures:
+            lang = locale.get('lang')
+            if lang in langs:
                 request.errors.add(
                     'body', 'locales',
-                    'culture "%s" is given twice' % (culture))
+                    'lang "%s" is given twice' % (lang))
                 return
-            cultures.add(culture)
+            langs.add(lang)
 
 
 def check_get_for_integer_property(request, key, required):

--- a/c2corg_api/views/waypoint.py
+++ b/c2corg_api/views/waypoint.py
@@ -92,14 +92,14 @@ def update_linked_route_titles(waypoint, update_types):
     linked_routes = DBSession.query(Route). \
         filter(Route.main_waypoint_id == waypoint.document_id). \
         options(joinedload(Route.locales).load_only(
-            RouteLocale.culture, RouteLocale.id)). \
+            RouteLocale.lang, RouteLocale.id)). \
         options(load_only(Route.document_id)). \
         all()
 
     if linked_routes:
         waypoint_locales = waypoint.locales
         waypoint_locales_index = {
-            locale.culture: locale for locale in waypoint_locales}
+            locale.lang: locale for locale in waypoint_locales}
 
         for route in linked_routes:
             set_route_title_prefix(

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ git+https://github.com/tsauerwein/ColanderAlchemy.git@c2corg
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@46bd43eea4e095b614cfaeb2021ca1b8987dbc2c
+git+https://github.com/c2corg/v6_common.git@2171a050d68a7c620277e4df239cab71cfe212b4
 
 # Discourse API client
 git+https://github.com/c2corg/pydiscourse.git@65e398343bbbc74fdb71cca4637c9f808e5adfb2


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_api/issues/101

Must be merged in combination with https://github.com/c2corg/v6_common/pull/7 and https://github.com/c2corg/v6_ui/pull/145

Commands used to make the searches/replaces:
```
git grep -l culture | xargs sed -i 's/culture/lang/g'
git grep -l Culture | xargs sed -i 's/Culture/Lang/g'
```

I have reverted by hand some changes so that fields from v5 (in the migration scripts) remain ``culture``.

I have not renamed the ``?l=`` parameter yet (as suggested in https://github.com/c2corg/v6_api/issues/101#issuecomment-166672389)