### PR TITLE
Handle protected documents

### DIFF
--- a/c2corg_api/models/area_association.py
+++ b/c2corg_api/models/area_association.py
@@ -141,7 +141,7 @@ def get_areas(document, lang):
             AreaAssociation,
             Area.document_id == AreaAssociation.area_id). \
         options(load_only(
-            Area.document_id, Area.area_type, Area.version)). \
+            Area.document_id, Area.area_type, Area.version, Area.protected)). \
         options(joinedload(Area.locales).load_only(
             DocumentLocale.lang, DocumentLocale.title,
             DocumentLocale.version)). \

--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -90,7 +90,7 @@ def get_associations(document, lang):
         return query. \
             options(load_only(
                 Waypoint.waypoint_type, Waypoint.document_id,
-                Waypoint.elevation, Waypoint.version)). \
+                Waypoint.elevation, Waypoint.version, Waypoint.protected)). \
             options(joinedload(Waypoint.locales).load_only(
                 WaypointLocale.lang, WaypointLocale.title,
                 WaypointLocale.version))
@@ -114,7 +114,7 @@ def get_associations(document, lang):
         return query.\
             options(load_only(
                 Route.document_id, Route.activities, Route.elevation_min,
-                Route.elevation_max, Route.version)). \
+                Route.elevation_max, Route.version, Route.protected)). \
             options(joinedload(Waypoint.locales).load_only(
                 RouteLocale.lang, RouteLocale.title, RouteLocale.title_prefix,
                 RouteLocale.version))

--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -52,6 +52,8 @@ class _DocumentMixin(object):
     `ArchiveDocument`.
     """
     version = Column(Integer, nullable=False, server_default='1')
+
+    # a protected document can only be edited by moderators
     protected = Column(Boolean)
 
     @declared_attr

--- a/c2corg_api/models/topo_map.py
+++ b/c2corg_api/models/topo_map.py
@@ -113,7 +113,7 @@ def get_maps(document, lang):
             TopoMap.document_id == DocumentGeometry.document_id). \
         options(load_only(
             TopoMap.document_id, TopoMap.editor, TopoMap.code,
-            TopoMap.version)). \
+            TopoMap.version, TopoMap.protected)). \
         options(joinedload(TopoMap.locales).load_only(
             DocumentLocale.lang, DocumentLocale.title,
             DocumentLocale.version)). \

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -90,6 +90,7 @@ class BaseDocumentTestRest(BaseTestRest):
             doc = documents[0]
             available_langs = doc.get('available_langs')
             self.assertEqual(sorted(available_langs), ['en', 'fr'])
+            self.assertIn('protected', doc)
 
         if limit is None:
             nb_docs = self.session.query(self._model). \
@@ -117,6 +118,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(len(locales), 1)
         locale = locales[0]
         self.assertEqual('fr', locale['lang'])
+        self.assertIn('protected', doc)
 
         return body
 
@@ -188,6 +190,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(len(locales), 1)
         locale_en = locales[0]
         self.assertEqual(locale_en.get('lang'), self.locale_en.lang)
+        self.assertIn('protected', body)
 
     def get_new_lang(self, reference, user=None):
         headers = {} if not user else \

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -4,7 +4,7 @@ import datetime
 from c2corg_api.models import DBSession
 from c2corg_common.attributes import langs_priority
 from colander import null
-from pyramid.httpexceptions import HTTPError, HTTPNotFound
+from pyramid.httpexceptions import HTTPError, HTTPNotFound, HTTPForbidden
 from pyramid.view import view_config
 from cornice import Errors
 from cornice.util import json_error, _JSONError
@@ -24,6 +24,7 @@ cors_policy = dict(
 
 @view_config(context=HTTPNotFound)
 @view_config(context=HTTPError)
+@view_config(context=HTTPForbidden)
 def http_error_handler(exc, request):
     """In case of a HTTP error, return the error details as JSON, e.g.:
 

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -78,7 +78,8 @@ def to_json_dict(obj, schema):
     # cleaner to add the field to the schema, but ColanderAlchemy doesn't like
     # it because it's not a real column)
     special_attributes = [
-        'available_langs', 'associations', 'maps', 'areas', 'author'
+        'available_langs', 'associations', 'maps', 'areas', 'author',
+        'protected'
     ]
     for attr in special_attributes:
         if hasattr(obj, attr):

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -67,7 +67,8 @@ class DocumentRest(object):
             base_query = base_query. \
                 options(
                     joinedload(getattr(clazz, '_areas')).
-                    load_only('document_id', 'area_type', 'version').
+                    load_only(
+                        'document_id', 'area_type', 'version', 'protected').
                     joinedload('locales').
                     load_only(
                         'lang', 'title',

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -16,7 +16,8 @@ from c2corg_api.views import to_json_dict, to_seconds, set_best_locale
 from c2corg_api.views.validation import check_required_fields, \
     check_duplicate_locales, validate_id, validate_lang
 from cornice.resource import resource, view
-from pyramid.httpexceptions import HTTPNotFound, HTTPConflict, HTTPBadRequest
+from pyramid.httpexceptions import HTTPNotFound, HTTPConflict, \
+    HTTPBadRequest, HTTPForbidden
 from sqlalchemy.orm import joinedload, contains_eager
 from sqlalchemy.orm.exc import StaleDataError
 from sqlalchemy.sql.expression import literal_column, union
@@ -243,8 +244,11 @@ class DocumentRest(object):
 
         # get the current version of the document
         document = self._get_document(clazz, id)
+
         if document.redirects_to:
             raise HTTPBadRequest('can not update merged document')
+        if document.protected and not self.request.has_permission('moderator'):
+            raise HTTPForbidden('No permission to change a protected document')
 
         self._check_versions(document, document_in)
 

--- a/c2corg_api/views/route.py
+++ b/c2corg_api/views/route.py
@@ -88,7 +88,7 @@ class RouteRest(DocumentRest):
             filter(Association.parent_document_id == route.document_id). \
             options(load_only(
                 Outing.document_id, Outing.activities, Outing.date_start,
-                Outing.date_end, Outing.version)). \
+                Outing.date_end, Outing.version, Outing.protected)). \
             options(joinedload(Outing.locales).load_only(
                 DocumentLocale.lang, DocumentLocale.title,
                 DocumentLocale.version)). \

--- a/c2corg_api/views/waypoint.py
+++ b/c2corg_api/views/waypoint.py
@@ -101,7 +101,7 @@ class WaypointRest(DocumentRest):
                     t_route_wp.child_document_id == t_route.document_id)). \
             options(load_only(
                 Outing.document_id, Outing.activities, Outing.date_start,
-                Outing.date_end, Outing.version)). \
+                Outing.date_end, Outing.version, Outing.protected)). \
             options(joinedload(Outing.locales).load_only(
                 DocumentLocale.lang, DocumentLocale.title,
                 DocumentLocale.version)). \


### PR DESCRIPTION
* Include `protected` field in output
* Only moderators can edit protected documents (changing the protected status will come later with the moderator tools)

PR based on https://github.com/c2corg/v6_api/pull/189, only the last 2 commits are new.
Closes https://github.com/c2corg/v6_api/issues/73