### PR TITLE
Two different views to get a document for editing or detail page

### DIFF
--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -105,6 +105,16 @@ class TestWaypointRest(BaseDocumentTestRest):
             self.outing.document_id,
             recent_outings['outings'][0].get('document_id'))
 
+    def test_get_no_associations(self):
+        response = self.app.get(self._prefix + '/' +
+                                str(self.waypoint.document_id) + '?a=0',
+                                status=200)
+        body = response.json
+
+        self.assertNotIn('associations', body)
+        self.assertIn('maps', body)
+        self.assertNotIn('areas', body)
+
     def test_get_version(self):
         self.get_version(self.waypoint, self.waypoint_version)
 

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -146,14 +146,17 @@ class DocumentRest(object):
         document = self._get_document(clazz, id, lang)
         set_available_langs([document])
 
-        self._set_associations(document, lang)
-        if set_custom_associations:
-            set_custom_associations(document, lang)
+        include_associations = self.request.GET.get('a', '1') == '1'
+        if include_associations:
+            self._set_associations(document, lang)
+            if set_custom_associations:
+                set_custom_associations(document, lang)
+
+            if include_areas:
+                self._set_areas(document, lang)
 
         if include_maps:
             self._set_maps(document, lang)
-        if include_areas:
-            self._set_areas(document, lang)
 
         if adapt_schema:
             schema = adapt_schema(schema, document)


### PR DESCRIPTION
The view to get a single document now returns associated areas, maps and other documents, because this information is needed in the detail page. It might make sense to have a separate view which is used for the edit form which does only contain the data needed to edit the document.