### PR TITLE
Quality field

### DIFF
--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -23,6 +23,7 @@ from c2corg_api.ext import colander_ext
 from c2corg_api.models.utils import copy_attributes, extend_dict
 from pyramid.httpexceptions import HTTPInternalServerError
 from c2corg_common import document_types
+from c2corg_common.attributes import quality_types
 
 UpdateType = enum.Enum(
     'UpdateType', 'FIGURES LANG GEOM')
@@ -53,7 +54,8 @@ class _DocumentMixin(object):
             Integer, ForeignKey(schema + '.documents.document_id'),
             nullable=True)
 
-    quality = Column(enums.quality_type)
+    quality = Column(
+        enums.quality_type, nullable=False, server_default=quality_types[1])
 
     type = Column(String(1))
     __mapper_args__ = {

--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -381,7 +381,7 @@ class ArchiveDocumentGeometry(Base, _DocumentGeometryMixin):
 
 
 schema_attributes = [
-    'document_id', 'version', 'locales', 'geometry'
+    'document_id', 'version', 'locales', 'geometry', 'quality'
 ]
 schema_locale_attributes = [
     'version', 'lang', 'title', 'description', 'summary'

--- a/c2corg_api/scripts/migration/documents/area.py
+++ b/c2corg_api/scripts/migration/documents/area.py
@@ -1,7 +1,8 @@
 from c2corg_api.models.area import Area, ArchiveArea, AREA_TYPE
 from c2corg_api.models.document import DocumentLocale, ArchiveDocumentLocale, \
     DOCUMENT_TYPE
-from c2corg_api.scripts.migration.documents.document import MigrateDocuments
+from c2corg_api.scripts.migration.documents.document import MigrateDocuments, \
+    DEFAULT_QUALITY
 
 
 class MigrateAreas(MigrateDocuments):
@@ -68,6 +69,7 @@ class MigrateAreas(MigrateDocuments):
             redirects_to=document_in.redirects_to,
             area_type=self.convert_type(
                 document_in.area_type, MigrateAreas.area_types),
+            quality=DEFAULT_QUALITY
         )
 
     def get_document_locale(self, document_in, version):

--- a/c2corg_api/scripts/migration/documents/document.py
+++ b/c2corg_api/scripts/migration/documents/document.py
@@ -8,6 +8,10 @@ from c2corg_api.models.document import DocumentGeometry, \
     ArchiveDocumentGeometry
 from c2corg_api.scripts.migration.documents.batch_document import DocumentBatch
 from c2corg_api.scripts.migration.migrate_base import MigrateBase
+from c2corg_common.attributes import quality_types
+
+
+DEFAULT_QUALITY = quality_types[2]
 
 
 class MigrateDocuments(MigrateBase):

--- a/c2corg_api/scripts/migration/documents/images.py
+++ b/c2corg_api/scripts/migration/documents/images.py
@@ -1,7 +1,8 @@
 from c2corg_api.models.image import Image, ArchiveImage, IMAGE_TYPE
 from c2corg_api.models.document import DocumentLocale, ArchiveDocumentLocale, \
     DOCUMENT_TYPE
-from c2corg_api.scripts.migration.documents.document import MigrateDocuments
+from c2corg_api.scripts.migration.documents.document import MigrateDocuments, \
+    DEFAULT_QUALITY
 
 
 class MigrateImages(MigrateDocuments):
@@ -87,7 +88,8 @@ class MigrateImages(MigrateDocuments):
             has_svg=document_in.has_svg,
             width=document_in.width,
             height=document_in.height,
-            file_size=document_in.file_size
+            file_size=document_in.file_size,
+            quality=DEFAULT_QUALITY
         )
 
     def get_document_locale(self, document_in, version):

--- a/c2corg_api/scripts/migration/documents/outings.py
+++ b/c2corg_api/scripts/migration/documents/outings.py
@@ -1,6 +1,7 @@
 from c2corg_api.models.outing import OutingLocale, Outing, ArchiveOuting, \
     ArchiveOutingLocale, OUTING_TYPE
-from c2corg_api.scripts.migration.documents.document import MigrateDocuments
+from c2corg_api.scripts.migration.documents.document import MigrateDocuments, \
+    DEFAULT_QUALITY
 from c2corg_api.scripts.migration.documents.routes import MigrateRoutes
 import phpserialize
 import json
