### PR TITLE
Include remaining document types in simple search

### DIFF
--- a/c2corg_api/models/image.py
+++ b/c2corg_api/models/image.py
@@ -1,3 +1,5 @@
+from c2corg_api.models.schema_utils import restrict_schema
+from c2corg_common.fields_image import fields_image
 from sqlalchemy import (
     Boolean,
     Column,
@@ -122,3 +124,5 @@ schema_image = SQLAlchemySchemaNode(
     })
 
 schema_update_image = get_update_schema(schema_image)
+schema_listing_image = restrict_schema(
+    schema_image, fields_image.get('listing'))

--- a/c2corg_api/models/user.py
+++ b/c2corg_api/models/user.py
@@ -14,7 +14,7 @@ from colanderalchemy import SQLAlchemySchemaNode
 from c2corg_api.models import Base, users_schema, schema
 
 import colander
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, backref
 from sqlalchemy.sql.schema import ForeignKey
 
 import os
@@ -54,7 +54,8 @@ class User(Base):
         Integer, ForeignKey(schema + '.user_profiles.document_id'),
         primary_key=True)
     profile = relationship(
-        UserProfile, primaryjoin=id == UserProfile.document_id, backref='user')
+        UserProfile, primaryjoin=id == UserProfile.document_id, uselist=False,
+        backref=backref('user', uselist=False))
 
     username = Column(String(200), nullable=False, unique=True)
     name = Column(String(200))

--- a/c2corg_api/models/user_profile.py
+++ b/c2corg_api/models/user_profile.py
@@ -5,7 +5,7 @@ from c2corg_api.models.document import (
 from c2corg_api.models.enums import user_category, activity_type
 from c2corg_api.models.schema_utils import restrict_schema
 from c2corg_api.models.utils import copy_attributes, ArrayOfEnum
-from c2corg_common.fields_area import fields_area
+from c2corg_common.fields_user_profile import fields_user_profile
 from colanderalchemy import SQLAlchemySchemaNode
 from sqlalchemy import (
     Column,
@@ -13,6 +13,7 @@ from sqlalchemy import (
     ForeignKey
     )
 from c2corg_common import document_types
+from sqlalchemy.ext.associationproxy import association_proxy
 
 USERPROFILE_TYPE = document_types.USERPROFILE_TYPE
 
@@ -38,6 +39,9 @@ class UserProfile(_UserProfileMixin, Document):
         'polymorphic_identity': USERPROFILE_TYPE,
         'inherit_condition': Document.document_id == document_id
     }
+
+    username = association_proxy('user', 'username')
+    name = association_proxy('user', 'name')
 
     def to_archive(self):
         user_profile = ArchiveUserProfile()
@@ -116,4 +120,4 @@ schema_internal_user_profile = SQLAlchemySchemaNode(
 
 schema_update_user_profile = get_update_schema(schema_user_profile)
 schema_listing_user_profile = restrict_schema(
-    schema_user_profile, fields_area.get('listing'))
+    schema_user_profile, fields_user_profile.get('listing'))

--- a/c2corg_api/scripts/es/fill_index.py
+++ b/c2corg_api/scripts/es/fill_index.py
@@ -2,6 +2,8 @@ import os
 import sys
 
 from c2corg_api.models.route import RouteLocale
+from c2corg_api.models.user import User
+from c2corg_api.models.user_profile import USERPROFILE_TYPE
 from pyramid.paster import (
     get_appsettings,
     setup_logging,
@@ -58,11 +60,15 @@ def fill_index(db_session):
             DocumentLocale.document_id, DocumentLocale.title,
             DocumentLocale.summary, DocumentLocale.description,
             DocumentLocale.lang, Document.type,
-            RouteLocale.__table__.c.title_prefix). \
+            RouteLocale.__table__.c.title_prefix,
+            User.name, User.username). \
         join(Document).filter(Document.redirects_to.is_(None)). \
         outerjoin(
             RouteLocale.__table__,
             DocumentLocale.id == RouteLocale.__table__.c.id).\
+        outerjoin(
+            User,
+            DocumentLocale.document_id == User.id).\
         order_by(DocumentLocale.document_id, DocumentLocale.lang)
 
     def progress(count, total_count):
@@ -78,7 +84,7 @@ def fill_index(db_session):
     count = 0
     with batch:
         for document_id, title, summary, description, lang, type, \
-                title_prefix in q:
+                title_prefix, user_login, user_name in q:
             if search_document is not None and document_id != last_id:
                 batch.add(search_document)
                 search_document = None
@@ -91,6 +97,11 @@ def fill_index(db_session):
                     '_id': document_id,
                     'doc_type': type
                 }
+
+            if type == USERPROFILE_TYPE:
+                # set user login + full-name as document title so that it can
+                # be searched
+                title = '{0} {1}'.format(user_name or '', user_login or '')
 
             search_document['title_' + lang] = get_title(
                 title, title_prefix)

