### PR TITLE
Fix generation of area associations

### DIFF
--- a/c2corg_api/scripts/migration/area_associations.py
+++ b/c2corg_api/scripts/migration/area_associations.py
@@ -33,8 +33,9 @@ insert into guidebook.area_associations (document_id, area_id) (
   from (select g.document_id, g.geom, g.geom_detail from
     guidebook.documents_geometries g join guidebook.documents d
     on g.document_id = d.document_id and d.type <> 'a') d
-  join (select ga.document_id, ga.geom from
+  join (select ga.document_id, ga.geom_detail from
     guidebook.areas a join guidebook.documents_geometries ga
     on ga.document_id = a.document_id) a
-  on ST_Intersects(d.geom, a.geom) or ST_Intersects(d.geom_detail, a.geom));
+  on ST_Intersects(d.geom, a.geom_detail) or
+     ST_Intersects(d.geom_detail, a.geom_detail));
 """


### PR DESCRIPTION
The area geometry is now in `geom_detail`.

Follow up on https://github.com/c2corg/v6_api/pull/179.