@@ -119,7 +120,8 @@ class MigrateOutings(MigrateDocuments):
                 document_in.lift_status,
                 MigrateOutings.lift_status),
             partial_trip=document_in.partial_trip,
-            public_transport=document_in.outing_with_public_transportation
+            public_transport=document_in.outing_with_public_transportation,
+            quality=DEFAULT_QUALITY
         )
 
     def get_document_locale(self, document_in, version):

--- a/c2corg_api/scripts/migration/documents/routes.py
+++ b/c2corg_api/scripts/migration/documents/routes.py
@@ -1,6 +1,7 @@
 from c2corg_api.models.route import Route, RouteLocale, ArchiveRoute, \
     ArchiveRouteLocale, ROUTE_TYPE
-from c2corg_api.scripts.migration.documents.document import MigrateDocuments
+from c2corg_api.scripts.migration.documents.document import MigrateDocuments, \
+    DEFAULT_QUALITY
 
 
 class MigrateRoutes(MigrateDocuments):
@@ -174,6 +175,7 @@ class MigrateRoutes(MigrateDocuments):
             exposition_rock_rating=self.convert_type(
                 document_in.rock_exposition_rating,
                 MigrateRoutes.exposition_rock_ratings),
+            quality=DEFAULT_QUALITY
         )
 
     def get_document_locale(self, document_in, version):

--- a/c2corg_api/scripts/migration/documents/waypoints/huts.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/huts.py
@@ -1,4 +1,5 @@
 from c2corg_api.models.waypoint import WAYPOINT_TYPE
+from c2corg_api.scripts.migration.documents.document import DEFAULT_QUALITY
 from c2corg_api.scripts.migration.documents.waypoints.waypoint import \
     MigrateWaypoints
 
@@ -74,7 +75,8 @@ class MigrateHuts(MigrateWaypoints):
             gas_unstaffed=self.convert_type(
                 document_in.has_unstaffed_gas, MigrateHuts.boolean_types),
             heating_unstaffed=self.convert_type(
-                document_in.has_unstaffed_wood, MigrateHuts.boolean_types)
+                document_in.has_unstaffed_wood, MigrateHuts.boolean_types),
+            quality=DEFAULT_QUALITY
         )
 
     def get_document_locale(self, document_in, version):

--- a/c2corg_api/scripts/migration/documents/waypoints/parking.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/parking.py
@@ -1,4 +1,5 @@
 from c2corg_api.models.waypoint import WAYPOINT_TYPE
+from c2corg_api.scripts.migration.documents.document import DEFAULT_QUALITY
 from c2corg_api.scripts.migration.documents.waypoints.waypoint import \
     MigrateWaypoints
 
@@ -67,8 +68,8 @@ class MigrateParkings(MigrateWaypoints):
                 MigrateParkings.snow_clearance_ratings),
             public_transportation_types=self.convert_types(
                 document_in.public_transportation_types,
-                MigrateParkings.public_transportation_types, [0])
-
+                MigrateParkings.public_transportation_types, [0]),
+            quality=DEFAULT_QUALITY
         )
 
     def get_document_locale(self, document_in, version):

--- a/c2corg_api/scripts/migration/documents/waypoints/products.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/products.py
@@ -1,4 +1,5 @@
 from c2corg_api.models.waypoint import WAYPOINT_TYPE
+from c2corg_api.scripts.migration.documents.document import DEFAULT_QUALITY
 from c2corg_api.scripts.migration.documents.waypoints.waypoint import \
     MigrateWaypoints
 
@@ -58,7 +59,8 @@ class MigrateProducts(MigrateWaypoints):
             product_types=self.convert_types(
                 document_in.product_type,
                 MigrateProducts.product_types, [0]),
-            url=document_in.url
+            url=document_in.url,
+            quality=DEFAULT_QUALITY
         )
 
     def get_document_locale(self, document_in, version):

--- a/c2corg_api/scripts/migration/documents/waypoints/sites.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/sites.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from c2corg_api.models.waypoint import WAYPOINT_TYPE
+from c2corg_api.scripts.migration.documents.document import DEFAULT_QUALITY
 from c2corg_api.scripts.migration.documents.waypoints.waypoint import \
     MigrateWaypoints
 