--- a/c2corg_api/scripts/es/fill_index.py
+++ b/c2corg_api/scripts/es/fill_index.py
@@ -57,7 +57,7 @@ def fill_index(db_session):
     q = DBSession.query(
             DocumentLocale.document_id, DocumentLocale.title,
             DocumentLocale.summary, DocumentLocale.description,
-            DocumentLocale.lang, DocumentLocale.type,
+            DocumentLocale.lang, Document.type,
             RouteLocale.__table__.c.title_prefix). \
         join(Document).filter(Document.redirects_to.is_(None)). \
         outerjoin(

--- a/c2corg_api/search/search.py
+++ b/c2corg_api/search/search.py
@@ -8,7 +8,8 @@ from c2corg_api.views import to_json_dict, set_best_locale
 
 
 def search_for_type(
-        search_term, document_type, model, schema, adapt_schema, limit, lang):
+        search_term, document_type, model, locale_model,
+        schema, adapt_schema, limit, lang):
     # search in all title* (title_en, title_fr, ...), summary* and
     # description* fields. "boost" title fields and summary fields.
     search_query = MultiMatch(
@@ -30,7 +31,7 @@ def search_for_type(
     document_ids = [int(doc.meta.id) for doc in response]
 
     # then load the documents for the returned ids
-    documents = get_documents(document_ids, model, lang)
+    documents = get_documents(document_ids, model, locale_model, lang)
 
     count = len(documents)
     total = response.hits.total
@@ -44,7 +45,7 @@ def search_for_type(
     }
 
 
-def get_documents(document_ids, model, lang):
+def get_documents(document_ids, model, locale_model, lang):
     """Load the documents for the given ids.
     The documents are returned in the same order as the ids. If a document
     for a given id does not exist, the document is skipped.
@@ -56,7 +57,7 @@ def get_documents(document_ids, model, lang):
         query(model).\
         filter(model.redirects_to.is_(None)).\
         filter(model.document_id.in_(document_ids)).\
-        options(joinedload(model.locales)). \
+        options(joinedload(model.locales.of_type(locale_model))). \
         options(joinedload(model.geometry)). \
         all()
 

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -5,7 +5,7 @@ import transaction
 import os
 import logging
 
-from c2corg_api.models.document import DocumentLocale
+from c2corg_api.models.document import DocumentLocale, DocumentGeometry
 from c2corg_api.models.user_profile import UserProfile
 from sqlalchemy import engine_from_config
 from pyramid.paster import get_appsettings
@@ -51,7 +51,10 @@ def _add_global_test_data(session):
 
     contributor_profile = UserProfile(
         categories=['amateur'],
-        locales=[DocumentLocale(title='', lang='en')])
+        locales=[
+            DocumentLocale(title='', description='Me', lang='en'),
+            DocumentLocale(title='', description='Moi', lang='fr')],
+        geometry=DocumentGeometry(geom='SRID=3857;POINT(635956 5723604)'))
 
     contributor = User(
         username='contributor', email='contributor@camptocamp.org',

--- a/c2corg_api/tests/search/test_search.py
+++ b/c2corg_api/tests/search/test_search.py
@@ -1,4 +1,4 @@
-from c2corg_api.models.document import DocumentGeometry
+from c2corg_api.models.document import DocumentGeometry, DocumentLocale
 from c2corg_api.models.waypoint import Waypoint, WaypointLocale
 from c2corg_api.tests import BaseTestCase
 from c2corg_api.search import search
@@ -33,10 +33,12 @@ class SearchTest(BaseTestCase):
             ]))
         self.session.flush()
 
-        docs = search.get_documents([71171, 71172], Waypoint, None)
+        docs = search.get_documents(
+            [71171, 71172], Waypoint, DocumentLocale, None)
         self.assertEqual(71171, docs[0].document_id)
         self.assertEqual(71172, docs[1].document_id)
 
-        docs = search.get_documents([71172, 71171], Waypoint, None)
+        docs = search.get_documents(
+            [71172, 71171], Waypoint, DocumentLocale, None)
         self.assertEqual(71172, docs[0].document_id)
         self.assertEqual(71171, docs[1].document_id)

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -491,7 +491,8 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(len(errors), 1)
         self.assertCorniceRequired(errors[0], field)
 
-    def put_success_all(self, request_body, document, user='contributor'):
+    def put_success_all(
+            self, request_body, document, user='contributor', check_es=True):
         """Test updating a document with changes to the figures and locales.
         """
         response = self.app.put_json(
@@ -578,19 +579,20 @@ class BaseDocumentTestRest(BaseTestRest):
             archive_locale_fr.version, self.locale_fr.version)
         self.assertEqual(archive_locale_fr.lang, 'fr')
 
-        # check updates to the search index
-        search_doc = SearchDocument.get(
-            id=document.document_id,
-            index=elasticsearch_config['index'])
+        if check_es:
+            # check updates to the search index
+            search_doc = SearchDocument.get(
+                id=document.document_id,
+                index=elasticsearch_config['index'])
 
-        self.assertEqual(search_doc['doc_type'], document.type)
-        self.assertEqual(search_doc['title_en'], archive_locale.title)
-        self.assertEqual(search_doc['title_fr'], archive_locale_fr.title)
+            self.assertEqual(search_doc['doc_type'], document.type)
+            self.assertEqual(search_doc['title_en'], archive_locale.title)
+            self.assertEqual(search_doc['title_fr'], archive_locale_fr.title)
 
         return (body, document)
 
     def put_success_figures_only(
-            self, request_body, document, user='contributor'):
+            self, request_body, document, user='contributor', check_es=True):
         """Test updating a document with changes to the figures only.
         """
         response = self.app.put_json(
@@ -675,7 +677,7 @@ class BaseDocumentTestRest(BaseTestRest):
             locale_fr = document.get_locale('fr')
             title = locale_fr.title_prefix + ' : ' + locale_fr.title
             self.assertEqual(search_doc['title_fr'], title)
-        else:
+        elif check_es:
             self.assertEqual(
                 search_doc['title_en'], document.get_locale('en').title)
             self.assertEqual(
@@ -684,7 +686,7 @@ class BaseDocumentTestRest(BaseTestRest):
         return (body, document)
 
     def put_success_lang_only(
-            self, request_body, document, user='contributor'):
+            self, request_body, document, user='contributor', check_es=True):
         """Test updating a document with only changes to a locale.
         """
         response = self.app.put_json(
@@ -755,19 +757,21 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertIs(archive_waypoint_en, archive_waypoint_fr)
 
         # check updates to the search index
-        search_doc = SearchDocument.get(
-            id=document.document_id,
-            index=elasticsearch_config['index'])
+        if check_es:
+            search_doc = SearchDocument.get(
+                id=document.document_id,
+                index=elasticsearch_config['index'])
 
-        self.assertEqual(search_doc['doc_type'], document.type)
-        self.assertEqual(
-            search_doc['title_en'], document.get_locale('en').title)
-        self.assertEqual(
-            search_doc['title_fr'], document.get_locale('fr').title)
+            self.assertEqual(search_doc['doc_type'], document.type)
+            self.assertEqual(
+                search_doc['title_en'], document.get_locale('en').title)
+            self.assertEqual(
+                search_doc['title_fr'], document.get_locale('fr').title)
 
         return (body, document)
 
-    def put_success_new_lang(self, request_body, document, user='contributor'):
+    def put_success_new_lang(
+            self, request_body, document, user='contributor', check_es=True):
         """Test updating a document by adding a new locale.
         """
         response = self.app.put_json(
@@ -847,16 +851,17 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertIs(archive_document_es, archive_document_fr)
 
         # check updates to the search index
-        search_doc = SearchDocument.get(
-            id=document.document_id,
-            index=elasticsearch_config['index'])
+        if check_es:
+            search_doc = SearchDocument.get(
+                id=document.document_id,
+                index=elasticsearch_config['index'])
 
-        self.assertEqual(search_doc['doc_type'], document.type)
-        self.assertEqual(
-            search_doc['title_en'], document.get_locale('en').title)
-        self.assertEqual(
-            search_doc['title_fr'], document.get_locale('fr').title)
-        self.assertEqual(
-            search_doc['title_es'], document.get_locale('es').title)
+            self.assertEqual(search_doc['doc_type'], document.type)
+            self.assertEqual(
+                search_doc['title_en'], document.get_locale('en').title)
+            self.assertEqual(
+                search_doc['title_fr'], document.get_locale('fr').title)
+            self.assertEqual(
+                search_doc['title_es'], document.get_locale('es').title)
 
         return (body, document)

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -145,7 +145,7 @@ class BaseDocumentTestRest(BaseTestRest):
 
         locales = body.get('locales')
         self.assertEqual(len(locales), 2)
-        locale_en = locales[0]
+        locale_en = get_locale(locales, 'en')
         self.assertNotIn('id', locale_en)
         self.assertIsNotNone(locale_en.get('version'))
         self.assertEqual(locale_en.get('lang'), self.locale_en.lang)
@@ -865,3 +865,7 @@ class BaseDocumentTestRest(BaseTestRest):
                 search_doc['title_es'], document.get_locale('es').title)
 
         return (body, document)
+
+
+def get_locale(locales, lang):
+    return next(filter(lambda locale: locale['lang'] == lang, locales), None)

--- a/c2corg_api/tests/views/test_area.py
+++ b/c2corg_api/tests/views/test_area.py
@@ -25,6 +25,7 @@ class TestAreaRest(BaseDocumentTestRest):
         body = self.get_collection()
         doc = body['documents'][0]
         self.assertNotIn('areas', doc)
+        self.assertNotIn('geometry', doc)
 
     def test_get_collection_paginated(self):
         self.app.get("/areas?offset=invalid", status=400)

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -18,7 +18,9 @@ class TestImageRest(BaseDocumentTestRest):
         self._add_test_data()
 
     def test_get_collection(self):
-        self.get_collection()
+        body = self.get_collection()
+        doc = body['documents'][0]
+        self.assertNotIn('filename', doc)
 
     def test_get_collection_paginated(self):
         self.app.get("/images?offset=invalid", status=400)

--- a/c2corg_api/tests/views/test_search.py
+++ b/c2corg_api/tests/views/test_search.py
@@ -59,6 +59,11 @@ class TestSearchRest(BaseTestRest):
 
         self.assertIn('waypoints', body)
         self.assertIn('routes', body)
+        self.assertIn('maps', body)
+        self.assertIn('users', body)
+        self.assertIn('areas', body)
+        self.assertIn('images', body)
+        self.assertIn('outings', body)
 
         waypoints = body['waypoints']
         self.assertTrue(waypoints['total'] > 0)
@@ -67,6 +72,10 @@ class TestSearchRest(BaseTestRest):
 
         routes = body['routes']
         self.assertEqual(0, routes['total'])
+
+        # tests that user results are not included when not authenticated
+        users = body['users']
+        self.assertNotIn('total', users)
 
     def test_search_lang(self):
         response = self.app.get(self._prefix + '?q=crolles&pl=fr', status=200)
@@ -99,3 +108,15 @@ class TestSearchRest(BaseTestRest):
         documents = get_documents(
             [waypoint.document_id], Waypoint, DocumentLocale, None)
         self.assertEquals(0, len(documents))
+
+    def test_search_authenticated(self):
+        """Tests that user results are included when authenticated.
+        """
+        headers = self.add_authorization_header(username='contributor')
+        response = self.app.get(self._prefix + '?q=crolles', headers=headers,
+                                status=200)
+        body = response.json
+
+        self.assertIn('users', body)
+        users = body['users']
+        self.assertIn('total', users)

--- a/c2corg_api/tests/views/test_search.py
+++ b/c2corg_api/tests/views/test_search.py
@@ -130,3 +130,18 @@ class TestSearchRest(BaseTestRest):
         self.assertNotIn('images', body)
         self.assertNotIn('outings', body)
         self.assertNotIn('users', body)
+
+    def test_search_by_document_id(self):
+        response = self.app.get(
+            self._prefix + '?q=' + str(self.waypoint1.document_id), status=200)
+        body = response.json
+
+        waypoints = body['waypoints']
+        self.assertEquals(waypoints['total'], 1)
+        self.assertEquals(waypoints['count'], 1)
+        self.assertEquals(len(waypoints['documents']), 1)
+
+        routes = body['routes']
+        self.assertEquals(routes['total'], 0)
+        self.assertEquals(routes['count'], 0)
+        self.assertEquals(len(routes['documents']), 0)

--- a/c2corg_api/tests/views/test_search.py
+++ b/c2corg_api/tests/views/test_search.py
@@ -1,4 +1,4 @@
-from c2corg_api.models.document import DocumentGeometry
+from c2corg_api.models.document import DocumentGeometry, DocumentLocale
 from c2corg_api.models.route import Route, RouteLocale
 from c2corg_api.models.waypoint import Waypoint, WaypointLocale
 from c2corg_api.scripts.es.fill_index import fill_index
@@ -96,5 +96,6 @@ class TestSearchRest(BaseTestRest):
                     summary='The heighest point in Europe')
             ])
         self.session.add(waypoint)
-        documents = get_documents([waypoint.document_id], Waypoint, None)
+        documents = get_documents(
+            [waypoint.document_id], Waypoint, DocumentLocale, None)
         self.assertEquals(0, len(documents))

--- a/c2corg_api/tests/views/test_search.py
+++ b/c2corg_api/tests/views/test_search.py
@@ -60,7 +60,6 @@ class TestSearchRest(BaseTestRest):
         self.assertIn('waypoints', body)
         self.assertIn('routes', body)
         self.assertIn('maps', body)
-        self.assertIn('users', body)
         self.assertIn('areas', body)
         self.assertIn('images', body)
         self.assertIn('outings', body)
@@ -74,8 +73,7 @@ class TestSearchRest(BaseTestRest):
         self.assertEqual(0, routes['total'])
 
         # tests that user results are not included when not authenticated
-        users = body['users']
-        self.assertNotIn('total', users)
+        self.assertNotIn('users', body)
 
     def test_search_lang(self):
         response = self.app.get(self._prefix + '?q=crolles&pl=fr', status=200)
@@ -120,3 +118,15 @@ class TestSearchRest(BaseTestRest):
         self.assertIn('users', body)
         users = body['users']
         self.assertIn('total', users)
+
+    def test_search_limit_types(self):
+        response = self.app.get(self._prefix + '?q=crolles&t=w,r', status=200)
+        body = response.json
+
+        self.assertIn('waypoints', body)
+        self.assertIn('routes', body)
+        self.assertNotIn('maps', body)
+        self.assertNotIn('areas', body)
+        self.assertNotIn('images', body)
+        self.assertNotIn('outings', body)
+        self.assertNotIn('users', body)

--- a/c2corg_api/tests/views/test_topo_map.py
+++ b/c2corg_api/tests/views/test_topo_map.py
@@ -19,7 +19,9 @@ class TestTopoMapRest(BaseDocumentTestRest):
         self._add_test_data()
 
     def test_get_collection(self):
-        self.get_collection()
+        body = self.get_collection()
+        doc = body['documents'][0]
+        self.assertNotIn('geometry', doc)
 
     def test_get_collection_paginated(self):
         self.app.get("/maps?offset=invalid", status=400)

--- a/c2corg_api/tests/views/test_user_profile.py
+++ b/c2corg_api/tests/views/test_user_profile.py
@@ -26,6 +26,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
         body = self.get_collection(user='contributor')
         doc = body['documents'][0]
         self.assertIn('areas', doc)
+        self.assertNotIn('geometry', doc)
 
     def test_get_collection_paginated(self):
         self.assertResultsEqual(

--- a/c2corg_api/tests/views/test_user_profile.py
+++ b/c2corg_api/tests/views/test_user_profile.py
@@ -1,10 +1,12 @@
 import json
 
 from c2corg_api.models.user_profile import UserProfile, ArchiveUserProfile
+from c2corg_api.search import elasticsearch_config
+from c2corg_api.search.mapping import SearchDocument
 from shapely.geometry import shape, Point
 
 from c2corg_api.models.document import (
-    DocumentGeometry, ArchiveDocumentLocale, DocumentLocale)
+    ArchiveDocumentLocale, DocumentLocale)
 from c2corg_api.views.document import DocumentRest
 
 from c2corg_api.tests.views import BaseDocumentTestRest
@@ -32,20 +34,20 @@ class TestUserProfileRest(BaseDocumentTestRest):
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 0, 'limit': 0}, user='contributor'),
-            [], 7)
+            [], 6)
 
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 0, 'limit': 1}, user='contributor'),
-            [self.profile4.document_id], 7)
+            [self.profile4.document_id], 6)
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 0, 'limit': 2}, user='contributor'),
-            [self.profile4.document_id, self.profile3.document_id], 7)
+            [self.profile4.document_id, self.profile3.document_id], 6)
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 1, 'limit': 2}, user='contributor'),
-            [self.profile3.document_id, self.profile2.document_id], 7)
+            [self.profile3.document_id, self.profile2.document_id], 6)
 
         self.assertResultsEqual(
             self.get_collection(
@@ -100,7 +102,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
             }
         }
 
-        headers = self.add_authorization_header(username='contributor')
+        headers = self.add_authorization_header(username='contributor2')
         self.app.put_json(
             self._prefix + '/' + str(self.profile1.document_id), body,
             headers=headers, status=403)
@@ -186,7 +188,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
             }
         }
         (body, profile) = self.put_success_all(
-            body, self.profile1, user='moderator')
+            body, self.profile1, user='moderator', check_es=False)
 
         # version with lang 'en'
         version_en = profile.versions[2]
@@ -194,6 +196,8 @@ class TestUserProfileRest(BaseDocumentTestRest):
         # geometry has been changed
         archive_geometry_en = version_en.document_geometry_archive
         self.assertEqual(archive_geometry_en.version, 2)
+
+        self._check_es_index()
 
     def test_put_success_figures_only(self):
         body = {
@@ -209,9 +213,10 @@ class TestUserProfileRest(BaseDocumentTestRest):
             }
         }
         (body, profile) = self.put_success_figures_only(
-            body, self.profile1, user='moderator')
+            body, self.profile1, user='moderator', check_es=False)
 
         self.assertEquals(profile.categories, ['mountain_guide'])
+        self._check_es_index()
 
     def test_put_success_lang_only(self):
         body = {
@@ -227,10 +232,11 @@ class TestUserProfileRest(BaseDocumentTestRest):
             }
         }
         (body, profile) = self.put_success_lang_only(
-            body, self.profile1, user='moderator')
+            body, self.profile1, user='moderator', check_es=False)
 
         self.assertEquals(
             profile.get_locale('en').description, 'Me!')
+        self._check_es_index()
 
     def test_put_reset_title(self):
         """Tests that the title can not be set.
@@ -249,12 +255,15 @@ class TestUserProfileRest(BaseDocumentTestRest):
             }
         }
         (body, profile) = self.put_success_lang_only(
-            body, self.profile1, user='moderator')
+            body, self.profile1, user='moderator', check_es=False)
 
         self.assertEquals(
             profile.get_locale('en').description, 'Me!')
         self.session.refresh(self.locale_en)
         self.assertEqual(self.locale_en.title, '')
