### PR TITLE
Add support for outings

### DIFF
--- a/c2corg_api/models/document_history.py
+++ b/c2corg_api/models/document_history.py
@@ -36,7 +36,8 @@ class DocumentVersion(Base):
         nullable=False)
     document = relationship(
         Document, primaryjoin=document_id == Document.document_id,
-        backref=backref('versions', viewonly=True))
+        backref=backref(
+            'versions', viewonly=True, order_by=id))
 
     lang = Column(
         String(2), ForeignKey(schema + '.langs.lang'),

--- a/c2corg_api/models/enums.py
+++ b/c2corg_api/models/enums.py
@@ -96,3 +96,19 @@ area_type = enum(
     'area_type', attributes.area_types)
 user_category = enum(
     'user_category', attributes.user_categories)
+frequentation_type = enum(
+    'frequentation_type', attributes.frequentation_types)
+access_condition = enum(
+    'access_condition', attributes.access_conditions)
+lift_status = enum(
+    'lift_status', attributes.lift_status)
+awesomeness = enum(
+    'awesomeness', attributes.awesomeness)
+condition_rating = enum(
+    'condition_rating', attributes.condition_ratings)
+glacier_rating = enum(
+    'glacier_rating', attributes.glacier_ratings)
+avalanche_signs = enum(
+    'avalanche_signs', attributes.avalanche_signs)
+hut_status = enum(
+    'hut_status', attributes.hut_status)

--- a/c2corg_api/models/outing.py
+++ b/c2corg_api/models/outing.py
@@ -1,0 +1,240 @@
+import colander
+from c2corg_api.models.schema_utils import restrict_schema
+from sqlalchemy import (
+    Column,
+    Integer,
+    Boolean,
+    SmallInteger,
+    String,
+    Date,
+    ForeignKey
+    )
+
+from colanderalchemy import SQLAlchemySchemaNode
+from colander import MappingSchema, SchemaNode, Integer as ColanderInteger
+
+from c2corg_api.models import schema
+from c2corg_api.models.utils import ArrayOfEnum
+from c2corg_api.models.utils import copy_attributes
+from c2corg_api.models.document import (
+    ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale,
+    get_update_schema, geometry_schema_overrides, schema_locale_attributes,
+    schema_attributes)
+from c2corg_api.models import enums
+
+OUTING_TYPE = 'o'
+
+
+class _OutingMixin(object):
+
+    activities = Column(ArrayOfEnum(enums.activity_type), nullable=False)
+
+    date_start = Column(Date, nullable=False)
+
+    date_end = Column(Date, nullable=False)
+
+    frequentation = Column(enums.frequentation_type)
+
+    participant_count = Column(SmallInteger)
+
+    elevation_min = Column(SmallInteger)
+
+    elevation_max = Column(SmallInteger)
+
+    elevation_access = Column(SmallInteger)
+
+    # altitude de chaussage
+    elevation_up_snow = Column(SmallInteger)
+
+    # altitude de dechaussage
+    elevation_down_snow = Column(SmallInteger)
+
+    height_diff_up = Column(SmallInteger)
+
+    height_diff_down = Column(SmallInteger)
+
+    length_total = Column(Integer)
+
+    partial_trip = Column(Boolean)
+
+    public_transport = Column(Boolean)
+
+    access_condition = Column(enums.access_condition)
+
+    lift_status = Column(enums.lift_status)
+
+    awesomeness = Column(enums.awesomeness)
+
+    duration = Column(SmallInteger)
+
+    duration_difficulties = Column(SmallInteger)
+
+    condition_rating = Column(enums.condition_rating)
+
+    snow_quantity = Column(enums.condition_rating)
+
+    snow_quality = Column(enums.condition_rating)
+
+    glacier_rating = Column(enums.glacier_rating)
+
+    avalanche_signs = Column(ArrayOfEnum(enums.avalanche_signs))
+
+    hut_status = Column(enums.hut_status)
+
+attributes = [
+    'access_condition', 'activities', 'avalanche_signs', 'awesomeness',
+    'condition_rating', 'date_end', 'date_start', 'duration',
+    'duration_difficulties', 'elevation_access', 'elevation_down_snow',
+    'elevation_max', 'elevation_min', 'elevation_up_snow', 'frequentation',
+    'glacier_rating', 'height_diff_down', 'height_diff_up', 'hut_status',
+    'length_total', 'lift_status', 'partial_trip', 'participant_count',
+    'public_transport', 'snow_quality', 'snow_quantity']
+
+
+class Outing(_OutingMixin, Document):
+    """
+    """
+    __tablename__ = 'outings'
+
+    document_id = Column(
+        Integer,
+        ForeignKey(schema + '.documents.document_id'), primary_key=True)
+
+    __mapper_args__ = {
+        'polymorphic_identity': OUTING_TYPE,
+        'inherit_condition': Document.document_id == document_id
+    }
+
+    def to_archive(self):
+        outing = ArchiveOuting()
+        super(Outing, self)._to_archive(outing)
+        copy_attributes(self, outing, attributes)
+
+        return outing
+
+    def update(self, other):
+        super(Outing, self).update(other)
+        copy_attributes(other, self, attributes)
+
+
+class ArchiveOuting(_OutingMixin, ArchiveDocument):
+    """
+    """
+    __tablename__ = 'outings_archives'
+
+    id = Column(
+        Integer,
+        ForeignKey(schema + '.documents_archives.id'), primary_key=True)
+
+    __mapper_args__ = {
+        'polymorphic_identity': OUTING_TYPE,
+        'inherit_condition': ArchiveDocument.id == id
+    }
+
+
+class _OutingLocaleMixin(object):
+
+    __mapper_args__ = {
+        'polymorphic_identity': OUTING_TYPE
+    }
+
+    participants = Column(String)
+
+    access_comment = Column(String)
+
+    weather = Column(String)
+
+    timing = Column(String)
+
+    conditions_levels = Column(String)
+
+    conditions = Column(String)
+
+    avalanches = Column(String)
+
+    hut_comment = Column(String)
+
+    route_description = Column(String)
+
+
+attributes_locales = [
+    'access_comment', 'avalanches', 'conditions', 'conditions_levels',
+    'hut_comment', 'participants', 'route_description', 'timing', 'weather'
+]
+
+
+class OutingLocale(_OutingLocaleMixin, DocumentLocale):
+    """
+    """
+    __tablename__ = 'outings_locales'
+
+    id = Column(
+                Integer,
+                ForeignKey(schema + '.documents_locales.id'), primary_key=True)
+
+    def to_archive(self):
+        locale = ArchiveOutingLocale()
+        super(OutingLocale, self)._to_archive(locale)
+        copy_attributes(self, locale, attributes_locales)
+
+        return locale
+
+    def update(self, other):
+        super(OutingLocale, self).update(other)
+        copy_attributes(other, self, attributes_locales)
+
+
+class ArchiveOutingLocale(_OutingLocaleMixin, ArchiveDocumentLocale):
+    """
+    """
+    __tablename__ = 'outings_locales_archives'
+
+    id = Column(
+        Integer,
+        ForeignKey(schema + '.documents_locales_archives.id'),
+        primary_key=True)
+
+
+schema_outing_locale = SQLAlchemySchemaNode(
+    OutingLocale,
+    # whitelisted attributes
+    includes=schema_locale_attributes + attributes_locales,
+    overrides={
+        'version': {
+            'missing': None
+        }
+    })
+
+schema_outing = SQLAlchemySchemaNode(
+    Outing,
+    # whitelisted attributes
+    includes=schema_attributes + attributes,
+    overrides={
+        'document_id': {
+            'missing': None
+        },
+        'version': {
+            'missing': None
+        },
+        'locales': {
+            'children': [schema_outing_locale]
+        },
+        'activities': {
+            'validator': colander.Length(min=1)
+        },
+        'geometry': geometry_schema_overrides
+    })
+
+
+class CreateOutingSchema(MappingSchema):
+    """The schema used for the web-service to create a new outing.
+    """
+    waypoint_id = SchemaNode(ColanderInteger())
+    route_id = SchemaNode(ColanderInteger())
+    outing = schema_outing.clone()
+
+schema_create_outing = CreateOutingSchema()
+schema_update_outing = get_update_schema(schema_outing)
+schema_association_outing = restrict_schema(schema_outing, [
+    'locales.title', 'activities'
+])

--- a/c2corg_api/models/outing.py
+++ b/c2corg_api/models/outing.py
@@ -11,7 +11,8 @@ from sqlalchemy import (
     )
 
 from colanderalchemy import SQLAlchemySchemaNode
-from colander import MappingSchema, SchemaNode, Integer as ColanderInteger
+from colander import MappingSchema, SchemaNode, Integer as ColanderInteger, \
+    Sequence
 
 from c2corg_api.models import schema
 from c2corg_api.models.utils import ArrayOfEnum
@@ -231,6 +232,9 @@ class CreateOutingSchema(MappingSchema):
     """
     waypoint_id = SchemaNode(ColanderInteger())
     route_id = SchemaNode(ColanderInteger())
+    user_ids = SchemaNode(Sequence(),
+                          SchemaNode(ColanderInteger()),
+                          validator=colander.Length(min=1))
     outing = schema_outing.clone()
 
 schema_create_outing = CreateOutingSchema()

--- a/c2corg_api/models/outing.py
+++ b/c2corg_api/models/outing.py
@@ -230,7 +230,6 @@ schema_outing = SQLAlchemySchemaNode(
 class CreateOutingSchema(MappingSchema):
     """The schema used for the web-service to create a new outing.
     """
-    waypoint_id = SchemaNode(ColanderInteger())
     route_id = SchemaNode(ColanderInteger())
     user_ids = SchemaNode(Sequence(),
                           SchemaNode(ColanderInteger()),

--- a/c2corg_api/models/outing.py
+++ b/c2corg_api/models/outing.py
@@ -239,5 +239,5 @@ class CreateOutingSchema(MappingSchema):
 schema_create_outing = CreateOutingSchema()
 schema_update_outing = get_update_schema(schema_outing)
 schema_association_outing = restrict_schema(schema_outing, [
-    'locales.title', 'activities'
+    'locales.title', 'activities', 'date_start', 'date_end'
 ])

--- a/c2corg_api/models/user.py
+++ b/c2corg_api/models/user.py
@@ -1,4 +1,5 @@
 import bcrypt
+from c2corg_api.models.schema_utils import restrict_schema
 from c2corg_api.models.user_profile import UserProfile
 from sqlalchemy import (
     Boolean,
@@ -114,3 +115,7 @@ schema_create_user = SQLAlchemySchemaNode(
             'validator': colander.Email()
         }
     })
+
+schema_association_user = restrict_schema(schema_user, [
+    'id', 'username'
+])

--- a/c2corg_api/scripts/migration/documents/associations.py
+++ b/c2corg_api/scripts/migration/documents/associations.py
@@ -7,7 +7,8 @@ from c2corg_api.models.association import Association, AssociationLog
 from c2corg_api.scripts.migration.batch import SimpleBatch
 from c2corg_api.scripts.migration.migrate_base import MigrateBase
 
-# TODO currently only importing associations for waypoints and routes
+# TODO currently only importing associations for waypoints, routes and
+# outings
 associations_query_count =\
     'select count(*) from (' \
     '  select a.main_id, a.linked_id from app_documents_associations a ' \
@@ -92,7 +93,11 @@ class MigrateAssociations(MigrateBase):
             count = 0
             for entity_in in self.connection_source.execute(query):
                 count += 1
-                batch.add(get_entity(entity_in))
+                # ignore associations for these documents because the
+                # documents are broken (no latest version)
+                if entity_in.main_id not in [224228, 436917] and \
+                        entity_in.linked_id not in [224228, 436917]:
+                    batch.add(get_entity(entity_in))
                 self.progress(count, total_count)
 
             # the transaction will not be committed automatically when doing

--- a/c2corg_api/scripts/migration/documents/document.py
+++ b/c2corg_api/scripts/migration/documents/document.py
@@ -103,9 +103,13 @@ class MigrateDocuments(MigrateBase):
                     current_document_id = document_in.id
                 else:
                     if current_document_id != document_in.id:
-                        raise AssertionError(
-                            'no latest version for {0}'.format(
+                        print('WARNING: no latest version for {0}'.format(
                                 current_document_id))
+                        archives = []
+                        geometry_archives = []
+                        version = 1
+                        current_document_id = document_in.id
+
                 if locales:
                     document_archive = self.get_document_locale_archive(
                         document_in, version)

--- a/c2corg_api/scripts/migration/documents/outings.py
+++ b/c2corg_api/scripts/migration/documents/outings.py
@@ -1,0 +1,183 @@
+from c2corg_api.models.outing import OutingLocale, Outing, ArchiveOuting, \
+    ArchiveOutingLocale, OUTING_TYPE
+from c2corg_api.scripts.migration.documents.document import MigrateDocuments
+from c2corg_api.scripts.migration.documents.routes import MigrateRoutes
+
+
+class MigrateOutings(MigrateDocuments):
+
+    def get_name(self):
+        return 'outings'
+
+    def get_model_document(self, locales):
+        return OutingLocale if locales else Outing
+
+    def get_model_archive_document(self, locales):
+        return ArchiveOutingLocale if locales else ArchiveOuting
+
+    def get_document_geometry(self, document_in, version):
+        return dict(
+            document_id=document_in.id,
+            id=document_in.id,
+            version=version,
+            geom=document_in.geom
+        )
+
+    def get_count_query(self):
+        return (
+            'select count(*) from app_outings_archives;'
+        )
+
+    def get_query(self):
+        return (
+            'select '
+            '   id, document_archive_id, is_latest_version, elevation, '
+            '   is_protected, redirects_to, '
+            '   ST_Force2D(ST_SetSRID(geom, 3857)) geom, '
+            '   date, activities, height_diff_up, height_diff_down, '
+            '   outing_length, min_elevation, max_elevation, partial_trip, '
+            '   hut_status, frequentation_status, conditions_status, '
+            '   access_status, access_elevation, lift_status, glacier_status, '
+            '   up_snow_elevation, down_snow_elevation, track_status, '
+            '   outing_with_public_transportation, avalanche_date '
+            'from app_outings_archives '
+            'order by id, document_archive_id;'
+        )
+
+    def get_count_query_locales(self):
+        return (
+            'select count(*) from app_outings_i18n_archives;'
+        )
+
+    def get_query_locales(self):
+        return (
+            'select '
+            '   id, document_i18n_archive_id, is_latest_version, culture, '
+            '   name, description, participants, timing, weather, '
+            '   hut_comments, access_comments, conditions, conditions_levels, '
+            '   avalanche_desc, outing_route_desc '
+            'from app_outings_i18n_archives '
+            ' order by id, document_i18n_archive_id;'
+        )
+
+    def get_document(self, document_in, version):
+        activities = self.convert_types(
+            document_in.activities, MigrateRoutes.activities)
+        if activities is None:
+            # there are ~100 outings which do not have an activity. because
+            # only one of them is the latest version, we assign a default
+            # activity (in v6 activities are required)
+            activities = ['skitouring']
+
+        return dict(
+            document_id=document_in.id,
+            type=OUTING_TYPE,
+            version=version,
+            protected=document_in.is_protected,
+            redirects_to=document_in.redirects_to,
+            activities=activities,
+            access_condition=self.convert_type(
+                document_in.access_status,
+                MigrateOutings.access_conditions),
+            avalanche_signs=self.convert_types(
+                document_in.avalanche_date,
+                MigrateOutings.avalanche_signs),
+            condition_rating=self.convert_type(
+                document_in.conditions_status,
+                MigrateOutings.condition_ratings),
+            date_end=document_in.date,
+            date_start=document_in.date,
+            elevation_access=document_in.access_elevation,
+            elevation_down_snow=document_in.down_snow_elevation,
+            elevation_up_snow=document_in.up_snow_elevation,
+            elevation_max=document_in.max_elevation,
+            elevation_min=document_in.min_elevation,
+            frequentation=self.convert_type(
+                document_in.frequentation_status,
+                MigrateOutings.frequentation_types),
+            glacier_rating=self.convert_type(
+                document_in.glacier_status,
+                MigrateOutings.glacier_ratings),
+            height_diff_down=document_in.height_diff_down,
+            height_diff_up=document_in.height_diff_up,
+            hut_status=self.convert_type(
+                document_in.hut_status,
+                MigrateOutings.hut_status),
+            length_total=document_in.outing_length,
+            lift_status=self.convert_type(
+                document_in.lift_status,
+                MigrateOutings.lift_status),
+            partial_trip=document_in.partial_trip,
+            public_transport=document_in.outing_with_public_transportation
+        )
+
+    def get_document_locale(self, document_in, version):
+        description, summary = self.extract_summary(document_in.description)
+        return dict(
+            document_id=document_in.id,
+            id=document_in.document_i18n_archive_id,
+            type=OUTING_TYPE,
+            version=version,
+            lang=document_in.culture,
+            title=document_in.name,
+            description=description,
+            summary=summary,
+            access_comment=document_in.access_comments,
+            avalanches=document_in.avalanche_desc,
+            route_description=document_in.outing_route_desc,
+            conditions=document_in.conditions,
+            conditions_levels=document_in.conditions_levels,
+            hut_comment=document_in.hut_comments,
+            participants=document_in.participants,
+            timing=document_in.timing,
+            weather=document_in.weather
+        )
+
+    access_conditions = {
+        '2': 'cleared',
+        '4': 'snow',
+        '6': 'closed_snow'
+    }
+
+    avalanche_signs = {
+        '1': 'no',
+        '2': 'danger_sign',
+        '3': 'recent_avalanche',
+        '4': 'natural_avalanche',
+        '5': 'accidental_avalanche'
+    }
+
+    condition_ratings = {
+        '1': 'excellent',
+        '2': 'good',
+        '3': 'average',
+        '4': 'poor',
+        '5': 'awful'
+    }
+
+    frequentation_types = {
+        '1': None,
+        '2': 'quiet',
+        '4': 'some',
+        '6': 'crowded',
+        '8': 'overcrowded'
+    }
+
+    glacier_ratings = {
+        '2': 'easy',
+        '4': 'possible',
+        '6': 'difficult',
+        '8': 'impossible'
+    }
+
+    hut_status = {
+        '2': 'open_guarded',
+        '4': 'open_non_guarded',
+        '6': 'closed',
+        '8': None
+    }
+
+    lift_status = {
+        '2': 'open',
+        '4': 'closed'
+    }

--- a/c2corg_api/scripts/migration/documents/versions.py
+++ b/c2corg_api/scripts/migration/documents/versions.py
@@ -13,7 +13,8 @@ from c2corg_api.scripts.migration.migrate_base import MigrateBase
 tables = [
     'app_huts_archives', 'app_parkings_archives', 'app_products_archives',
     'app_sites_archives', 'app_summits_archives', 'app_routes_archives',
-    'app_maps_archives', 'app_areas_archives', 'app_users_i18n_archives'
+    'app_maps_archives', 'app_areas_archives', 'app_users_i18n_archives',
+    'app_outings_archives'
 ]
 tables_union = ' union '.join(['select id from ' + t for t in tables])
 
@@ -105,9 +106,16 @@ class MigrateVersions(MigrateBase):
                 self.session_target.add(version)
 
     def get_meta_data(self, row):
+        if row.history_metadata_id == 75191:
+            # the user_id (8040) is wrong for this entry, use the user_id of
+            # the user who created the outing
+            user_id = 206753
+        else:
+            user_id = row.user_id
+
         return dict(
             id=row.history_metadata_id,
-            user_id=row.user_id,
+            user_id=user_id,
             comment=row.comment,
             written_at=row.written_at
         )

--- a/c2corg_api/scripts/migration/migrate.py
+++ b/c2corg_api/scripts/migration/migrate.py
@@ -9,6 +9,7 @@ from c2corg_api.scripts.migration.documents.associations import \
 from c2corg_api.scripts.migration.documents.maps import MigrateMaps
 from c2corg_api.scripts.migration.documents.user_profiles import \
     MigrateUserProfiles
+from c2corg_api.scripts.migration.documents.outings import MigrateOutings
 from sqlalchemy import engine_from_config
 
 import os
@@ -68,6 +69,7 @@ def main(argv=sys.argv):
     MigrateRoutes(connection_source, session, batch_size).migrate()
     MigrateMaps(connection_source, session, batch_size).migrate()
     MigrateAreas(connection_source, session, batch_size).migrate()
+    MigrateOutings(connection_source, session, batch_size).migrate()
     MigrateVersions(connection_source, session, batch_size).migrate()
     MigrateAssociations(connection_source, session, batch_size).migrate()
     MigrateAreaAssociations(connection_source, session, batch_size).migrate()

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -42,6 +42,7 @@ global_passwords = {}
 
 def _add_global_test_data(session):
     global_passwords['contributor'] = 'super pass'
+    global_passwords['contributor2'] = 'better pass'
     global_passwords['moderator'] = 'even better pass'
 
     contributor_profile = UserProfile(
@@ -53,6 +54,15 @@ def _add_global_test_data(session):
         password='super pass',
         profile=contributor_profile)
 
+    contributor2_profile = UserProfile(
+        category='amateur',
+        locales=[DocumentLocale(title='...', lang='en')])
+
+    contributor2 = User(
+        username='contributor2', email='contributor2@camptocamp.org',
+        password='better pass',
+        profile=contributor2_profile)
+
     moderator_profile = UserProfile(
         categories=['mountain_guide'],
         locales=[DocumentLocale(title='...', lang='en')])
@@ -62,7 +72,7 @@ def _add_global_test_data(session):
         moderator=True, password='even better pass',
         profile=moderator_profile)
 
-    users = [moderator, contributor]
+    users = [moderator, contributor, contributor2]
     session.add_all(users)
     session.flush()
 
@@ -71,7 +81,7 @@ def _add_global_test_data(session):
     now = datetime.datetime.utcnow()
     exp = now + datetime.timedelta(weeks=10)
 
-    for user in [moderator, contributor]:
+    for user in [moderator, contributor, contributor2]:
         claims = create_claims(user, exp)
         token = jwt.encode(claims, key=key, algorithm=algorithm). \
             decode('utf-8')

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -55,7 +55,7 @@ def _add_global_test_data(session):
         profile=contributor_profile)
 
     contributor2_profile = UserProfile(
-        category='amateur',
+        categories=['amateur'],
         locales=[DocumentLocale(title='...', lang='en')])
 
     contributor2 = User(

--- a/c2corg_api/tests/models/test_outing.py
+++ b/c2corg_api/tests/models/test_outing.py
@@ -1,0 +1,41 @@
+from c2corg_api.models.outing import Outing, OutingLocale
+
+from c2corg_api.tests import BaseTestCase
+
+
+class TestOuting(BaseTestCase):
+
+    def test_to_archive(self):
+        outing = Outing(
+            document_id=1, activities=['skitouring'],
+            elevation_max=1200,
+            locales=[
+                OutingLocale(
+                    id=2, lang='en', title='A', description='abc',
+                    route_description='...'),
+                OutingLocale(
+                    id=3, lang='fr', title='B', description='bcd',
+                    route_description='...'),
+            ]
+        )
+
+        outing_archive = outing.to_archive()
+
+        self.assertIsNone(outing_archive.id)
+        self.assertEqual(outing_archive.document_id, outing.document_id)
+        self.assertEqual(
+            outing_archive.activities, outing.activities)
+        self.assertEqual(outing_archive.elevation_max, outing.elevation_max)
+
+        archive_locals = outing.get_archive_locales()
+
+        self.assertEqual(len(archive_locals), 2)
+        locale = outing.locales[0]
+        locale_archive = archive_locals[0]
+        self.assertIsNot(locale_archive, locale)
+        self.assertIsNone(locale_archive.id)
+        self.assertEqual(locale_archive.lang, locale.lang)
+        self.assertEqual(locale_archive.title, locale.title)
+        self.assertEqual(locale_archive.description, locale.description)
+        self.assertEqual(
+            locale_archive.route_description, locale.route_description)

--- a/c2corg_api/tests/test_fields.py
+++ b/c2corg_api/tests/test_fields.py
@@ -2,6 +2,8 @@ import unittest
 
 from c2corg_api.models.user_profile import UserProfile
 from c2corg_common.fields_user_profile import fields_user_profile
+from c2corg_api.models.outing import Outing, OutingLocale
+from c2corg_common.fields_outing import fields_outing
 from c2corg_common.fields_waypoint import fields_waypoint
 from c2corg_common.fields_route import fields_route
 from c2corg_common.attributes import waypoint_types, activities
@@ -40,6 +42,15 @@ class TestFields(unittest.TestCase):
         self._test_fields(fields.get('fields'), model, model_locale)
         self._test_fields(fields.get('required'), model, model_locale)
         self._test_fields(fields.get('listing'), model, model_locale)
+
+    def test_outing_fields(self):
+        """Test that the fields listed for a outing activity are correct.
+        """
+        for type in fields_outing:
+            self.assertIn(
+                type, activities, 'invalid outing type: %s' % (type))
+            self._test_fields_for_type(
+                type, fields_outing, Outing, OutingLocale)
 
     def _test_fields_for_type(
             self, waypoint_type, fields, model, model_locale):

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -223,7 +223,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertGreater(len(errors), 0)
         return body
 
-    def post_missing_title(self, request_body, user='contributor'):
+    def post_missing_title(self, request_body, user='contributor', prefix=''):
         response = self.app.post_json(self._prefix, request_body,
                                       expect_errors=True, status=403)
 
@@ -235,7 +235,7 @@ class BaseDocumentTestRest(BaseTestRest):
         body = response.json
         self.assertEqual(body.get('status'), 'error')
         errors = body.get('errors')
-        self.assertCorniceRequired(errors[0], 'locales.0.title')
+        self.assertCorniceRequired(errors[0], prefix + 'locales.0.title')
         return body
 
     def post_missing_geometry(self, request_body):

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -35,6 +35,25 @@ class TestOutingRest(BaseDocumentTestRest):
         author = doc4['author']
         self.assertEqual(author['username'], 'contributor')
         self.assertEqual(author['user_id'], self.global_userids['contributor'])
+        self._add_test_data()
+
+    def test_get_collection_for_route(self):
+        response = self.app.get(
+            self._prefix + '?r=' + str(self.route.document_id), status=200)
+
+        documents = response.json['documents']
+
+        self.assertEqual(documents[0]['document_id'], self.outing.document_id)
+        self.assertEqual(response.json['total'], 1)
+
+    def test_get_collection_for_waypoint(self):
+        response = self.app.get(
+            self._prefix + '?wp=' + str(self.waypoint.document_id), status=200)
+
+        documents = response.json['documents']
+
+        self.assertEqual(documents[0]['document_id'], self.outing.document_id)
+        self.assertEqual(response.json['total'], 1)
 
     def test_get_collection_paginated(self):
         self.app.get("/outings?offset=invalid", status=400)
@@ -710,6 +729,9 @@ class TestOutingRest(BaseDocumentTestRest):
             gear='paraglider'))
         self.session.add(self.route)
         self.session.flush()
+        self.session.add(Association(
+            parent_document_id=self.waypoint.document_id,
+            child_document_id=self.route.document_id))
         self.session.add(Association(
             parent_document_id=self.route.document_id,
             child_document_id=self.outing.document_id))

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -25,9 +25,16 @@ class TestOutingRest(BaseDocumentTestRest):
 
     def test_get_collection(self):
         body = self.get_collection()
-        doc = body['documents'][0]
-        self.assertNotIn('frequentation', doc)
-        self.assertNotIn('duration_difficulties', doc)
+        self.assertEqual(len(body['documents']), 4)
+        doc1 = body['documents'][0]
+        self.assertNotIn('frequentation', doc1)
+        self.assertNotIn('duration_difficulties', doc1)
+
+        doc4 = body['documents'][3]
+        self.assertIn('author', doc4)
+        author = doc4['author']
+        self.assertEqual(author['username'], 'contributor')
+        self.assertEqual(author['user_id'], self.global_userids['contributor'])
 
     def test_get_collection_paginated(self):
         self.app.get("/outings?offset=invalid", status=400)
@@ -65,9 +72,14 @@ class TestOutingRest(BaseDocumentTestRest):
         associations = body.get('associations')
 
         linked_routes = associations.get('routes')
-        self.assertEqual(1, len(linked_routes))
+        self.assertEqual(len(linked_routes), 1)
         self.assertEqual(
             self.route.document_id, linked_routes[0].get('document_id'))
+
+        linked_users = associations.get('users')
+        self.assertEqual(len(linked_users), 1)
+        self.assertEqual(
+            linked_users[0]['id'], self.global_userids['contributor'])
 
     def test_get_version(self):
         self.get_version(self.outing, self.outing_version)

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -1,0 +1,569 @@
+import datetime
+import json
+
+from c2corg_api.models.association import Association
+from c2corg_api.models.document_history import DocumentVersion
+from c2corg_api.models.outing import Outing, ArchiveOuting, \
+    ArchiveOutingLocale, OutingLocale
+from c2corg_api.models.waypoint import Waypoint, WaypointLocale
+from shapely.geometry import shape, LineString
+
+from c2corg_api.models.route import Route, RouteLocale
+from c2corg_api.models.document import DocumentGeometry
+from c2corg_api.views.document import DocumentRest
+
+from c2corg_api.tests.views import BaseDocumentTestRest
+
+
+class TestOutingRest(BaseDocumentTestRest):
+
+    def setUp(self):  # noqa
+        self.set_prefix_and_model(
+            '/outings', Outing, ArchiveOuting, ArchiveOutingLocale)
+        BaseDocumentTestRest.setUp(self)
+        self._add_test_data()
+
+    def test_get_collection(self):
+        body = self.get_collection()
+        doc = body['documents'][0]
+        self.assertNotIn('frequentation', doc)
+        self.assertNotIn('duration_difficulties', doc)
+
+    def test_get_collection_paginated(self):
+        self.app.get("/outings?offset=invalid", status=400)
+
+        self.assertResultsEqual(
+            self.get_collection({'offset': 0, 'limit': 0}), [], 4)
+
+        self.assertResultsEqual(
+            self.get_collection({'offset': 0, 'limit': 1}),
+            [self.outing4.document_id], 4)
+        self.assertResultsEqual(
+            self.get_collection({'offset': 0, 'limit': 2}),
+            [self.outing4.document_id, self.outing3.document_id], 4)
+        self.assertResultsEqual(
+            self.get_collection({'offset': 1, 'limit': 2}),
+            [self.outing3.document_id, self.outing2.document_id], 4)
+
+        self.assertResultsEqual(
+            self.get_collection(
+                {'after': self.outing3.document_id, 'limit': 1}),
+            [self.outing2.document_id], -1)
+
+    def test_get_collection_lang(self):
+        self.get_collection_lang()
+
+    def test_get(self):
+        body = self.get(self.outing)
+        self.assertEqual(
+            body.get('activities'), self.outing.activities)
+        self._assert_geometry(body)
+        self.assertNotIn('duration_difficulties', body)
+        self.assertIn('frequentation', body)
+
+        self.assertIn('associations', body)
+        associations = body.get('associations')
+
+        linked_waypoints = associations.get('waypoints')
+        self.assertEqual(1, len(linked_waypoints))
+        self.assertEqual(
+            self.waypoint.document_id, linked_waypoints[0].get('document_id'))
+
+        linked_routes = associations.get('routes')
+        self.assertEqual(1, len(linked_routes))
+        self.assertEqual(
+            self.route.document_id, linked_routes[0].get('document_id'))
+
+    def test_get_version(self):
+        self.get_version(self.outing, self.outing_version)
+
+    def test_get_lang(self):
+        self.get_lang(self.outing)
+
+    def test_get_new_lang(self):
+        self.get_new_lang(self.outing)
+
+    def test_get_404(self):
+        self.get_404()
+
+    def test_post_error(self):
+        body = self.post_error({})
+        errors = body.get('errors')
+        self.assertEqual(len(errors), 3)
+        self.assertCorniceMissing(errors[0], 'outing')
+        self.assertCorniceMissing(errors[1], 'waypoint_id')
+        self.assertCorniceMissing(errors[2], 'route_id')
+
+    def test_post_empty_activities_error(self):
+        body = self.post_error({
+            'outing': {
+                'activities': [],
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-02'
+            },
+            'waypoint_id': self.waypoint.document_id,
+            'route_id': self.route.document_id
+        })
+        errors = body.get('errors')
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(
+            errors[0].get('description'), 'Shorter than minimum length 1')
+        self.assertEqual(errors[0].get('name'), 'outing.activities')
+
+    def test_post_invalid_activity(self):
+        body_post = {
+            'outing': {
+                'activities': ['cooking'],
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-02',
+                'elevation_min': 700,
+                'elevation_max': 1500,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'geometry': {
+                    'id': 5678, 'version': 6789,
+                    'geom': '{"type": "LineString", "coordinates": ' +
+                            '[[635956, 5723604], [635966, 5723644]]}'
+                },
+                'locales': [
+                    {'lang': 'en', 'title': 'Some nice loop'}
+                ]
+            },
+            'waypoint_id': self.waypoint.document_id,
+            'route_id': self.route.document_id
+        }
+        body = self.post_error(body_post)
+        errors = body.get('errors')
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(
+            errors[0].get('description'), 'invalid value: cooking')
+        self.assertEqual(errors[0].get('name'), 'activities')
+
+    def test_post_missing_title(self):
+        body_post = {
+            'outing': {
+                'activities': ['skitouring'],
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-02',
+                'elevation_min': 700,
+                'elevation_max': 1500,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'geometry': {
+                    'id': 5678, 'version': 6789,
+                    'geom': '{"type": "LineString", "coordinates": ' +
+                            '[[635956, 5723604], [635966, 5723644]]}'
+                },
+                'locales': [
+                    {'lang': 'en'}
+                ]
+            },
+            'waypoint_id': self.waypoint.document_id,
+            'route_id': self.route.document_id
+        }
+        body = self.post_missing_title(body_post, prefix='outing.')
+        errors = body.get('errors')
+        self.assertEqual(len(errors), 1)
+
+    def test_post_non_whitelisted_attribute(self):
+        body = {
+            'outing': {
+                'activities': ['skitouring'],
+                'protected': True,
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-02',
+                'elevation_min': 700,
+                'elevation_max': 1500,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'geometry': {
+                    'id': 5678, 'version': 6789,
+                    'geom': '{"type": "LineString", "coordinates": ' +
+                            '[[635956, 5723604], [635966, 5723644]]}'
+                },
+                'locales': [
+                    {'lang': 'en', 'title': 'Some nice loop',
+                     'weather': 'sunny'}
+                ]
+            },
+            'waypoint_id': self.waypoint.document_id,
+            'route_id': self.route.document_id
+        }
+        self.post_non_whitelisted_attribute(body)
+
+    def test_post_missing_content_type(self):
+        self.post_missing_content_type({})
+
+    def test_post_success(self):
+        body = {
+            'outing': {
+                'activities': ['skitouring'],
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-02',
+                'elevation_min': 700,
+                'elevation_max': 1500,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'geometry': {
+                    'id': 5678, 'version': 6789,
+                    'geom': '{"type": "LineString", "coordinates": ' +
+                            '[[635956, 5723604], [635966, 5723644]]}'
+                },
+                'locales': [
+                    {'lang': 'en', 'title': 'Some nice loop',
+                     'weather': 'sunny'}
+                ]
+            },
+            'waypoint_id': self.waypoint.document_id,
+            'route_id': self.route.document_id
+        }
+        body, doc = self.post_success(body)
+        self._assert_geometry(body)
+
+        version = doc.versions[0]
+
+        archive_outing = version.document_archive
+        self.assertEqual(archive_outing.activities, ['skitouring'])
+        self.assertEqual(archive_outing.elevation_max, 1500)
+
+        archive_locale = version.document_locales_archive
+        self.assertEqual(archive_locale.lang, 'en')
+        self.assertEqual(archive_locale.title, 'Some nice loop')
+
+        archive_geometry = version.document_geometry_archive
+        self.assertEqual(archive_geometry.version, doc.geometry.version)
+        self.assertIsNotNone(archive_geometry.geom)
+
+    def test_put_wrong_document_id(self):
+        body = {
+            'document': {
+                'document_id': '-9999',
+                'version': self.outing.version,
+                'activities': ['skitouring'],
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-02',
+                'elevation_min': 700,
+                'elevation_max': 1600,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'locales': [
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
+                     'description': '...', 'weather': 'mostly sunny',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        self.put_wrong_document_id(body)
+
+    def test_put_wrong_document_version(self):
+        body = {
+            'document': {
+                'document_id': self.outing.document_id,
+                'version': -9999,
+                'activities': ['skitouring'],
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-02',
+                'elevation_min': 700,
+                'elevation_max': 1600,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'locales': [
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
+                     'description': '...', 'weather': 'mostly sunny',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        self.put_wrong_version(body, self.outing.document_id)
+
+    def test_put_wrong_locale_version(self):
+        body = {
+            'document': {
+                'document_id': self.outing.document_id,
+                'version': self.outing.version,
+                'activities': ['skitouring'],
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-02',
+                'elevation_min': 700,
+                'elevation_max': 1600,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'locales': [
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
+                     'description': '...', 'weather': 'mostly sunny',
+                     'version': -9999}
+                ]
+            }
+        }
+        self.put_wrong_version(body, self.outing.document_id)
+
+    def test_put_wrong_ids(self):
+        body = {
+            'document': {
+                'document_id': self.outing.document_id,
+                'version': self.outing.version,
+                'activities': ['skitouring'],
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-02',
+                'elevation_min': 700,
+                'elevation_max': 1600,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'locales': [
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
+                     'description': '...', 'weather': 'mostly sunny',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        self.put_wrong_ids(body, self.outing.document_id)
+
+    def test_put_no_document(self):
+        self.put_put_no_document(self.outing.document_id)
+
+    def test_put_success_all(self):
+        body = {
+            'message': 'Update',
+            'document': {
+                'document_id': self.outing.document_id,
+                'version': self.outing.version,
+                'activities': ['skitouring'],
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-02',
+                'elevation_min': 700,
+                'elevation_max': 1600,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'locales': [
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
+                     'description': '...', 'weather': 'mostly sunny',
+                     'version': self.locale_en.version}
+                ],
+                'geometry': {
+                    'version': self.outing.geometry.version,
+                    'geom': '{"type": "LineString", "coordinates": ' +
+                            '[[635956, 5723604], [635976, 5723654]]}'
+                }
+            }
+        }
+        (body, outing) = self.put_success_all(body, self.outing)
+
+        self.assertEquals(outing.elevation_max, 1600)
+        locale_en = outing.get_locale('en')
+        self.assertEquals(locale_en.description, '...')
+        self.assertEquals(locale_en.weather, 'mostly sunny')
+
+        # version with lang 'en'
+        versions = outing.versions
+        version_en = versions[2]
+        archive_locale = version_en.document_locales_archive
+        self.assertEqual(archive_locale.title, 'Mont Blanc from the air')
+        self.assertEqual(archive_locale.weather, 'mostly sunny')
+
+        archive_document_en = version_en.document_archive
+        self.assertEqual(archive_document_en.activities, ['skitouring'])
+        self.assertEqual(archive_document_en.elevation_max, 1600)
+
+        archive_geometry_en = version_en.document_geometry_archive
+        self.assertEqual(archive_geometry_en.version, 2)
+
+        # version with lang 'fr'
+        version_fr = versions[3]
+        archive_locale = version_fr.document_locales_archive
+        self.assertEqual(archive_locale.title, 'Mont Blanc du ciel')
+        self.assertEqual(archive_locale.weather, 'grand beau')
+
+    def test_put_success_figures_only(self):
+        body = {
+            'message': 'Changing figures',
+            'document': {
+                'document_id': self.outing.document_id,
+                'version': self.outing.version,
+                'activities': ['skitouring'],
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-01',
+                'elevation_min': 700,
+                'elevation_max': 1600,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'locales': [
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
+                     'description': '...', 'weather': 'sunny',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        (body, route) = self.put_success_figures_only(body, self.outing)
+
+        self.assertEquals(route.elevation_max, 1600)
+
+    def test_put_success_lang_only(self):
+        body = {
+            'message': 'Changing lang',
+            'document': {
+                'document_id': self.outing.document_id,
+                'version': self.outing.version,
+                'activities': ['skitouring'],
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-01',
+                'elevation_min': 700,
+                'elevation_max': 1500,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'locales': [
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
+                     'description': '...', 'weather': 'mostly sunny',
+                     'version': self.locale_en.version}
+                ]
+            }
+        }
+        (body, route) = self.put_success_lang_only(body, self.outing)
+
+        self.assertEquals(route.get_locale('en').weather, 'mostly sunny')
+
+    def test_put_success_new_lang(self):
+        """Test updating a document by adding a new locale.
+        """
+        body = {
+            'message': 'Adding lang',
+            'document': {
+                'document_id': self.outing.document_id,
+                'version': self.outing.version,
+                'activities': ['skitouring'],
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-01',
+                'elevation_min': 700,
+                'elevation_max': 1500,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'locales': [
+                    {'lang': 'es', 'title': 'Mont Blanc del cielo',
+                     'description': '...', 'weather': 'soleado'}
+                ]
+            }
+        }
+        (body, route) = self.put_success_new_lang(body, self.outing)
+
+        self.assertEquals(route.get_locale('es').weather, 'soleado')
+
+    def test_history(self):
+        id = self.outing.document_id
+        langs = ['fr', 'en']
+        for lang in langs:
+            body = self.app.get('/document/%d/history/%s' % (id, lang))
+            username = 'contributor'
+            user_id = self.global_userids[username]
+
+            title = body.json['title']
+            versions = body.json['versions']
+            self.assertEqual(len(versions), 1)
+            self.assertEqual(getattr(self, 'locale_' + lang).title, title)
+            for r in versions:
+                self.assertEqual(r['username'], username)
+                self.assertEqual(r['user_id'], user_id)
+                self.assertIn('written_at', r)
+                self.assertIn('version_id', r)
+
+    def test_history_no_lang(self):
+        id = self.outing.document_id
+        self.app.get('/document/%d/history/es' % id, status=404)
+
+    def test_history_no_doc(self):
+        self.app.get('/document/99999/history/es', status=404)
+
+    def _assert_geometry(self, body):
+        self.assertIsNotNone(body.get('geometry'))
+        geometry = body.get('geometry')
+        self.assertIsNotNone(geometry.get('version'))
+        self.assertIsNotNone(geometry.get('geom'))
+
+        geom = geometry.get('geom')
+        line = shape(json.loads(geom))
+        self.assertIsInstance(line, LineString)
+        self.assertAlmostEqual(line.coords[0][0], 635956)
+        self.assertAlmostEqual(line.coords[0][1], 5723604)
+        self.assertAlmostEqual(line.coords[1][0], 635966)
+        self.assertAlmostEqual(line.coords[1][1], 5723644)
+
+    def _add_test_data(self):
+        self.outing = Outing(
+            activities=['skitouring'], date_start=datetime.date(2016, 1, 1),
+            date_end=datetime.date(2016, 1, 1), elevation_max=1500,
+            elevation_min=700, height_diff_up=800, height_diff_down=800
+        )
+        self.locale_en = OutingLocale(
+            lang='en', title='Mont Blanc from the air', description='...',
+            weather='sunny')
+
+        self.locale_fr = OutingLocale(
+            lang='fr', title='Mont Blanc du ciel', description='...',
+            weather='grand beau')
+
+        self.outing.locales.append(self.locale_en)
+        self.outing.locales.append(self.locale_fr)
+
+        self.outing.geometry = DocumentGeometry(
+            geom='SRID=3857;LINESTRING(635956 5723604, 635966 5723644)')
+
+        self.session.add(self.outing)
+        self.session.flush()
+
+        user_id = self.global_userids['contributor']
+        DocumentRest(None)._create_new_version(self.outing, user_id)
+        self.outing_version = self.session.query(DocumentVersion). \
+            filter(DocumentVersion.document_id == self.outing.document_id). \
+            filter(DocumentVersion.lang == 'en').first()
+
+        self.outing2 = Outing(
+            activities=['skitouring'], date_start=datetime.date(2016, 1, 1),
+            date_end=datetime.date(2016, 1, 1)
+        )
+        self.session.add(self.outing2)
+        self.outing3 = Outing(
+            activities=['skitouring'], date_start=datetime.date(2016, 1, 1),
+            date_end=datetime.date(2016, 1, 1)
+        )
+        self.session.add(self.outing3)
+        self.outing4 = Outing(
+            activities=['skitouring'], date_start=datetime.date(2016, 1, 1),
+            date_end=datetime.date(2016, 1, 1)
+        )
+        self.outing4.locales.append(OutingLocale(
+            lang='en', title='Mont Granier (en)', description='...'))
+        self.outing4.locales.append(OutingLocale(
+            lang='fr', title='Mont Granier (fr)', description='...'))
+        self.session.add(self.outing4)
+
+        # add some associations
+        self.waypoint = Waypoint(
+            waypoint_type='summit', elevation=4,
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POINT(635956 5723604)'))
+        self.waypoint.locales.append(WaypointLocale(
+            lang='en', title='Mont Granier (en)', description='...',
+            access='yep'))
+        self.waypoint.locales.append(WaypointLocale(
+            lang='fr', title='Mont Granier (fr)', description='...',
+            access='ouai'))
+        self.session.add(self.waypoint)
+        self.session.flush()
+        self.session.add(Association(
+            parent_document_id=self.waypoint.document_id,
+            child_document_id=self.outing.document_id))
+        self.session.flush()
+
+        self.route = Route(
+            activities=['skitouring'], elevation_max=1500, elevation_min=700,
+            height_diff_up=800, height_diff_down=800, durations='1')
+        self.route.locales.append(RouteLocale(
+            lang='en', title='Mont Blanc from the air', description='...',
+            gear='paraglider', title_prefix='Main waypoint title'))
+        self.route.locales.append(RouteLocale(
+            lang='fr', title='Mont Blanc du ciel', description='...',
+            gear='paraglider'))
+        self.session.add(self.route)
+        self.session.flush()
+        self.session.add(Association(
+            parent_document_id=self.route.document_id,
+            child_document_id=self.outing.document_id))
+        self.session.flush()

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -1,7 +1,9 @@
+import datetime
 import json
 
 from c2corg_api.models.association import Association
 from c2corg_api.models.document_history import DocumentVersion
+from c2corg_api.models.outing import Outing, OutingLocale
 from c2corg_api.models.waypoint import Waypoint, WaypointLocale
 from c2corg_api.views.route import update_title_prefix
 from shapely.geometry import shape, LineString
@@ -77,6 +79,13 @@ class TestRouteRest(BaseDocumentTestRest):
         self.assertEqual(1, len(linked_routes))
         self.assertEqual(
             self.route4.document_id, linked_routes[0].get('document_id'))
+
+        recent_outings = associations.get('recent_outings')
+        self.assertEqual(1, recent_outings['total'])
+        self.assertEqual(1, len(recent_outings['outings']))
+        self.assertEqual(
+            self.outing.document_id,
+            recent_outings['outings'][0].get('document_id'))
 
     def test_get_version(self):
         self.get_version(self.route, self.route_version)
@@ -582,4 +591,19 @@ class TestRouteRest(BaseDocumentTestRest):
         self.session.add(Association(
             parent_document_id=self.waypoint.document_id,
             child_document_id=self.route.document_id))
+
+        self.outing = Outing(
+            activities=['skitouring'], date_start=datetime.date(2016, 1, 1),
+            date_end=datetime.date(2016, 1, 1),
+            locales=[
+                OutingLocale(
+                    lang='en', title='...', description='...',
+                    weather='sunny')
+            ]
+        )
+        self.session.add(self.outing)
+        self.session.flush()
+        self.session.add(Association(
+            parent_document_id=self.route.document_id,
+            child_document_id=self.outing.document_id))
         self.session.flush()

--- a/c2corg_api/tests/views/test_user_profile.py
+++ b/c2corg_api/tests/views/test_user_profile.py
@@ -31,20 +31,20 @@ class TestUserProfileRest(BaseDocumentTestRest):
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 0, 'limit': 0}, user='contributor'),
-            [], 6)
+            [], 7)
 
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 0, 'limit': 1}, user='contributor'),
-            [self.profile4.document_id], 6)
+            [self.profile4.document_id], 7)
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 0, 'limit': 2}, user='contributor'),
-            [self.profile4.document_id, self.profile3.document_id], 6)
+            [self.profile4.document_id, self.profile3.document_id], 7)
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 1, 'limit': 2}, user='contributor'),
-            [self.profile3.document_id, self.profile2.document_id], 6)
+            [self.profile3.document_id, self.profile2.document_id], 7)
 
         self.assertResultsEqual(
             self.get_collection(

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -77,7 +77,7 @@ def to_json_dict(obj, schema):
     # cleaner to add the field to the schema, but ColanderAlchemy doesn't like
     # it because it's not a real column)
     special_attributes = [
-        'available_langs', 'associations', 'maps', 'areas'
+        'available_langs', 'associations', 'maps', 'areas', 'author'
     ]
     for attr in special_attributes:
         if hasattr(obj, attr):

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -28,6 +28,9 @@ LIMIT_MAX = 100
 # listing request)
 LIMIT_DEFAULT = 30
 
+# the number of recent outings that are included for waypoint and routes
+NUM_RECENT_OUTINGS = 10
+
 
 class DocumentRest(object):
 

--- a/c2corg_api/views/outing.py
+++ b/c2corg_api/views/outing.py
@@ -1,0 +1,68 @@
+from c2corg_api.models.outing import schema_outing, Outing, \
+    schema_create_outing, schema_update_outing, ArchiveOuting, \
+    ArchiveOutingLocale
+from c2corg_common.fields_outing import fields_outing
+from cornice.resource import resource, view
+
+
+from c2corg_api.models.schema_utils import restrict_schema
+from c2corg_api.views.document import DocumentRest, make_validator_create, \
+    make_validator_update, make_schema_adaptor, get_all_fields
+from c2corg_api.views import cors_policy, restricted_json_view
+from c2corg_api.views.validation import validate_id, validate_pagination, \
+    validate_lang, validate_version_id, validate_lang_param, \
+    validate_preferred_lang_param
+from c2corg_common.attributes import activities
+
+validate_route_create = make_validator_create(
+    fields_outing, 'activities', activities, document_field='outing')
+validate_outing_update = make_validator_update(
+    fields_outing, 'activities', activities)
+
+
+def adapt_schema_for_activities(activities, field_list_type):
+    """Get the schema for a set of activities.
+    `field_list_type` should be either "fields" or "listing".
+    """
+    fields = get_all_fields(fields_outing, activities, field_list_type)
+    return restrict_schema(schema_outing, fields)
+
+
+schema_adaptor = make_schema_adaptor(
+    adapt_schema_for_activities, 'activities', 'fields')
+listing_schema_adaptor = make_schema_adaptor(
+    adapt_schema_for_activities, 'activities', 'listing')
+
+
+@resource(collection_path='/outings', path='/outings/{id}',
+          cors_policy=cors_policy)
+class OutingRest(DocumentRest):
+
+    @view(validators=[validate_pagination, validate_preferred_lang_param])
+    def collection_get(self):
+        return self._collection_get(
+            Outing, schema_outing, listing_schema_adaptor)
+
+    @view(validators=[validate_id, validate_lang_param])
+    def get(self):
+        return self._get(Outing, schema_outing, schema_adaptor)
+
+    @restricted_json_view(schema=schema_create_outing,
+                          validators=validate_route_create)
+    def collection_post(self):
+        # TODO set up associations in after_add
+        return self._collection_post(schema_outing, document_field='outing')
+
+    @restricted_json_view(schema=schema_update_outing,
+                          validators=[validate_id, validate_outing_update])
+    def put(self):
+        return self._put(Outing, schema_outing)
+
+
+@resource(path='/outings/{id}/{lang}/{version_id}', cors_policy=cors_policy)
+class OutingVersionRest(DocumentRest):
+
+    @view(validators=[validate_id, validate_lang, validate_version_id])
+    def get(self):
+        return self._get_version(
+            ArchiveOuting, ArchiveOutingLocale, schema_outing, schema_adaptor)

--- a/c2corg_api/views/route.py
+++ b/c2corg_api/views/route.py
@@ -9,7 +9,8 @@ from c2corg_api.models.route import Route, schema_route, schema_update_route, \
     ArchiveRoute, ArchiveRouteLocale, RouteLocale
 from c2corg_api.models.schema_utils import restrict_schema
 from c2corg_api.views.document import DocumentRest, make_validator_create, \
-    make_validator_update, make_schema_adaptor, get_all_fields
+    make_validator_update, make_schema_adaptor, get_all_fields, \
+    NUM_RECENT_OUTINGS
 from c2corg_api.views import cors_policy, restricted_json_view, \
     get_best_locale, to_json_dict, set_best_locale
 from c2corg_api.views.validation import validate_id, validate_pagination, \
@@ -71,7 +72,7 @@ class RouteRest(DocumentRest):
         recent_outings = DBSession.query(Outing). \
             join(
                 Association,
-            Outing.document_id == Association.child_document_id). \
+                Outing.document_id == Association.child_document_id). \
             filter(Association.parent_document_id == route.document_id). \
             options(load_only(
                 Outing.document_id, Outing.activities, Outing.date_start,
@@ -79,8 +80,8 @@ class RouteRest(DocumentRest):
             options(joinedload(Outing.locales).load_only(
                 DocumentLocale.lang, DocumentLocale.title,
                 DocumentLocale.version)). \
-            order_by(Outing.date_end). \
-            limit(10). \
+            order_by(Outing.date_end.desc()). \
+            limit(NUM_RECENT_OUTINGS). \
             all()
 
         set_author(recent_outings, None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ git+https://github.com/tsauerwein/ColanderAlchemy.git@c2corg
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@e3dd6883b0f18a30add9019e3aa5dde5b0335564
+git+https://github.com/c2corg/v6_common.git@b6e2b35
 
 # Discourse API client
 git+https://github.com/c2corg/pydiscourse.git@65e398343bbbc74fdb71cca4637c9f808e5adfb2


### PR DESCRIPTION
TODO

* [x] Include associated users in response
* [x] Make it possible to include associated users when creating an outing
* [x] Check that only associated users or moderators can edit an outing
* [x] Create associations for linked waypoint and route when creating an outing
* [x] Include associated outings for waypoints and routes (maybe the latest 10?)
* [x] Add new web-service to get all associated outings for a document (paginated, for [this page](http://www.camptocamp.org/outings/list/summits/41165/orderby/date/order/desc))
* [x] Check that associations between users and outings are migrated
* [x] Check if the association between outing and waypoint is needed (it seems in v5 there are no associations between outings and waypoints)

Requires #156 