### PR TITLE
Skip 'other_users' user category when migrating from v5

### DIFF
--- a/c2corg_api/scripts/migration/documents/user_profiles.py
+++ b/c2corg_api/scripts/migration/documents/user_profiles.py
@@ -131,7 +131,7 @@ class MigrateUserProfiles(MigrateDocuments):
                 document_in.activities, MigrateRoutes.activities),
             categories=self.convert_types(
                 categories, MigrateUserProfiles.user_categories,
-                skip_values=[0, 2]),
+                skip_values=[0, 2, 5]),
         )
 
     def get_document_locale(self, document_in, version):


### PR DESCRIPTION
Else the profile migration tool fails because of an unknown "5" value introduced recently in v5:
https://github.com/c2corg/camptocamp.org/blob/03e9666faf87f5c667bf7c68b47727f11f58a2d3/apps/frontend/modules/users/config/module.yml#L29