### PR TITLE
Do not return full document on create/update

### DIFF
--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -473,9 +473,13 @@ class BaseDocumentTestRest(BaseTestRest):
             status=403)
 
         headers = self.add_authorization_header(username=user)
-        response = self.app.put_json(
+        self.app.put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             headers=headers, status=200)
+
+        response = self.app.get(
+            self._prefix + '/' + str(document.document_id), status=200)
+        self.assertEqual(response.content_type, 'application/json')
 
         body = response.json
         document_id = body.get('document_id')
@@ -567,9 +571,13 @@ class BaseDocumentTestRest(BaseTestRest):
             status=403)
 
         headers = self.add_authorization_header(username=user)
-        response = self.app.put_json(
+        self.app.put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             headers=headers, status=200)
+
+        response = self.app.get(
+            self._prefix + '/' + str(document.document_id), status=200)
+        self.assertEqual(response.content_type, 'application/json')
 
         body = response.json
         document_id = body.get('document_id')
@@ -656,9 +664,13 @@ class BaseDocumentTestRest(BaseTestRest):
             status=403)
 
         headers = self.add_authorization_header(username=user)
-        response = self.app.put_json(
+        self.app.put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             headers=headers, status=200)
+
+        response = self.app.get(
+            self._prefix + '/' + str(document.document_id), status=200)
+        self.assertEqual(response.content_type, 'application/json')
 
         body = response.json
         document_id = body.get('document_id')
@@ -734,11 +746,14 @@ class BaseDocumentTestRest(BaseTestRest):
             status=403)
 
         headers = self.add_authorization_header(username=user)
-        response = self.app.put_json(
+        self.app.put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             headers=headers, status=200)
 
-        headers = self.add_authorization_header(username='contributor')
+        response = self.app.get(
+            self._prefix + '/' + str(document.document_id), status=200)
+        self.assertEqual(response.content_type, 'application/json')
+
         body = response.json
         document_id = body.get('document_id')
         # document version does not change!

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -339,8 +339,14 @@ class BaseDocumentTestRest(BaseTestRest):
 
         body = response.json
         document_id = body.get('document_id')
-        self.assertIsNotNone(body.get('version'))
         self.assertIsNotNone(document_id)
+
+        response = self.app.get(self._prefix + '/' + str(document_id),
+                                status=200)
+        self.assertEqual(response.content_type, 'application/json')
+
+        body = response.json
+        self.assertIsNotNone(body.get('version'))
 
         # check that the version was created correctly
         doc = self.session.query(self._model).get(document_id)

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -588,9 +588,13 @@ class TestWaypointRest(BaseDocumentTestRest):
             status=403)
 
         headers = self.add_authorization_header(username='contributor')
-        response = self.app.put_json(
+        self.app.put_json(
             self._prefix + '/' + str(waypoint.document_id), body_put,
             headers=headers, status=200)
+
+        response = self.app.get(
+            self._prefix + '/' + str(waypoint.document_id), status=200)
+        self.assertEqual(response.content_type, 'application/json')
 
         body = response.json
         document_id = body.get('document_id')

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -236,7 +236,6 @@ class TestWaypointRest(BaseDocumentTestRest):
         }
         body, doc = self.post_success(body)
         self._assert_geometry(body, 'geom')
-        self._assert_geometry(body, 'geom_detail')
 
         # test that document_id and version was reset
         self.assertNotEqual(body.get('document_id'), 1234)

--- a/c2corg_api/views/area.py
+++ b/c2corg_api/views/area.py
@@ -32,7 +32,7 @@ class AreaRest(DocumentRest):
             permission='moderator')
     def collection_post(self):
         return self._collection_post(
-            Area, schema_area, after_add=insert_associations)
+            schema_area, after_add=insert_associations)
 
     @restricted_json_view(
             schema=schema_update_area,

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -171,7 +171,7 @@ class DocumentRest(object):
                 to_json_dict(m, schema_listing_area) for m in document._areas
             ]
 
-    def _collection_post(self, clazz, schema, after_add=None):
+    def _collection_post(self, schema, after_add=None):
         document = schema.objectify(self.request.validated)
         document.document_id = None
 
@@ -188,7 +188,7 @@ class DocumentRest(object):
 
         sync_search_index(document)
 
-        return to_json_dict(document, schema)
+        return {'document_id': document.document_id}
 
     def _put(self, clazz, schema, after_update=None):
         user_id = self.request.authenticated_userid

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -204,9 +204,6 @@ class DocumentRest(object):
         # remember the current version numbers of the document
         old_versions = document.get_versions()
 
-        # find out whether the update of the geometry should be skipped.
-        skip_geometry_update = document_in.geometry is None
-
         # update the document with the input document
         document.update(document_in)
 
@@ -236,15 +233,7 @@ class DocumentRest(object):
             # And the search updated
             sync_search_index(document)
 
-        json_dict = to_json_dict(document, schema)
-
-        if skip_geometry_update:
-            # Optimization: the geometry is not sent back if the client
-            # requested to skip the geometry update. Geometries may be very
-            # huge; this optimization should speed the data transfer.
-            json_dict['geometry'] = None
-
-        return json_dict
+        return {}
 
     def _get_document(self, clazz, id, lang=None):
         """Get a document with either a single locale (if `lang is given)

--- a/c2corg_api/views/image.py
+++ b/c2corg_api/views/image.py
@@ -21,7 +21,7 @@ class ImageRest(DocumentRest):
 
     @restricted_json_view(schema=schema_image)
     def collection_post(self):
-        return self._collection_post(Image, schema_image)
+        return self._collection_post(schema_image)
 
     @restricted_json_view(schema=schema_update_image, validators=validate_id)
     def put(self):

--- a/c2corg_api/views/route.py
+++ b/c2corg_api/views/route.py
@@ -51,8 +51,7 @@ class RouteRest(DocumentRest):
     @restricted_json_view(schema=schema_route,
                           validators=validate_route_create)
     def collection_post(self):
-        return self._collection_post(
-            Route, schema_route, after_add=init_title_prefix)
+        return self._collection_post(schema_route, after_add=init_title_prefix)
 
     @restricted_json_view(schema=schema_update_route,
                           validators=[validate_id, validate_route_update])

--- a/c2corg_api/views/topo_map.py
+++ b/c2corg_api/views/topo_map.py
@@ -30,7 +30,7 @@ class TopoMapRest(DocumentRest):
             schema=schema_topo_map, validators=validate_map_create,
             permission='moderator')
     def collection_post(self):
-        return self._collection_post(TopoMap, schema_topo_map)
+        return self._collection_post(schema_topo_map)
 
     @restricted_json_view(
             schema=schema_update_topo_map,

--- a/c2corg_api/views/waypoint.py
+++ b/c2corg_api/views/waypoint.py
@@ -60,7 +60,7 @@ class WaypointRest(DocumentRest):
     @restricted_json_view(schema=schema_waypoint,
                           validators=validate_waypoint_create)
     def collection_post(self):
-        return self._collection_post(Waypoint, schema_waypoint)
+        return self._collection_post(schema_waypoint)
 
     @restricted_json_view(schema=schema_update_waypoint,
                           validators=[validate_id, validate_waypoint_update])


### PR DESCRIPTION
Create only returns the `document_id` (`{'document_id': ...}`), update an empty object (`{}`).

Closes https://github.com/c2corg/v6_api/issues/38