### PR TITLE
Create association to main waypoint when creating/updating route

### DIFF
--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -46,6 +46,14 @@ class Association(Base):
         Base.__table_args__
     )
 
+    def get_log(self, user_id, is_creation=True):
+        return AssociationLog(
+            parent_document_id=self.parent_document_id,
+            child_document_id=self.child_document_id,
+            user_id=user_id,
+            is_creation=is_creation
+        )
+
 
 class AssociationLog(Base):
     """Model to log when an association between documents was established or
@@ -136,3 +144,39 @@ def get_associations(document, lang):
         set_best_locale(routes, lang)
 
     return parent_waypoints + child_waypoints, routes
+
+
+def exists_already(link):
+    """ Checks if the given association exists already. For example, for
+    two given documents D1 and D2, it checks if there is no association
+    D1 -> D2 or D2 -> D1.
+    """
+    associations_exists = DBSession.query(Association). \
+        filter(or_(
+            and_(
+                Association.parent_document_id == link.parent_document_id,
+                Association.child_document_id == link.child_document_id
+            ),
+            and_(
+                Association.child_document_id == link.parent_document_id,
+                Association.parent_document_id == link.child_document_id
+            )
+        )). \
+        exists()
+    return DBSession.query(associations_exists).scalar()
+
+
+def add_association(
+        parent_document_id, child_document_id, user_id, check_first=False):
+    """Create an association between the two documents and create a log entry
+    in the association history table with the given user id.
+    """
+    association = Association(
+        parent_document_id=parent_document_id,
+        child_document_id=child_document_id)
+
+    if check_first and exists_already(association):
+        return
+
+    DBSession.add(association)
+    DBSession.add(association.get_log(user_id, is_creation=True))

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 
-from c2corg_api.models.association import Association
+from c2corg_api.models.association import Association, AssociationLog
 from c2corg_api.models.document_history import DocumentVersion
 from c2corg_api.models.outing import Outing, ArchiveOuting, \
     ArchiveOutingLocale, OutingLocale
@@ -343,9 +343,25 @@ class TestOutingRest(BaseDocumentTestRest):
             (self.route.document_id, doc.document_id))
         self.assertIsNotNone(association_route)
 
+        association_route_log = self.session.query(AssociationLog). \
+            filter(AssociationLog.parent_document_id ==
+                   self.route.document_id). \
+            filter(AssociationLog.child_document_id ==
+                   doc.document_id). \
+            first()
+        self.assertIsNotNone(association_route_log)
+
         association_user = self.session.query(Association).get(
             (self.global_userids['contributor'], doc.document_id))
         self.assertIsNotNone(association_user)
+
+        association_user_log = self.session.query(AssociationLog). \
+            filter(AssociationLog.parent_document_id ==
+                   self.global_userids['contributor']). \
+            filter(AssociationLog.child_document_id ==
+                   doc.document_id). \
+            first()
+        self.assertIsNotNone(association_user_log)
 
     def test_post_set_default_geom_from_route(self):
         body = {

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -3,7 +3,7 @@ import json
 
 from c2corg_api.models.area import Area
 from c2corg_api.models.area_association import AreaAssociation
-from c2corg_api.models.association import Association
+from c2corg_api.models.association import Association, AssociationLog
 from c2corg_api.models.document_history import DocumentVersion
 from c2corg_api.models.outing import Outing, OutingLocale
 from c2corg_api.models.topo_map import TopoMap
@@ -257,6 +257,14 @@ class TestRouteRest(BaseDocumentTestRest):
         association_main_wp = self.session.query(Association).get(
             (self.waypoint.document_id, doc.document_id))
         self.assertIsNotNone(association_main_wp)
+
+        association_main_wp_log = self.session.query(AssociationLog). \
+            filter(AssociationLog.parent_document_id ==
+                   self.waypoint.document_id). \
+            filter(AssociationLog.child_document_id ==
+                   doc.document_id). \
+            first()
+        self.assertIsNotNone(association_main_wp_log)
 
     def test_post_default_geom_multi_line(self):
         body = {
@@ -557,6 +565,14 @@ class TestRouteRest(BaseDocumentTestRest):
         association_main_wp = self.session.query(Association).get(
             (self.waypoint2.document_id, route.document_id))
         self.assertIsNotNone(association_main_wp)
+
+        association_main_wp_log = self.session.query(AssociationLog). \
+            filter(AssociationLog.parent_document_id ==
+                   self.waypoint2.document_id). \
+            filter(AssociationLog.child_document_id ==
+                   route.document_id). \
+            first()
+        self.assertIsNotNone(association_main_wp_log)
 
     def test_put_success_lang_only(self):
         body = {

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -253,6 +253,11 @@ class TestRouteRest(BaseDocumentTestRest):
         self.assertEqual(len(links), 1)
         self.assertEqual(links[0].area_id, self.area1.document_id)
 
+        # check that a link to the main waypoint is created
+        association_main_wp = self.session.query(Association).get(
+            (self.waypoint.document_id, doc.document_id))
+        self.assertIsNotNone(association_main_wp)
+
     def test_post_default_geom_multi_line(self):
         body = {
             'main_waypoint_id': self.waypoint.document_id,
@@ -523,7 +528,7 @@ class TestRouteRest(BaseDocumentTestRest):
             'message': 'Changing figures',
             'document': {
                 'document_id': self.route.document_id,
-                'main_waypoint_id': self.waypoint.document_id,
+                'main_waypoint_id': self.waypoint2.document_id,
                 'version': self.route.version,
                 'activities': ['skitouring'],
                 'elevation_min': 700,
@@ -543,10 +548,15 @@ class TestRouteRest(BaseDocumentTestRest):
         # but the route has a track)
         self._assert_default_geometry(body)
 
-        self.assertEqual(route.main_waypoint_id, self.waypoint.document_id)
+        self.assertEqual(route.main_waypoint_id, self.waypoint2.document_id)
         locale_en = route.get_locale('en')
         self.assertEqual(
-            locale_en.title_prefix, self.waypoint.get_locale('en').title)
+            locale_en.title_prefix, self.waypoint2.get_locale('en').title)
+
+        # check that a link to the new main waypoint is created
+        association_main_wp = self.session.query(Association).get(
+            (self.waypoint2.document_id, route.document_id))
+        self.assertIsNotNone(association_main_wp)
 
     def test_put_success_lang_only(self):
         body = {
@@ -751,6 +761,14 @@ class TestRouteRest(BaseDocumentTestRest):
             lang='fr', title='Mont Granier (fr)', description='...',
             access='ouai'))
         self.session.add(self.waypoint)
+        self.waypoint2 = Waypoint(
+            waypoint_type='summit', elevation=4,
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POINT(635956 5723604)'))
+        self.waypoint2.locales.append(WaypointLocale(
+            lang='en', title='Mont Granier (en)', description='...',
+            access='yep'))
+        self.session.add(self.waypoint2)
         self.session.flush()
         self.session.add(Association(
             parent_document_id=self.route.document_id,

--- a/c2corg_api/views/area.py
+++ b/c2corg_api/views/area.py
@@ -47,13 +47,13 @@ class AreaRest(DocumentRest):
         return self._put(Area, schema_area, after_update=update_associations)
 
 
-def insert_associations(area):
+def insert_associations(area, user_id):
     """Create links between this new area and documents.
     """
     update_area(area, reset=False)
 
 
-def update_associations(area, update_types):
+def update_associations(area, update_types, user_id):
     """Update the links between this area and documents when the geometry
     has changed.
     """

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -198,24 +198,24 @@ class DocumentRest(object):
     def _collection_post(
             self, schema, before_add=None, after_add=None,
             document_field=None):
+        user_id = self.request.authenticated_userid
         document_in = self.request.validated if document_field is None else \
-                self.request.validated[document_field]
+            self.request.validated[document_field]
         document = schema.objectify(document_in)
         document.document_id = None
 
         if before_add:
-            before_add(document)
+            before_add(document, user_id=user_id)
 
         DBSession.add(document)
         DBSession.flush()
-        user_id = self.request.authenticated_userid
         DocumentRest.create_new_version(document, user_id)
 
         if document.type != AREA_TYPE:
             update_areas_for_document(document, reset=False)
 
         if after_add:
-            after_add(document)
+            after_add(document, user_id=user_id)
 
         sync_search_index(document)
 
@@ -239,7 +239,7 @@ class DocumentRest(object):
         document.update(document_in)
 
         if before_update:
-            before_update(document, document_in)
+            before_update(document, document_in, user_id=user_id)
 
         try:
             DBSession.flush()
@@ -262,7 +262,7 @@ class DocumentRest(object):
                 update_areas_for_document(document, reset=True)
 
             if after_update:
-                after_update(document, update_types)
+                after_update(document, update_types, user_id=user_id)
 
             # And the search updated
             sync_search_index(document)

--- a/c2corg_api/views/outing.py
+++ b/c2corg_api/views/outing.py
@@ -1,6 +1,6 @@
 import functools
 from c2corg_api.models import DBSession
-from c2corg_api.models.association import Association
+from c2corg_api.models.association import Association, add_association
 from c2corg_api.models.document import ArchiveDocument, Document, \
     DocumentGeometry
 from c2corg_api.models.document_history import HistoryMetaData, DocumentVersion
@@ -238,7 +238,7 @@ def set_author(outings, lang):
         outing.author = author_for_outings.get(outing.document_id)
 
 
-def set_default_geometry(route_id, outing):
+def set_default_geometry(route_id, outing, user_id):
     """When creating a new outing, set the default geometry to the middle point
     of a given track, if not to the geometry of the associated route.
     """
@@ -257,7 +257,7 @@ def set_default_geometry(route_id, outing):
             outing.geometry = DocumentGeometry(geom=route_point)
 
 
-def update_default_geometry(outing, outing_in):
+def update_default_geometry(outing, outing_in, user_id):
     """When updating an outing, set the default geometry to the middle point
     of a new track, or directly update with a given geometry.
     """
@@ -279,12 +279,10 @@ class OutingVersionRest(DocumentRest):
             ArchiveOuting, ArchiveOutingLocale, schema_outing, schema_adaptor)
 
 
-def add_associations(route_id, user_ids, outing):
+def add_associations(route_id, user_ids, outing, user_id):
     """When creating a new outing, associations to the linked route
     and users are set up at the same time.
     """
-    DBSession.add(Association(
-        parent_document_id=route_id, child_document_id=outing.document_id))
+    add_association(route_id, outing.document_id, user_id)
     for user_id in user_ids:
-        DBSession.add(Association(
-            parent_document_id=user_id, child_document_id=outing.document_id))
+        add_association(user_id, outing.document_id, user_id)

--- a/c2corg_api/views/route.py
+++ b/c2corg_api/views/route.py
@@ -1,7 +1,7 @@
 import functools
 
 from c2corg_api.models import DBSession
-from c2corg_api.models.association import Association
+from c2corg_api.models.association import Association, add_association
 from c2corg_api.models.document import DocumentLocale, DocumentGeometry
 from c2corg_api.models.outing import schema_association_outing, Outing
 from c2corg_api.views.outing import set_author
@@ -22,7 +22,6 @@ from c2corg_api.views.validation import validate_id, validate_pagination, \
 from c2corg_common.fields_route import fields_route
 from c2corg_common.attributes import activities
 from sqlalchemy.orm import load_only, joinedload
-from sqlalchemy.sql.expression import exists, and_
 
 validate_route_create = make_validator_create(
     fields_route, 'activities', activities)
@@ -125,7 +124,7 @@ class RouteVersionRest(DocumentRest):
             ArchiveRoute, ArchiveRouteLocale, schema_route, schema_adaptor)
 
 
-def set_default_geometry(route):
+def set_default_geometry(route, user_id):
     """When creating a new route, set the default geometry to the middle point
     of a given track, if not to the geometry of the associated main waypoint.
     """
@@ -144,7 +143,7 @@ def set_default_geometry(route):
             route.geometry = DocumentGeometry(geom=main_wp_point)
 
 
-def update_default_geometry(old_main_waypoint_id, route, route_in):
+def update_default_geometry(old_main_waypoint_id, route, route_in, user_id):
     geometry_in = route_in.geometry
     if geometry_in is not None and geometry_in.geom is not None:
         # default geom is manually set in the request
@@ -172,34 +171,27 @@ def main_waypoint_has_changed(route, old_main_waypoint_id):
         return old_main_waypoint_id != route.main_waypoint_id
 
 
-def after_route_add(route):
-    create_main_waypoint_association(route)
+def after_route_add(route, user_id):
+    create_main_waypoint_association(route, user_id)
     init_title_prefix(route)
 
 
-def create_main_waypoint_association(route, check_first=False):
+def create_main_waypoint_association(route, user_id, check_first=False):
     """Create an association between the newly created route and the main
     waypoint.
     """
     if route.main_waypoint_id:
-        if check_first:
-            association_exists = exists().where(and_(
-                Association.parent_document_id == route.main_waypoint_id,
-                Association.child_document_id == route.document_id,
-            ))
-            if DBSession.query(association_exists).scalar():
-                return
-        DBSession.add(Association(
-            parent_document_id=route.main_waypoint_id,
-            child_document_id=route.document_id))
+        add_association(
+            route.main_waypoint_id, route.document_id, user_id,
+            check_first=check_first)
 
 
 def init_title_prefix(route):
     update_title_prefix(route, create=True)
 
 
-def after_route_update(route, update_types):
-    create_main_waypoint_association(route, check_first=True)
+def after_route_update(route, update_types, user_id):
+    create_main_waypoint_association(route, user_id, check_first=True)
     update_title_prefix(route)
 
 

--- a/c2corg_api/views/waypoint.py
+++ b/c2corg_api/views/waypoint.py
@@ -147,7 +147,7 @@ class WaypointVersionRest(DocumentRest):
             schema_adaptor)
 
 
-def update_linked_route_titles(waypoint, update_types):
+def update_linked_route_titles(waypoint, update_types, user_id):
     """When a waypoint is the main waypoint of a route, the field
     `title_prefix`, which caches the waypoint name, has to be updated.
     This method takes care of updating all routes, that the waypoint is


### PR DESCRIPTION
The `main_waypoint_id` field can be set when creating or updating a route. But currently no explicit association is created between the route and this main waypoint.