@@ -89,7 +90,8 @@ class MigrateSites(MigrateWaypoints):
             orientation=self.convert_types(
                 document_in.facings, MigrateSites.orientation_types, [0]),
             best_periods=self.convert_types(
-                document_in.best_periods, MigrateSites.best_periods)
+                document_in.best_periods, MigrateSites.best_periods),
+            quality=DEFAULT_QUALITY
         )
 
     def get_document_locale(self, document_in, version):

--- a/c2corg_api/scripts/migration/documents/waypoints/summit.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/summit.py
@@ -1,4 +1,5 @@
 from c2corg_api.models.waypoint import WAYPOINT_TYPE
+from c2corg_api.scripts.migration.documents.document import DEFAULT_QUALITY
 from c2corg_api.scripts.migration.documents.waypoints.waypoint import \
     MigrateWaypoints
 
@@ -51,7 +52,8 @@ class MigrateSummits(MigrateWaypoints):
             protected=document_in.is_protected,
             redirects_to=document_in.redirects_to,
             elevation=document_in.elevation,
-            maps_info=document_in.maps_info
+            maps_info=document_in.maps_info,
+            quality=DEFAULT_QUALITY
         )
 
     def get_document_locale(self, document_in, version):

--- a/c2corg_api/tests/views/test_area.py
+++ b/c2corg_api/tests/views/test_area.py
@@ -4,6 +4,7 @@ from c2corg_api.models.area import Area, ArchiveArea, AREA_TYPE
 from c2corg_api.models.area_association import AreaAssociation
 from c2corg_api.models.route import Route
 from c2corg_api.models.waypoint import Waypoint
