### PR TITLE
Rename API's 'l' parameter to 'lang'

### DIFF
--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -163,7 +163,7 @@ class BaseDocumentTestRest(BaseTestRest):
 
     def get_lang(self, reference):
         response = self.app.get(self._prefix + '/' +
-                                str(reference.document_id) + '?l=en',
+                                str(reference.document_id) + '?lang=en',
                                 status=200)
         self.assertEqual(response.content_type, 'application/json')
 
@@ -175,7 +175,7 @@ class BaseDocumentTestRest(BaseTestRest):
 
     def get_new_lang(self, reference):
         response = self.app.get(self._prefix + '/' +
-                                str(reference.document_id) + '?l=it',
+                                str(reference.document_id) + '?lang=it',
                                 status=200)
         self.assertEqual(response.content_type, 'application/json')
 
@@ -185,7 +185,7 @@ class BaseDocumentTestRest(BaseTestRest):
 
     def get_404(self):
         self.app.get(self._prefix + '/-9999', status=404)
-        self.app.get(self._prefix + '/-9999?l=es', status=404)
+        self.app.get(self._prefix + '/-9999?lang=es', status=404)
 
     def post_error(self, request_body, user='contributor'):
         response = self.app.post_json(self._prefix, request_body,

--- a/c2corg_api/views/validation.py
+++ b/c2corg_api/views/validation.py
@@ -36,9 +36,9 @@ def validate_lang(request):
 
 def validate_lang_param(request):
     """Checks if the language given in the url as GET parameter
-    is correct ("...?l=...").
+    is correct ("...?lang=...").
     """
-    lang = request.GET.get('l')
+    lang = request.GET.get('lang')
     validate_lang_(lang, request)
 
 


### PR DESCRIPTION
See https://github.com/c2corg/v6_api/issues/101#issuecomment-166672389

Should we rename the "pl" parameter as well?