+
+        # check that the the user names are added to the search index
+        self._check_es_index()
 
     def test_put_success_new_lang(self):
         """Test updating a document by adding a new locale.
@@ -271,9 +280,20 @@ class TestUserProfileRest(BaseDocumentTestRest):
             }
         }
         (body, profile) = self.put_success_new_lang(
-            body, self.profile1, user='moderator')
+            body, self.profile1, user='moderator', check_es=False)
 
         self.assertEquals(profile.get_locale('es').description, 'Yo')
+        search_doc = self._check_es_index()
+        self.assertEqual(search_doc['title_es'], 'contributor Contributor')
+
+    def _check_es_index(self):
+        search_doc = SearchDocument.get(
+            id=self.profile1.document_id,
+            index=elasticsearch_config['index'])
+        self.assertEqual(search_doc['doc_type'], self.profile1.type)
+        self.assertEqual(search_doc['title_en'], 'contributor Contributor')
+        self.assertEqual(search_doc['title_fr'], 'contributor Contributor')
+        return search_doc
 
     def _assert_geometry(self, body):
         self.assertIsNotNone(body.get('geometry'))
@@ -287,20 +307,9 @@ class TestUserProfileRest(BaseDocumentTestRest):
 
     def _add_test_data(self):
         user_id = self.global_userids['contributor']
-        self.profile1 = UserProfile(categories=['amateur'])
-
-        self.locale_en = DocumentLocale(lang='en', description='Me', title='')
-        self.locale_fr = DocumentLocale(lang='fr', description='Moi', title='')
-
-        self.profile1.locales.append(self.locale_en)
-        self.profile1.locales.append(self.locale_fr)
-
-        self.profile1.geometry = DocumentGeometry(
-            geom='SRID=3857;POINT(635956 5723604)')
-
-        self.session.add(self.profile1)
-        self.session.flush()
-
+        self.profile1 = self.session.query(UserProfile).get(user_id)
+        self.locale_en = self.profile1.get_locale('en')
+        self.locale_fr = self.profile1.get_locale('fr')
         DocumentRest.create_new_version(self.profile1, user_id)
 
         self.profile2 = UserProfile(categories=['amateur'])

--- a/c2corg_api/tests/views/test_user_profile.py
+++ b/c2corg_api/tests/views/test_user_profile.py
@@ -28,6 +28,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
         body = self.get_collection(user='contributor')
         doc = body['documents'][0]
         self.assertIn('areas', doc)
+        self.assertIn('username', doc)
         self.assertNotIn('geometry', doc)
 
     def test_get_collection_paginated(self):
@@ -67,6 +68,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
         self._assert_geometry(body)
         self.assertIsNone(body['locales'][0].get('title'))
         self.assertNotIn('maps', body)
+        self.assertIn('username', body)
 
     def test_get_lang(self):
         self.get_lang(self.profile1, user='contributor')

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -80,7 +80,7 @@ def to_json_dict(obj, schema):
     # it because it's not a real column)
     special_attributes = [
         'available_langs', 'associations', 'maps', 'areas', 'author',
-        'protected'
+        'protected', 'name', 'username'
     ]
     for attr in special_attributes:
         if hasattr(obj, attr):

--- a/c2corg_api/views/area.py
+++ b/c2corg_api/views/area.py
@@ -1,4 +1,5 @@
-from c2corg_api.models.area import schema_area, Area, schema_update_area
+from c2corg_api.models.area import schema_area, Area, schema_update_area, \
+    schema_listing_area
 from c2corg_api.models.area_association import update_area
 from c2corg_api.models.document import UpdateType
 from c2corg_common.fields_area import fields_area
@@ -21,7 +22,8 @@ class AreaRest(DocumentRest):
 
     @view(validators=[validate_pagination, validate_preferred_lang_param])
     def collection_get(self):
-        return self._collection_get(Area, schema_area, include_areas=False)
+        return self._collection_get(
+            Area, schema_listing_area, include_areas=False)
 
     @view(validators=[validate_id, validate_lang_param])
     def get(self):

--- a/c2corg_api/views/image.py
+++ b/c2corg_api/views/image.py
@@ -1,6 +1,7 @@
 from c2corg_api.models import DBSession
 from c2corg_api.models.document_history import has_been_created_by
-from c2corg_api.models.image import Image, schema_image, schema_update_image
+from c2corg_api.models.image import Image, schema_image, schema_update_image, \
+    schema_listing_image
 from c2corg_common.fields_image import fields_image
 from cornice.resource import resource, view
 
@@ -22,7 +23,7 @@ class ImageRest(DocumentRest):
 
     @view(validators=[validate_pagination, validate_preferred_lang_param])
     def collection_get(self):
-        return self._collection_get(Image, schema_image)
+        return self._collection_get(Image, schema_listing_image)
 
     @view(validators=[validate_id, validate_lang_param])
     def get(self):

--- a/c2corg_api/views/search.py
+++ b/c2corg_api/views/search.py
@@ -53,7 +53,7 @@ class SearchRest(object):
 
             `limit=...` (optional)
             How many results should be returned per document type
-            (default: 10). The maximum ist 50.
+            (default: 10). The maximum is 50.
 
             `t=...` (optional)
             Which document types should be included in the search. If not
@@ -100,7 +100,7 @@ class SearchRest(object):
                 search_term, IMAGE_TYPE, Image, DocumentLocale,
                 schema_listing_image, None, limit, lang)
 
-        if self._include_type(IMAGE_TYPE, types_to_include) and \
+        if self._include_type(USERPROFILE_TYPE, types_to_include) and \
                 self.request.has_permission('authenticated'):
             results['users'] = search.search_for_type(
                 search_term, USERPROFILE_TYPE, UserProfile, DocumentLocale,

--- a/c2corg_api/views/search.py
+++ b/c2corg_api/views/search.py
@@ -1,8 +1,10 @@
+from c2corg_api.models.document import DocumentLocale
 from cornice.resource import resource, view
 
 from c2corg_api.views.validation import validate_pagination, \
     validate_preferred_lang_param
-from c2corg_api.models.route import Route, ROUTE_TYPE, schema_route
+from c2corg_api.models.route import Route, ROUTE_TYPE, schema_route, \
+    RouteLocale
 from c2corg_api.views import cors_policy
 from c2corg_api.search import search
 from c2corg_api.models.waypoint import Waypoint, WAYPOINT_TYPE, schema_waypoint
@@ -35,9 +37,9 @@ class SearchRest(object):
 
         return {
             'waypoints': search.search_for_type(
-                search_term, WAYPOINT_TYPE, Waypoint, schema_waypoint,
-                waypoint_adaptor, limit, lang),
+                search_term, WAYPOINT_TYPE, Waypoint, DocumentLocale,
+                schema_waypoint, waypoint_adaptor, limit, lang),
             'routes': search.search_for_type(
-                search_term, ROUTE_TYPE, Route, schema_route,
-                route_adaptor, limit, lang)
+                search_term, ROUTE_TYPE, Route, RouteLocale,
+                schema_route, route_adaptor, limit, lang)
         }

--- a/c2corg_api/views/search.py
+++ b/c2corg_api/views/search.py
@@ -38,34 +38,83 @@ class SearchRest(object):
 
     @view(validators=[validate_pagination, validate_preferred_lang_param])
     def get(self):
+        """Search for a query word (simple search).
+
+        Request:
+            `GET` `/search?q=...[&lang=...][&limit=...][&t=...]`
+
+        Parameters:
+            `q=...`
+            The search word.
+
+            `lang=...` (optional)
+            When set only the given locale will be included (if available).
+            Otherwise all locales will be returned.
+
+            `limit=...` (optional)
+            How many results should be returned per document type
+            (default: 10). The maximum ist 50.
+
+            `t=...` (optional)
+            Which document types should be included in the search. If not
+            given, all document types are returned. Example: `...&t=w,r`
+            searches only for waypoints and routes.
+        """
         search_term = self.request.params.get('q')
         lang = self.request.validated.get('lang')
         limit = self.request.validated.get('limit')
         limit = min(
             SEARCH_LIMIT_DEFAULT if limit is None else limit,
             SEARCH_LIMIT_MAX)
+        types_to_include = self._parse_types_to_include(
+            self.request.params.get('t'))
 
-        return {
-            'waypoints': search.search_for_type(
+        results = {}
+        if self._include_type(WAYPOINT_TYPE, types_to_include):
+            results['waypoints'] = search.search_for_type(
                 search_term, WAYPOINT_TYPE, Waypoint, DocumentLocale,
-                schema_waypoint, waypoint_adaptor, limit, lang),
-            'routes': search.search_for_type(
+                schema_waypoint, waypoint_adaptor, limit, lang)
+
+        if self._include_type(ROUTE_TYPE, types_to_include):
+            results['routes'] = search.search_for_type(
                 search_term, ROUTE_TYPE, Route, RouteLocale,
-                schema_route, route_adaptor, limit, lang),
-            'outings': search.search_for_type(
+                schema_route, route_adaptor, limit, lang)
+
+        if self._include_type(OUTING_TYPE, types_to_include):
+            results['outings'] = search.search_for_type(
                 search_term, OUTING_TYPE, Outing, DocumentLocale,
-                schema_outing, outing_adaptor, limit, lang),
-            'areas': search.search_for_type(
+                schema_outing, outing_adaptor, limit, lang)
+
+        if self._include_type(AREA_TYPE, types_to_include):
+            results['areas'] = search.search_for_type(
                 search_term, AREA_TYPE, Area, DocumentLocale,
-                schema_listing_area, None, limit, lang),
-            'maps': search.search_for_type(
+                schema_listing_area, None, limit, lang)
+
+        if self._include_type(MAP_TYPE, types_to_include):
+            results['maps'] = search.search_for_type(
                 search_term, MAP_TYPE, TopoMap, DocumentLocale,
-                schema_listing_topo_map, None, limit, lang),
-            'images': search.search_for_type(
+                schema_listing_topo_map, None, limit, lang)
+
+        if self._include_type(IMAGE_TYPE, types_to_include):
+            results['images'] = search.search_for_type(
                 search_term, IMAGE_TYPE, Image, DocumentLocale,
-                schema_listing_image, None, limit, lang),
-            'users': search.search_for_type(
+                schema_listing_image, None, limit, lang)
+
+        if self._include_type(IMAGE_TYPE, types_to_include) and \
+                self.request.has_permission('authenticated'):
+            results['users'] = search.search_for_type(
                 search_term, USERPROFILE_TYPE, UserProfile, DocumentLocale,
                 schema_listing_user_profile, None, limit, lang)
-            if self.request.has_permission('authenticated') else {}
-        }
+
+        return results
+
+    def _parse_types_to_include(self, types_in):
+        if not types_in:
+            return None
+        return types_in.split(',')
+
+    def _include_type(self, doc_type, types_to_include):
+        if not types_to_include:
+            return True
+        else:
+            return doc_type in types_to_include

--- a/c2corg_api/views/search.py
+++ b/c2corg_api/views/search.py
@@ -1,4 +1,12 @@
+from c2corg_api.models.area import AREA_TYPE, Area, \
+    schema_listing_area
 from c2corg_api.models.document import DocumentLocale
+from c2corg_api.models.image import IMAGE_TYPE, Image, schema_listing_image
+from c2corg_api.models.outing import OUTING_TYPE, Outing, schema_outing
+from c2corg_api.models.topo_map import MAP_TYPE, TopoMap, \
+    schema_listing_topo_map
+from c2corg_api.models.user_profile import USERPROFILE_TYPE, UserProfile, \
+    schema_listing_user_profile
 from cornice.resource import resource, view
 
 from c2corg_api.views.validation import validate_pagination, \
@@ -12,6 +20,8 @@ from c2corg_api.views.route import listing_schema_adaptor \
     as route_adaptor
 from c2corg_api.views.waypoint import listing_schema_adaptor \
     as waypoint_adaptor
+from c2corg_api.views.outing import listing_schema_adaptor \
+    as outing_adaptor
 
 # the maximum number of documents that can be returned for each document type
 SEARCH_LIMIT_MAX = 50
@@ -41,5 +51,21 @@ class SearchRest(object):
                 schema_waypoint, waypoint_adaptor, limit, lang),
             'routes': search.search_for_type(
                 search_term, ROUTE_TYPE, Route, RouteLocale,
-                schema_route, route_adaptor, limit, lang)
+                schema_route, route_adaptor, limit, lang),
+            'outings': search.search_for_type(
+                search_term, OUTING_TYPE, Outing, DocumentLocale,
+                schema_outing, outing_adaptor, limit, lang),
+            'areas': search.search_for_type(
+                search_term, AREA_TYPE, Area, DocumentLocale,
+                schema_listing_area, None, limit, lang),
+            'maps': search.search_for_type(
+                search_term, MAP_TYPE, TopoMap, DocumentLocale,
+                schema_listing_topo_map, None, limit, lang),
+            'images': search.search_for_type(
+                search_term, IMAGE_TYPE, Image, DocumentLocale,
+                schema_listing_image, None, limit, lang),
+            'users': search.search_for_type(
+                search_term, USERPROFILE_TYPE, UserProfile, DocumentLocale,
+                schema_listing_user_profile, None, limit, lang)
+            if self.request.has_permission('authenticated') else {}
         }

--- a/c2corg_api/views/topo_map.py
+++ b/c2corg_api/views/topo_map.py
@@ -1,5 +1,5 @@
 from c2corg_api.models.topo_map import (
-    TopoMap, schema_topo_map, schema_update_topo_map)
+    TopoMap, schema_topo_map, schema_update_topo_map, schema_listing_topo_map)
 from c2corg_common.fields_topo_map import fields_topo_map
 from cornice.resource import resource, view
 
@@ -20,7 +20,7 @@ class TopoMapRest(DocumentRest):
 
     @view(validators=[validate_pagination, validate_preferred_lang_param])
     def collection_get(self):
-        return self._collection_get(TopoMap, schema_topo_map)
+        return self._collection_get(TopoMap, schema_listing_topo_map)
 
     @view(validators=[validate_id, validate_lang_param])
     def get(self):

--- a/c2corg_api/views/user_profile.py
+++ b/c2corg_api/views/user_profile.py
@@ -1,6 +1,7 @@
 
 from c2corg_api.models.user_profile import schema_update_user_profile, \
-    UserProfile, schema_user_profile, schema_internal_user_profile
+    UserProfile, schema_user_profile, schema_internal_user_profile, \
+    schema_listing_user_profile
 from cornice.resource import resource
 
 from c2corg_api.views.document import DocumentRest
@@ -17,7 +18,7 @@ class UserProfileRest(DocumentRest):
     @restricted_view(
         validators=[validate_pagination, validate_preferred_lang_param])
     def collection_get(self):
-        return self._collection_get(UserProfile, schema_user_profile)
+        return self._collection_get(UserProfile, schema_listing_user_profile)
 
     @restricted_view(validators=[validate_id, validate_lang_param])
     def get(self):


### PR DESCRIPTION
PR based on https://github.com/c2corg/v6_api/pull/191

Still to do:

* [x] Search for document id
* [x] Index user profile
* [x] Search for user profile (only when authenticated)
* [x] Add option to only search for specific document types. E.g. `?q=...&t=w,r` only searches for waypoints and routes.

Closes https://github.com/c2corg/v6_api/issues/155