### PR TITLE
Use custom ES mapping type for each document type

### DIFF
--- a/c2corg_api/scripts/es/fill_index.py
+++ b/c2corg_api/scripts/es/fill_index.py
@@ -14,7 +14,6 @@ from datetime import datetime, timedelta
 
 from sqlalchemy import engine_from_config
 
-from c2corg_api.search.mapping import SearchDocument
 from c2corg_api.models import DBSession
 from c2corg_api.models.document import DocumentLocale, Document
 from c2corg_api.scripts.es.es_batch import ElasticBatch
@@ -93,7 +92,7 @@ def fill_index(db_session):
                 search_document = {
                     '_op_type': 'index',
                     '_index': index_name,
-                    '_type': SearchDocument._doc_type.name,
+                    '_type': type,
                     '_id': document_id,
                     'doc_type': type
                 }

--- a/c2corg_api/scripts/initializees.py
+++ b/c2corg_api/scripts/initializees.py
@@ -1,5 +1,13 @@
 import os
 import sys
+
+from c2corg_api.search.mappings.area_mapping import SearchArea
+from c2corg_api.search.mappings.image_mapping import SearchImage
+from c2corg_api.search.mappings.outing_mapping import SearchOuting
+from c2corg_api.search.mappings.route_mapping import SearchRoute
+from c2corg_api.search.mappings.topo_map_mapping import SearchTopoMap
+from c2corg_api.search.mappings.user_mapping import SearchUser
+from c2corg_api.search.mappings.waypoint_mapping import SearchWaypoint
 from elasticsearch_dsl import Index
 
 from pyramid.paster import (
@@ -9,7 +17,7 @@ from pyramid.paster import (
 
 from pyramid.scripts.common import parse_vars
 
-from c2corg_api.search.mapping import SearchDocument, analysis_settings
+from c2corg_api.search.mapping import analysis_settings
 from c2corg_api.search import configure_es_from_config, elasticsearch_config
 
 
@@ -51,7 +59,15 @@ def setup_es():
 
     index = Index(index_name)
     index.settings(analysis=analysis_settings)
-    index.doc_type(SearchDocument)
+
+    index.doc_type(SearchArea)
+    index.doc_type(SearchImage)
+    index.doc_type(SearchOuting)
+    index.doc_type(SearchRoute)
+    index.doc_type(SearchTopoMap)
+    index.doc_type(SearchUser)
+    index.doc_type(SearchWaypoint)
+
     index.create()
 
     print('Index "{0}" created'.format(index_name))

--- a/c2corg_api/search/__init__.py
+++ b/c2corg_api/search/__init__.py
@@ -1,8 +1,20 @@
+from c2corg_api.models.area import AREA_TYPE
+from c2corg_api.models.image import IMAGE_TYPE
+from c2corg_api.models.outing import OUTING_TYPE
+from c2corg_api.models.route import ROUTE_TYPE
+from c2corg_api.models.topo_map import MAP_TYPE
+from c2corg_api.models.user_profile import USERPROFILE_TYPE
+from c2corg_api.models.waypoint import WAYPOINT_TYPE
+from c2corg_api.search.mappings.area_mapping import SearchArea
+from c2corg_api.search.mappings.image_mapping import SearchImage
+from c2corg_api.search.mappings.outing_mapping import SearchOuting
+from c2corg_api.search.mappings.route_mapping import SearchRoute
+from c2corg_api.search.mappings.topo_map_mapping import SearchTopoMap
+from c2corg_api.search.mappings.user_mapping import SearchUser
+from c2corg_api.search.mappings.waypoint_mapping import SearchWaypoint
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl.connections import connections
 from elasticsearch_dsl import Search
-
-from c2corg_api.search.mapping import SearchDocument
 
 elasticsearch_config = {
     'client': None,
@@ -29,8 +41,18 @@ def configure_es_from_config(settings):
     elasticsearch_config['port'] = int(settings['elasticsearch.port'])
 
 
-def create_search():
+def create_search(document_type):
     return Search(
         elasticsearch_config['client'],
         index=elasticsearch_config['index'],
-        doc_type=SearchDocument)
+        doc_type=search_documents[document_type])
+
+search_documents = {
+    AREA_TYPE: SearchArea,
+    IMAGE_TYPE: SearchImage,
+    OUTING_TYPE: SearchOuting,
+    ROUTE_TYPE: SearchRoute,
+    MAP_TYPE: SearchTopoMap,
+    USERPROFILE_TYPE: SearchUser,
+    WAYPOINT_TYPE: SearchWaypoint
+}

--- a/c2corg_api/search/mapping.py
+++ b/c2corg_api/search/mapping.py
@@ -1,8 +1,15 @@
 from elasticsearch_dsl import DocType, String, Integer, MetaField
 
 
+class BaseMeta:
+    # disable the '_all' field, see
+    # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-all-field.html
+    all = MetaField(enabled=False)
+
+
 class SearchDocument(DocType):
-    """The ElasticSearch mapping for documents.
+    """The base ElasticSearch mapping for documents. Each document type has
+    its own specific mapping.
 
     We are using the "one language per field" strategy, for example for the
     title field we have a field for each language: title_en, title_fr, ...
@@ -15,6 +22,9 @@ class SearchDocument(DocType):
     See also:
     https://www.elastic.co/guide/en/elasticsearch/guide/current/_index_time_search_as_you_type.html
     """
+    class Meta(BaseMeta):
+        pass
+
     id = Integer()
     doc_type = String(index='not_analyzed')
 
@@ -73,11 +83,6 @@ class SearchDocument(DocType):
         analyzer='index_basque', search_analyzer='search_basque')
     description_eu = String(
         analyzer='index_basque', search_analyzer='search_basque')
-
-    class Meta:
-        # disable the '_all' field, see
-        # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-all-field.html
-        all = MetaField(enabled=False)
 
 """To support partial-matching required for the autocomplete search, we
 have to set up a n-gram filter for each language analyzer. See also:

--- a/c2corg_api/search/mappings/__init__.py
+++ b/c2corg_api/search/mappings/__init__.py
@@ -1,0 +1,1 @@
+# package

--- a/c2corg_api/search/mappings/area_mapping.py
+++ b/c2corg_api/search/mappings/area_mapping.py
@@ -1,0 +1,7 @@
+from c2corg_api.models.area import AREA_TYPE
+from c2corg_api.search.mapping import SearchDocument, BaseMeta
+
+
+class SearchArea(SearchDocument):
+    class Meta(BaseMeta):
+        doc_type = AREA_TYPE

--- a/c2corg_api/search/mappings/image_mapping.py
+++ b/c2corg_api/search/mappings/image_mapping.py
@@ -1,0 +1,7 @@
+from c2corg_api.models.image import IMAGE_TYPE
+from c2corg_api.search.mapping import SearchDocument, BaseMeta
+
+
+class SearchImage(SearchDocument):
+    class Meta(BaseMeta):
+        doc_type = IMAGE_TYPE

--- a/c2corg_api/search/mappings/outing_mapping.py
+++ b/c2corg_api/search/mappings/outing_mapping.py
@@ -1,0 +1,7 @@
+from c2corg_api.models.outing import OUTING_TYPE
+from c2corg_api.search.mapping import SearchDocument, BaseMeta
+
+
+class SearchOuting(SearchDocument):
+    class Meta(BaseMeta):
+        doc_type = OUTING_TYPE

--- a/c2corg_api/search/mappings/route_mapping.py
+++ b/c2corg_api/search/mappings/route_mapping.py
@@ -1,0 +1,7 @@
+from c2corg_api.models.route import ROUTE_TYPE
+from c2corg_api.search.mapping import SearchDocument, BaseMeta
+
+
+class SearchRoute(SearchDocument):
+    class Meta(BaseMeta):
+        doc_type = ROUTE_TYPE

--- a/c2corg_api/search/mappings/topo_map_mapping.py
+++ b/c2corg_api/search/mappings/topo_map_mapping.py
@@ -1,0 +1,7 @@
+from c2corg_api.models.topo_map import MAP_TYPE
+from c2corg_api.search.mapping import SearchDocument, BaseMeta
+
+
+class SearchTopoMap(SearchDocument):
+    class Meta(BaseMeta):
+        doc_type = MAP_TYPE

--- a/c2corg_api/search/mappings/user_mapping.py
+++ b/c2corg_api/search/mappings/user_mapping.py
@@ -1,0 +1,7 @@
+from c2corg_api.models.user_profile import USERPROFILE_TYPE
+from c2corg_api.search.mapping import SearchDocument, BaseMeta
+
+
+class SearchUser(SearchDocument):
+    class Meta(BaseMeta):
+        doc_type = USERPROFILE_TYPE

--- a/c2corg_api/search/mappings/waypoint_mapping.py
+++ b/c2corg_api/search/mappings/waypoint_mapping.py
@@ -1,0 +1,7 @@
+from c2corg_api.models.waypoint import WAYPOINT_TYPE
+from c2corg_api.search.mapping import SearchDocument, BaseMeta
+
+
+class SearchWaypoint(SearchDocument):
+    class Meta(BaseMeta):
+        doc_type = WAYPOINT_TYPE

--- a/c2corg_api/search/search.py
+++ b/c2corg_api/search/search.py
@@ -29,7 +29,7 @@ def search_for_type(
         # filter on the document_type
         type_query = Term(doc_type=document_type)
 
-        search = create_search().\
+        search = create_search(document_type).\
             query(search_query).\
             filter(type_query).\
             fields([]).\

--- a/c2corg_api/search/sync.py
+++ b/c2corg_api/search/sync.py
@@ -6,7 +6,6 @@ from c2corg_api.models.route import Route
 from c2corg_api.models.user import User
 from c2corg_api.models.user_profile import UserProfile
 from c2corg_api.search import elasticsearch_config
-from c2corg_api.search.mapping import SearchDocument
 from c2corg_api.search.utils import strip_bbcodes, get_title
 
 log = logging.getLogger(__name__)
@@ -37,6 +36,7 @@ def sync_search_index(document):
      successfully.
     """
     document_id = document.document_id
+    document_type = document.type
 
     sync_operation = None
     if document.redirects_to:
@@ -47,14 +47,14 @@ def sync_search_index(document):
 
             client.delete(
                 index=index_name,
-                doc_type=SearchDocument._doc_type.name,
+                doc_type=document_type,
                 id=document_id,
                 ignore=404
             )
         sync_operation = remove_doc
     else:
         doc = {
-            'doc_type': document.type
+            'doc_type': document_type
         }
 
         if isinstance(document, Route):
@@ -96,7 +96,7 @@ def sync_search_index(document):
 
             client.index(
                 index=index_name,
-                doc_type=SearchDocument._doc_type.name,
+                doc_type=document_type,
                 id=document_id,
                 body=doc
             )

--- a/c2corg_api/tests/scripts/es/test_fill_index.py
+++ b/c2corg_api/tests/scripts/es/test_fill_index.py
@@ -1,7 +1,8 @@
 from c2corg_api.models.document import DocumentGeometry
 from c2corg_api.models.route import Route, RouteLocale
 from c2corg_api.models.waypoint import Waypoint, WaypointLocale
-from c2corg_api.search.mapping import SearchDocument
+from c2corg_api.search.mappings.route_mapping import SearchRoute
+from c2corg_api.search.mappings.waypoint_mapping import SearchWaypoint
 from c2corg_api.tests import BaseTestCase
 from c2corg_api.scripts.es.fill_index import fill_index
 
@@ -66,24 +67,24 @@ class FillIndexTest(BaseTestCase):
         # fill the ElasticSearch index
         fill_index(self.session)
 
-        waypoint1 = SearchDocument.get(id=71171)
+        waypoint1 = SearchWaypoint.get(id=71171)
         self.assertIsNotNone(waypoint1)
         self.assertEqual(waypoint1.title_en, 'Mont Granier')
         self.assertEqual(waypoint1.title_fr, 'Mont Granier')
         self.assertEqual(waypoint1.summary_fr, 'Le Mont  Granier ')
         self.assertEqual(waypoint1.doc_type, 'w')
 
-        waypoint2 = SearchDocument.get(id=71172)
+        waypoint2 = SearchWaypoint.get(id=71172)
         self.assertIsNotNone(waypoint2)
         self.assertEqual(waypoint2.title_en, 'Mont Blanc')
         self.assertEqual(waypoint2.title_fr, '')
         self.assertEqual(waypoint2.doc_type, 'w')
 
-        route = SearchDocument.get(id=71173)
+        route = SearchRoute.get(id=71173)
         self.assertIsNotNone(route)
         self.assertEqual(route.title_en, 'Mont Blanc : Face N')
         self.assertEqual(route.title_fr, '')
         self.assertEqual(route.doc_type, 'r')
 
         # merged document is ignored
-        self.assertIsNone(SearchDocument.get(id=71174, ignore=404))
+        self.assertIsNone(SearchWaypoint.get(id=71174, ignore=404))

--- a/c2corg_api/tests/search/test_sync.py
+++ b/c2corg_api/tests/search/test_sync.py
@@ -3,7 +3,7 @@ import transaction
 from c2corg_api.models.document import DocumentGeometry
 from c2corg_api.models.waypoint import Waypoint, WaypointLocale
 from c2corg_api.search import elasticsearch_config
-from c2corg_api.search.mapping import SearchDocument
+from c2corg_api.search.mappings.waypoint_mapping import SearchWaypoint
 from c2corg_api.search.sync import sync_search_index
 from c2corg_api.tests import BaseTestCase
 
@@ -30,7 +30,7 @@ class SyncTest(BaseTestCase):
         sync_search_index(waypoint)
         t.commit()
 
-        doc = SearchDocument.get(id=51251, index=index)
+        doc = SearchWaypoint.get(id=51251, index=index)
         self.assertEqual(doc['title_fr'], 'Mont Granier')
         self.assertEqual(doc['summary_fr'], 'Le Mont  Granier ')
         self.assertEqual(doc['doc_type'], 'w')
@@ -77,7 +77,7 @@ class SyncTest(BaseTestCase):
         sync_search_index(waypoint)
         t.commit()
 
-        doc = SearchDocument.get(id=51252, index=index)
+        doc = SearchWaypoint.get(id=51252, index=index)
         self.assertEqual(doc['title_fr'], 'Mont Granier')
         self.assertEqual(doc['summary_fr'], 'Le Mont Granier')
         self.assertEqual(doc['title_en'], 'Mont Granier')
@@ -105,7 +105,7 @@ class SyncTest(BaseTestCase):
         sync_search_index(waypoint)
         t.commit()
 
-        self.assertIsNotNone(SearchDocument.get(id=51251, index=index))
+        self.assertIsNotNone(SearchWaypoint.get(id=51251, index=index))
 
         # then set `redirects_to` and sync again
         waypoint.redirects_to = 51252
@@ -115,7 +115,7 @@ class SyncTest(BaseTestCase):
         t.commit()
 
         # check that the document is removed
-        self.assertIsNone(SearchDocument.get(id=51251, ignore=404))
+        self.assertIsNone(SearchWaypoint.get(id=51251, ignore=404))
 
         # now sync a 2nd time to check that already deleted documents are not
         # a problem
@@ -125,4 +125,4 @@ class SyncTest(BaseTestCase):
         t.commit()
 
         # check that the document is removed
-        self.assertIsNone(SearchDocument.get(id=51251, ignore=404))
+        self.assertIsNone(SearchWaypoint.get(id=51251, ignore=404))

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -4,8 +4,7 @@ import urllib.parse
 import urllib.error
 
 from c2corg_api.models.route import Route
-from c2corg_api.search import elasticsearch_config
-from c2corg_api.search.mapping import SearchDocument
+from c2corg_api.search import elasticsearch_config, search_documents
 from c2corg_api.tests import BaseTestCase
 
 
@@ -63,8 +62,10 @@ class BaseTestRest(BaseTestCase):
 class BaseDocumentTestRest(BaseTestRest):
 
     def set_prefix_and_model(
-            self, prefix, model, model_archive, model_archive_locale):
+            self, prefix, doc_type, model,
+            model_archive, model_archive_locale):
         self._prefix = prefix
+        self._doc_type = doc_type
         self._model = model
         self._model_archive = model_archive
         self._model_archive_locale = model_archive_locale
@@ -401,7 +402,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(archive_locale.lang, lang)
 
         # check updates to the search index
-        search_doc = SearchDocument.get(
+        search_doc = search_documents[self._doc_type].get(
             id=doc.document_id,
             index=elasticsearch_config['index'])
 
@@ -581,7 +582,7 @@ class BaseDocumentTestRest(BaseTestRest):
 
         if check_es:
             # check updates to the search index
-            search_doc = SearchDocument.get(
+            search_doc = search_documents[self._doc_type].get(
                 id=document.document_id,
                 index=elasticsearch_config['index'])
 
@@ -663,7 +664,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertIs(archive_document_en, archive_document_fr)
 
         # check updates to the search index
-        search_doc = SearchDocument.get(
+        search_doc = search_documents[self._doc_type].get(
             id=document.document_id,
             index=elasticsearch_config['index'])
 
@@ -758,7 +759,7 @@ class BaseDocumentTestRest(BaseTestRest):
 
         # check updates to the search index
         if check_es:
-            search_doc = SearchDocument.get(
+            search_doc = search_documents[self._doc_type].get(
                 id=document.document_id,
                 index=elasticsearch_config['index'])
 
@@ -852,7 +853,7 @@ class BaseDocumentTestRest(BaseTestRest):
 
         # check updates to the search index
         if check_es:
-            search_doc = SearchDocument.get(
+            search_doc = search_documents[self._doc_type].get(
                 id=document.document_id,
                 index=elasticsearch_config['index'])
 

--- a/c2corg_api/tests/views/test_area.py
+++ b/c2corg_api/tests/views/test_area.py
@@ -1,6 +1,6 @@
 import json
 
-from c2corg_api.models.area import Area, ArchiveArea
+from c2corg_api.models.area import Area, ArchiveArea, AREA_TYPE
 from c2corg_api.models.area_association import AreaAssociation
 from c2corg_api.models.route import Route
 from c2corg_api.models.waypoint import Waypoint
@@ -17,7 +17,7 @@ class TestAreaRest(BaseDocumentTestRest):
 
     def setUp(self):  # noqa
         self.set_prefix_and_model(
-            "/areas", Area, ArchiveArea, ArchiveDocumentLocale)
+            "/areas", AREA_TYPE, Area, ArchiveArea, ArchiveDocumentLocale)
         BaseDocumentTestRest.setUp(self)
         self._add_test_data()
 

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -1,7 +1,7 @@
 import json
 from shapely.geometry import shape, Point
 
-from c2corg_api.models.image import Image, ArchiveImage
+from c2corg_api.models.image import Image, ArchiveImage, IMAGE_TYPE
 from c2corg_api.models.document import (
     DocumentGeometry, ArchiveDocumentLocale, DocumentLocale)
 from c2corg_api.views.document import DocumentRest
@@ -13,7 +13,7 @@ class TestImageRest(BaseDocumentTestRest):
 
     def setUp(self):  # noqa
         self.set_prefix_and_model(
-            "/images", Image, ArchiveImage, ArchiveDocumentLocale)
+            "/images", IMAGE_TYPE, Image, ArchiveImage, ArchiveDocumentLocale)
         BaseDocumentTestRest.setUp(self)
         self._add_test_data()
 

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -4,7 +4,7 @@ import json
 from c2corg_api.models.association import Association, AssociationLog
 from c2corg_api.models.document_history import DocumentVersion
 from c2corg_api.models.outing import Outing, ArchiveOuting, \
-    ArchiveOutingLocale, OutingLocale
+    ArchiveOutingLocale, OutingLocale, OUTING_TYPE
 from c2corg_api.models.waypoint import Waypoint, WaypointLocale
 from shapely.geometry import shape, LineString
 
@@ -20,7 +20,8 @@ class TestOutingRest(BaseDocumentTestRest):
 
     def setUp(self):  # noqa
         self.set_prefix_and_model(
-            '/outings', Outing, ArchiveOuting, ArchiveOutingLocale)
+            '/outings', OUTING_TYPE, Outing, ArchiveOuting,
+            ArchiveOutingLocale)
         BaseDocumentTestRest.setUp(self)
         self._add_test_data()
 

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -12,7 +12,7 @@ from c2corg_api.views.route import update_title_prefix
 from shapely.geometry import shape, LineString
 
 from c2corg_api.models.route import (
-    Route, RouteLocale, ArchiveRoute, ArchiveRouteLocale)
+    Route, RouteLocale, ArchiveRoute, ArchiveRouteLocale, ROUTE_TYPE)
 from c2corg_api.models.document import DocumentGeometry, DocumentLocale
 from c2corg_api.views.document import DocumentRest
 
@@ -24,7 +24,7 @@ class TestRouteRest(BaseDocumentTestRest):
 
     def setUp(self):  # noqa
         self.set_prefix_and_model(
-            "/routes", Route, ArchiveRoute, ArchiveRouteLocale)
+            "/routes", ROUTE_TYPE, Route, ArchiveRoute, ArchiveRouteLocale)
         BaseDocumentTestRest.setUp(self)
         self._add_test_data()
 

--- a/c2corg_api/tests/views/test_topo_map.py
+++ b/c2corg_api/tests/views/test_topo_map.py
@@ -1,6 +1,6 @@
 import json
 
-from c2corg_api.models.topo_map import ArchiveTopoMap, TopoMap
+from c2corg_api.models.topo_map import ArchiveTopoMap, TopoMap, MAP_TYPE
 from shapely.geometry import shape, Point
 
 from c2corg_api.models.document import (
@@ -14,7 +14,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
 
     def setUp(self):  # noqa
         self.set_prefix_and_model(
-            "/maps", TopoMap, ArchiveTopoMap, ArchiveDocumentLocale)
+            "/maps", MAP_TYPE, TopoMap, ArchiveTopoMap, ArchiveDocumentLocale)
         BaseDocumentTestRest.setUp(self)
         self._add_test_data()
 

--- a/c2corg_api/tests/views/test_user_profile.py
+++ b/c2corg_api/tests/views/test_user_profile.py
@@ -1,8 +1,9 @@
 import json
 
-from c2corg_api.models.user_profile import UserProfile, ArchiveUserProfile
+from c2corg_api.models.user_profile import UserProfile, ArchiveUserProfile, \
+    USERPROFILE_TYPE
 from c2corg_api.search import elasticsearch_config
-from c2corg_api.search.mapping import SearchDocument
+from c2corg_api.search.mappings.user_mapping import SearchUser
 from shapely.geometry import shape, Point
 
 from c2corg_api.models.document import (
@@ -16,7 +17,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
 
     def setUp(self):  # noqa
         self.set_prefix_and_model(
-            '/profiles', UserProfile, ArchiveUserProfile,
+            '/profiles', USERPROFILE_TYPE, UserProfile, ArchiveUserProfile,
             ArchiveDocumentLocale)
         BaseDocumentTestRest.setUp(self)
         self._add_test_data()
@@ -289,7 +290,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
         self.assertEqual(search_doc['title_es'], 'contributor Contributor')
 
     def _check_es_index(self):
-        search_doc = SearchDocument.get(
+        search_doc = SearchUser.get(
             id=self.profile1.document_id,
             index=elasticsearch_config['index'])
         self.assertEqual(search_doc['doc_type'], self.profile1.type)

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -8,12 +8,13 @@ from c2corg_api.models.document_history import DocumentVersion
 from c2corg_api.models.outing import Outing, OutingLocale
 from c2corg_api.models.topo_map import TopoMap
 from c2corg_api.search import elasticsearch_config
-from c2corg_api.search.mapping import SearchDocument
+from c2corg_api.search.mappings.route_mapping import SearchRoute
 from shapely.geometry import shape, Point
 
 from c2corg_api.models.route import Route, RouteLocale
 from c2corg_api.models.waypoint import (
-    Waypoint, WaypointLocale, ArchiveWaypoint, ArchiveWaypointLocale)
+    Waypoint, WaypointLocale, ArchiveWaypoint, ArchiveWaypointLocale,
+    WAYPOINT_TYPE)
 from c2corg_api.models.document import (
     DocumentGeometry, ArchiveDocumentGeometry, DocumentLocale)
 from c2corg_api.views.document import DocumentRest
@@ -25,7 +26,8 @@ class TestWaypointRest(BaseDocumentTestRest):
 
     def setUp(self):  # noqa
         self.set_prefix_and_model(
-            "/waypoints", Waypoint, ArchiveWaypoint, ArchiveWaypointLocale)
+            "/waypoints", WAYPOINT_TYPE, Waypoint, ArchiveWaypoint,
+            ArchiveWaypointLocale)
         BaseDocumentTestRest.setUp(self)
         self._add_test_data()
 
@@ -432,7 +434,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.assertEqual(route_locale_en.title_prefix, 'Mont Granier!')
 
         # check that the route was updated in the search index
-        search_doc = SearchDocument.get(
+        search_doc = SearchRoute.get(
             id=route.document_id,
             index=elasticsearch_config['index'])
         self.assertEqual(


### PR DESCRIPTION
Right now there is only one ElasticSearch [mapping type](https://github.com/c2corg/v6_api/blob/master/c2corg_api/search/mapping.py) for all document types. For the advanced search we will have to store more fields in ES so that it makes sense to have a separate mapping type for each document types.

After this PR is merged, the ES index has to be rebuilt:

```bash
curl -XDELETE 'http://localhost:9200/c2corg_tsauerwein/'
.build/venv/bin/initialize_c2corg_api_es development.ini
.build/venv/bin/fill_es_index development.ini
```