### PR TITLE
Add `name` field to user model

### DIFF
--- a/c2corg_api/models/user.py
+++ b/c2corg_api/models/user.py
@@ -51,6 +51,7 @@ class User(Base):
         UserProfile, primaryjoin=id == UserProfile.document_id, backref='user')
 
     username = Column(String(200), nullable=False, unique=True)
+    name = Column(String(200))
     email = Column(String(200), nullable=False, unique=True)
     email_validated = Column(Boolean, nullable=False, default=False)
     moderator = Column(Boolean, nullable=False, default=False)
@@ -98,7 +99,7 @@ schema_user = SQLAlchemySchemaNode(
     User,
     # whitelisted attributes
     includes=[
-        'id', 'username', 'email', 'email_validated', 'moderator'],
+        'id', 'username', 'name', 'email', 'email_validated', 'moderator'],
     overrides={
         'id': {
             'missing': None
@@ -109,7 +110,7 @@ schema_user = SQLAlchemySchemaNode(
 schema_create_user = SQLAlchemySchemaNode(
     User,
     # whitelisted attributes
-    includes=['username', 'email'],
+    includes=['username', 'name', 'email'],
     overrides={
         'email': {
             'validator': colander.Email()
@@ -117,5 +118,5 @@ schema_create_user = SQLAlchemySchemaNode(
     })
 
 schema_association_user = restrict_schema(schema_user, [
-    'id', 'username'
+    'id', 'username', 'name'
 ])

--- a/c2corg_api/models/user_profile.py
+++ b/c2corg_api/models/user_profile.py
@@ -1,7 +1,7 @@
 from c2corg_api.models import schema
 from c2corg_api.models.document import (
     ArchiveDocument, Document, get_update_schema, geometry_schema_overrides,
-    schema_document_locale, schema_attributes)
+    schema_document_locale, schema_attributes, DocumentLocale)
 from c2corg_api.models.enums import user_category, activity_type
 from c2corg_api.models.schema_utils import restrict_schema
 from c2corg_api.models.utils import copy_attributes, ArrayOfEnum
@@ -65,7 +65,38 @@ class ArchiveUserProfile(_UserProfileMixin, ArchiveDocument):
     }
 
 
+# user profiles use a special schema for the locales which ignores the 'title'
+# attribute (user profiles do not have a title).
+schema_user_profile_locale = SQLAlchemySchemaNode(
+    DocumentLocale,
+    # whitelisted attributes (without 'title')
+    includes=['version', 'lang', 'description', 'summary'],
+    overrides={
+        'version': {
+            'missing': None
+        }
+    })
+
+
 schema_user_profile = SQLAlchemySchemaNode(
+    UserProfile,
+    # whitelisted attributes
+    includes=schema_attributes + attributes,
+    overrides={
+        'document_id': {
+            'missing': None
+        },
+        'version': {
+            'missing': None
+        },
+        'locales': {
+            'children': [schema_user_profile_locale]
+        },
+        'geometry': geometry_schema_overrides
+    })
+
+
+schema_internal_user_profile = SQLAlchemySchemaNode(
     UserProfile,
     # whitelisted attributes
     includes=schema_attributes + attributes,

--- a/c2corg_api/scripts/migration/documents/user_profiles.py
+++ b/c2corg_api/scripts/migration/documents/user_profiles.py
@@ -52,7 +52,7 @@ class MigrateUserProfiles(MigrateDocuments):
         return (
             'select '
             '   id, document_i18n_archive_id, is_latest_version, culture, '
-            '   name, description '
+            '   description '
             'from app_users_i18n_archives '
             'order by id, document_i18n_archive_id;'
         )
@@ -128,7 +128,11 @@ class MigrateUserProfiles(MigrateDocuments):
             type=DOCUMENT_TYPE,
             version=version,
             lang=document_in.culture,
-            title=document_in.name,
+            # do not set the title (in v5 the title of an user profile was the
+            # topo-guide username. this name was also stored on the user itself
+            # and was copied to the locale when it was changed. to simplify
+            # things, the name is now only stored on the user.)
+            title='',
             description=description,
             summary=summary
         )

--- a/c2corg_api/scripts/migration/users.py
+++ b/c2corg_api/scripts/migration/users.py
@@ -26,7 +26,7 @@ class MigrateUsers(MigrateBase):
 
         print('Total: {0} rows'.format(total_count))
 
-        query = text('select id, login_name, email, '
+        query = text('select id, login_name, topo_name, email, '
                      'password, password_tmp '
                      'from app_users_private_data order by id')
 
@@ -63,6 +63,7 @@ class MigrateUsers(MigrateBase):
                 batch.add(dict(
                     id=user_in.id,
                     username=username,
+                    name=user_in.topo_name,
                     email=user_in.email,
                     _password=user_in.password,
                     temp_password=user_in.password_tmp,

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -47,7 +47,7 @@ def _add_global_test_data(session):
 
     contributor_profile = UserProfile(
         categories=['amateur'],
-        locales=[DocumentLocale(title='...', lang='en')])
+        locales=[DocumentLocale(title='', lang='en')])
 
     contributor = User(
         username='contributor', email='contributor@camptocamp.org',
@@ -65,7 +65,7 @@ def _add_global_test_data(session):
 
     moderator_profile = UserProfile(
         categories=['mountain_guide'],
-        locales=[DocumentLocale(title='...', lang='en')])
+        locales=[DocumentLocale(title='', lang='en')])
 
     moderator = User(
         username='moderator', email='moderator@camptocamp.org',

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -51,7 +51,7 @@ def _add_global_test_data(session):
 
     contributor = User(
         username='contributor', email='contributor@camptocamp.org',
-        password='super pass',
+        password='super pass', name='Contributor',
         profile=contributor_profile)
 
     contributor2_profile = UserProfile(

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -126,7 +126,7 @@ class BaseDocumentTestRest(BaseTestRest):
         actual_total = actual['total']
         self.assertEqual(actual_total, total)
 
-    def get(self, reference, user=None):
+    def get(self, reference, user=None, check_title=True):
         headers = {} if not user else \
             self.add_authorization_header(username=user)
         response = self.app.get(self._prefix + '/' +
@@ -146,7 +146,8 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertNotIn('id', locale_en)
         self.assertIsNotNone(locale_en.get('version'))
         self.assertEqual(locale_en.get('lang'), self.locale_en.lang)
-        self.assertEqual(locale_en.get('title'), self.locale_en.title)
+        if check_title:
+            self.assertEqual(locale_en.get('title'), self.locale_en.title)
 
         available_langs = body.get('available_langs')
         self.assertEqual(available_langs, ['en', 'fr'])

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -34,6 +34,7 @@ class TestOutingRest(BaseDocumentTestRest):
         self.assertIn('author', doc4)
         author = doc4['author']
         self.assertEqual(author['username'], 'contributor')
+        self.assertEqual(author['name'], 'Contributor')
         self.assertEqual(author['user_id'], self.global_userids['contributor'])
         self._add_test_data()
 

--- a/c2corg_api/tests/views/test_user.py
+++ b/c2corg_api/tests/views/test_user.py
@@ -17,6 +17,7 @@ class TestUserRest(BaseTestRest):
     def test_register(self):
         request_body = {
             'username': 'test',
+            'name': 'Max Mustermann',
             'password': 'super secret',
             'email': 'some_user@camptocamp.org'
         }
@@ -25,6 +26,7 @@ class TestUserRest(BaseTestRest):
         # First succeed in creating a new user
         body = self.app.post_json(url, request_body, status=200).json
         self.assertBodyEqual(body, 'username', 'test')
+        self.assertBodyEqual(body, 'name', 'Max Mustermann')
         self.assertBodyEqual(body, 'email', 'some_user@camptocamp.org')
         self.assertNotIn('password', body)
         self.assertIn('id', body)

--- a/c2corg_api/views/outing.py
+++ b/c2corg_api/views/outing.py
@@ -199,8 +199,9 @@ def set_author(outings, lang):
 
     t = DBSession.query(
         ArchiveDocument.document_id.label('document_id'),
-        User.username.label('username'),
         User.id.label('user_id'),
+        User.username.label('username'),
+        User.name.label('name'),
         over(
             func.rank(), partition_by=ArchiveDocument.document_id,
             order_by=HistoryMetaData.id).label('rank')). \
@@ -217,14 +218,15 @@ def set_author(outings, lang):
         filter(ArchiveDocument.document_id.in_(outing_ids)). \
         subquery('t')
     query = DBSession.query(
-            t.c.document_id, t.c.user_id, t.c.username). \
+            t.c.document_id, t.c.user_id, t.c.username, t.c.name). \
         filter(t.c.rank == 1)
 
     author_for_outings = {
         document_id: {
             'username': username,
+            'name': name,
             'user_id': user_id
-        } for document_id, user_id, username in query
+        } for document_id, user_id, username, name in query
     }
 
     for outing in outings:

--- a/c2corg_api/views/user.py
+++ b/c2corg_api/views/user.py
@@ -104,7 +104,7 @@ class UserRegistrationRest(object):
         # we can create the profile in that language.
         user.profile = UserProfile(
             categories=['amateur'],
-            locales=[DocumentLocale(lang='fr', title=user.username)]
+            locales=[DocumentLocale(lang='fr', title='')]
         )
 
         DBSession.add(user)

--- a/c2corg_api/views/user_profile.py
+++ b/c2corg_api/views/user_profile.py
@@ -1,6 +1,6 @@
 
 from c2corg_api.models.user_profile import schema_update_user_profile, \
-    UserProfile, schema_user_profile
+    UserProfile, schema_user_profile, schema_internal_user_profile
 from cornice.resource import resource
 
 from c2corg_api.views.document import DocumentRest
@@ -35,4 +35,16 @@ class UserProfileRest(DocumentRest):
                 raise HTTPForbidden(
                     'No permission to change this user profile')
 
-        return self._put(UserProfile, schema_user_profile)
+        self._reset_title()
+
+        return self._put(UserProfile, schema_internal_user_profile)
+
+    def _reset_title(self):
+        """The title of user profile documents is left empty. Because the title
+        must be non-null it is set to an empty string though.
+        """
+        document = self.request.validated['document']
+        locales = document.get('locales')
+        if locales:
+            for locale in locales:
+                locale['title'] = ''


### PR DESCRIPTION
In v5 the "topo_name" of an user was stored on the user, but also as title of the user profile (updated by a trigger). For simplicity the name is now only stored on the user.

Closes https://github.com/c2corg/v6_api/issues/163