+from c2corg_common.attributes import quality_types
 from shapely.geometry import shape, Polygon
 
 from c2corg_api.models.document import (
@@ -237,6 +238,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'document_id': self.area1.document_id,
                 'version': self.area1.version,
                 'area_type': 'admin_limits',
+                'quality': quality_types[1],
                 'locales': [
                     {'lang': 'en', 'title': 'New title',
                      'version': self.locale_en.version}
@@ -275,6 +277,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'document_id': self.area1.document_id,
                 'version': self.area1.version,
                 'area_type': 'admin_limits',
+                'quality': quality_types[1],
                 'geometry': {
                     'version': self.area1.geometry.version,
                     'geom_detail': '{"type":"Polygon","coordinates":[[[668519.249382151,5728802.39591739],[668518.249382151,5745465.66808356],[689156.247019149,5745465.66808356],[689156.247019149,5728802.39591739],[668519.249382151,5728802.39591739]]]}'  # noqa
@@ -310,6 +313,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'document_id': self.area1.document_id,
                 'version': self.area1.version,
                 'area_type': 'admin_limits',
+                'quality': quality_types[1],
                 'locales': [
                     {'lang': 'en', 'title': 'Chartreuse',
                      'version': self.locale_en.version}
@@ -336,6 +340,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'document_id': self.area1.document_id,
                 'version': self.area1.version,
                 'area_type': 'range',
+                'quality': quality_types[1],
                 'locales': [
                     {'lang': 'en', 'title': 'New title',
                      'version': self.locale_en.version}
@@ -365,6 +370,7 @@ class TestAreaRest(BaseDocumentTestRest):
                 'document_id': self.area1.document_id,
                 'version': self.area1.version,
                 'area_type': 'range',
+                'quality': quality_types[1],
                 'locales': [
                     {'lang': 'es', 'title': 'Chartreuse'}
                 ]

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -1,4 +1,6 @@
 import json
+
+from c2corg_common.attributes import quality_types
 from shapely.geometry import shape, Point
 
 from c2corg_api.models.image import Image, ArchiveImage, IMAGE_TYPE
@@ -229,6 +231,7 @@ class TestImageRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.image4.document_id,
                 'version': self.image4.version,
+                'quality': quality_types[1],
                 'activities': ['skitouring'],
                 'image_type': 'personal',
                 'height': 2000,
@@ -250,6 +253,7 @@ class TestImageRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.image.document_id,
                 'version': self.image.version,
+                'quality': quality_types[1],
                 'activities': ['paragliding'],
                 'image_type': 'collaborative',
                 'height': 2000,
@@ -294,6 +298,7 @@ class TestImageRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.image.document_id,
                 'version': self.image.version,
+                'quality': quality_types[1],
                 'activities': ['paragliding'],
                 'image_type': 'collaborative',
                 'height': 2000,
@@ -314,6 +319,7 @@ class TestImageRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.image.document_id,
                 'version': self.image.version,
+                'quality': quality_types[1],
                 'activities': ['paragliding'],
                 'image_type': 'collaborative',
                 'height': 1500,
@@ -337,6 +343,7 @@ class TestImageRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.image.document_id,
                 'version': self.image.version,
+                'quality': quality_types[1],
                 'activities': ['paragliding'],
                 'image_type': 'collaborative',
                 'height': 1500,
@@ -359,6 +366,7 @@ class TestImageRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.image.document_id,
                 'version': self.image.version,
+                'quality': quality_types[1],
                 'activities': ['paragliding'],
                 'image_type': 'personal',
                 'height': 1500,
@@ -383,6 +391,7 @@ class TestImageRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.image.document_id,
                 'version': self.image.version,
+                'quality': quality_types[1],
                 'activities': ['paragliding'],
                 'image_type': 'personal',
                 'height': 1500,
@@ -406,6 +415,7 @@ class TestImageRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.image4.document_id,
                 'version': self.image4.version,
+                'quality': quality_types[1],
                 'activities': ['paragliding'],
                 'image_type': 'collaborative',
                 'height': 1500,

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -6,6 +6,7 @@ from c2corg_api.models.document_history import DocumentVersion
 from c2corg_api.models.outing import Outing, ArchiveOuting, \
     ArchiveOutingLocale, OutingLocale, OUTING_TYPE
 from c2corg_api.models.waypoint import Waypoint, WaypointLocale
+from c2corg_common.attributes import quality_types
 from shapely.geometry import shape, LineString
 
 from c2corg_api.models.route import Route, RouteLocale
@@ -510,6 +511,7 @@ class TestOutingRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.outing.document_id,
                 'version': self.outing.version,
+                'quality': quality_types[1],
                 'activities': ['skitouring'],
                 'date_start': '2016-01-01',
                 'date_end': '2016-01-02',
@@ -535,6 +537,7 @@ class TestOutingRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.outing.document_id,
                 'version': self.outing.version,
+                'quality': quality_types[1],
                 'activities': ['skitouring'],
                 'date_start': '2016-01-01',
                 'date_end': '2016-01-02',
@@ -592,6 +595,7 @@ class TestOutingRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.outing.document_id,
                 'version': self.outing.version,
+                'quality': quality_types[1],
                 'activities': ['skitouring'],
                 'date_start': '2016-01-01',
                 'date_end': '2016-01-01',
@@ -619,6 +623,7 @@ class TestOutingRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.outing.document_id,
                 'version': self.outing.version,
+                'quality': quality_types[1],
                 'activities': ['skitouring'],
                 'date_start': '2016-01-01',
                 'date_end': '2016-01-01',
@@ -651,6 +656,7 @@ class TestOutingRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.outing.document_id,
                 'version': self.outing.version,
+                'quality': quality_types[1],
                 'activities': ['skitouring'],
                 'date_start': '2016-01-01',
                 'date_end': '2016-01-01',
@@ -678,6 +684,7 @@ class TestOutingRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.outing.document_id,
                 'version': self.outing.version,
+                'quality': quality_types[1],
                 'activities': ['skitouring'],
                 'date_start': '2016-01-01',
                 'date_end': '2016-01-01',

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -9,6 +9,7 @@ from c2corg_api.models.outing import Outing, OutingLocale
 from c2corg_api.models.topo_map import TopoMap
 from c2corg_api.models.waypoint import Waypoint, WaypointLocale
 from c2corg_api.views.route import update_title_prefix
+from c2corg_common.attributes import quality_types
 from shapely.geometry import shape, LineString
 
 from c2corg_api.models.route import (
@@ -400,6 +401,7 @@ class TestRouteRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.route.document_id,
                 'version': self.route.version,
+                'quality': quality_types[1],
                 'activities': ['skitouring'],
                 'elevation_min': 700,
                 'elevation_max': 1600,
@@ -453,6 +455,7 @@ class TestRouteRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.route.document_id,
                 'version': self.route.version,
+                'quality': quality_types[1],
                 'activities': ['skitouring'],
                 'elevation_min': 700,
                 'elevation_max': 1600,
@@ -480,6 +483,7 @@ class TestRouteRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.route.document_id,
                 'version': self.route.version,
+                'quality': quality_types[1],
                 'activities': ['skitouring'],
                 'elevation_min': 700,
                 'elevation_max': 1600,
@@ -514,6 +518,7 @@ class TestRouteRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.route2.document_id,
                 'version': self.route2.version,
+                'quality': quality_types[1],
                 'main_waypoint_id': self.waypoint.document_id,
                 'activities': ['skitouring'],
                 'elevation_min': 700,
@@ -538,6 +543,7 @@ class TestRouteRest(BaseDocumentTestRest):
                 'document_id': self.route.document_id,
                 'main_waypoint_id': self.waypoint2.document_id,
                 'version': self.route.version,
+                'quality': quality_types[1],
                 'activities': ['skitouring'],
                 'elevation_min': 700,
                 'elevation_max': 1500,
@@ -580,6 +586,7 @@ class TestRouteRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.route.document_id,
                 'version': self.route.version,
+                'quality': quality_types[1],
                 'activities': ['skitouring'],
                 'elevation_min': 700,
                 'elevation_max': 1500,
@@ -605,6 +612,7 @@ class TestRouteRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.route.document_id,
                 'version': self.route.version,
+                'quality': quality_types[1],
                 'activities': ['skitouring'],
                 'elevation_min': 700,
                 'elevation_max': 1500,

--- a/c2corg_api/tests/views/test_topo_map.py
+++ b/c2corg_api/tests/views/test_topo_map.py
@@ -1,6 +1,7 @@
 import json
 
 from c2corg_api.models.topo_map import ArchiveTopoMap, TopoMap, MAP_TYPE
+from c2corg_common.attributes import quality_types
 from shapely.geometry import shape, Point
 
 from c2corg_api.models.document import (
@@ -216,6 +217,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.map1.document_id,
                 'version': self.map1.version,
+                'quality': quality_types[1],
                 'editor': 'IGN',
                 'scale': '25000',
                 'code': '3433OT',
@@ -259,6 +261,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.map1.document_id,
                 'version': self.map1.version,
+                'quality': quality_types[1],
                 'editor': 'IGN',
                 'scale': '25000',
                 'code': '3433OT',
@@ -279,6 +282,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.map1.document_id,
                 'version': self.map1.version,
+                'quality': quality_types[1],
                 'editor': 'IGN',
                 'scale': '25000',
                 'code': '3431OT',
@@ -302,6 +306,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.map1.document_id,
                 'version': self.map1.version,
+                'quality': quality_types[1],
                 'editor': 'IGN',
                 'scale': '25000',
                 'code': '3431OT',

--- a/c2corg_api/tests/views/test_user_profile.py
+++ b/c2corg_api/tests/views/test_user_profile.py
@@ -4,6 +4,7 @@ from c2corg_api.models.user_profile import UserProfile, ArchiveUserProfile, \
     USERPROFILE_TYPE
 from c2corg_api.search import elasticsearch_config
 from c2corg_api.search.mappings.user_mapping import SearchUser
+from c2corg_common.attributes import quality_types
 from shapely.geometry import shape, Point
 
 from c2corg_api.models.document import (
@@ -179,6 +180,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.profile1.document_id,
                 'version': self.profile1.version,
+                'quality': quality_types[1],
                 'categories': ['mountain_guide'],
                 'locales': [
                     {'lang': 'en', 'description': 'Me!',
@@ -208,6 +210,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.profile1.document_id,
                 'version': self.profile1.version,
+                'quality': quality_types[1],
                 'categories': ['mountain_guide'],
                 'locales': [
                     {'lang': 'en', 'description': 'Me',
@@ -227,6 +230,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.profile1.document_id,
                 'version': self.profile1.version,
+                'quality': quality_types[1],
                 'categories': ['amateur'],
                 'locales': [
                     {'lang': 'en', 'description': 'Me!',
@@ -249,6 +253,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.profile1.document_id,
                 'version': self.profile1.version,
+                'quality': quality_types[1],
                 'categories': ['amateur'],
                 'locales': [
                     {'lang': 'en', 'title': 'Should not be set',
@@ -276,6 +281,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.profile1.document_id,
                 'version': self.profile1.version,
+                'quality': quality_types[1],
                 'categories': ['amateur'],
                 'locales': [
                     {'lang': 'es', 'description': 'Yo'}

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -9,6 +9,7 @@ from c2corg_api.models.outing import Outing, OutingLocale
 from c2corg_api.models.topo_map import TopoMap
 from c2corg_api.search import elasticsearch_config
 from c2corg_api.search.mappings.route_mapping import SearchRoute
+from c2corg_common.attributes import quality_types
 from shapely.geometry import shape, Point
 
 from c2corg_api.models.route import Route, RouteLocale
@@ -387,6 +388,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.waypoint.document_id,
                 'version': self.waypoint.version,
+                'quality': quality_types[1],
                 'waypoint_type': 'summit',
                 'elevation': 1234,
                 'locales': [
@@ -454,6 +456,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.waypoint.document_id,
                 'version': self.waypoint.version,
+                'quality': quality_types[1],
                 'waypoint_type': 'summit',
                 'elevation': 1234,
                 'locales': [
@@ -534,6 +537,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.waypoint.document_id,
                 'version': self.waypoint.version,
+                'quality': quality_types[1],
                 'waypoint_type': 'summit',
                 'elevation': 1234,
                 'locales': []
@@ -551,6 +555,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.waypoint.document_id,
                 'version': self.waypoint.version,
+                'quality': quality_types[1],
                 'waypoint_type': 'summit',
                 'elevation': 2203,
                 'locales': [
@@ -572,6 +577,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.waypoint.document_id,
                 'version': self.waypoint.version,
+                'quality': quality_types[1],
                 'waypoint_type': 'summit',
                 'elevation': 2203,
                 'locales': [
@@ -609,6 +615,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'document': {
                 'document_id': waypoint.document_id,
                 'version': waypoint.version,
+                'quality': quality_types[1],
                 'geometry': {
                     'geom':
                         '{"type": "Point", "coordinates": [635956, 5723604]}'
@@ -685,6 +692,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.waypoint5.document_id,
                 'version': self.waypoint5.version,
+                'quality': quality_types[1],
                 'waypoint_type': 'summit',
                 'elevation': 3779,
                 'locales': []
@@ -710,6 +718,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.waypoint4.document_id,
                 'version': self.waypoint4.version,
+                'quality': quality_types[1],
                 'waypoint_type': 'summit',
                 'elevation': 3779,
                 'locales': []
@@ -736,6 +745,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             'document': {
                 'document_id': self.waypoint4.document_id,
                 'version': self.waypoint4.version,
+                'quality': quality_types[1],
                 'waypoint_type': 'summit',
                 'elevation': 3779,
                 'locales': []

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ git+https://github.com/tsauerwein/ColanderAlchemy.git@c2corg
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@556db4c
+git+https://github.com/c2corg/v6_common.git@343e1ef
 
 # Discourse API client
 git+https://github.com/c2corg/pydiscourse.git@65e398343bbbc74fdb71cca4637c9f808e5adfb2


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_api/issues/220 and https://github.com/c2corg/v6_common/pull/19

Currently the tests fail because
> sqlalchemy.engine.base.Engine: INFO: UPDATE guidebook.documents SET version=%(version)s, quality=%(quality)s WHERE guidebook.documents.document_id = %(guidebook_documents_document_id)s AND guidebook.documents.version = %(guidebook_documents_version)s
sqlalchemy.engine.base.Engine: INFO: {'quality': None, 'version': 2, 'guidebook_documents_version': 1, 'guidebook_documents_document_id': 1531}
sqlalchemy.engine.base.Engine: INFO: ROLLBACK
txn.139844722906880: DEBUG: abort
c2corg_api: DEBUG: debug_authorization of url http://localhost/waypoints/1531 (view name '' against context IntegrityError('(psycopg2.IntegrityError) null value in column "quality" violates not-null constraint\nDETAIL: Failing row contains (2, null, null, w, 1531, null).\n',)): Allowed (NO_PERMISSION_REQUIRED)

see https://github.com/c2corg/v6_common/pull/19#issuecomment-207486296