### PR TITLE
Orientations fix

### DIFF
--- a/c2corg_api/models/route.py
+++ b/c2corg_api/models/route.py
@@ -152,7 +152,7 @@ attributes = [
     'main_waypoint_id', 'activities', 'elevation_min', 'elevation_max',
     'height_diff_up', 'height_diff_down', 'route_length',
     'difficulties_height', 'height_diff_access', 'height_diff_difficulties',
-    'route_types', 'orientation', 'duration', 'glacier_gear', 'configuration',
+    'route_types', 'orientations', 'duration', 'glacier_gear', 'configuration',
     'lift_access', 'ski_rating', 'ski_exposition', 'labande_ski_rating',
     'labande_global_rating', 'global_rating', 'engagement_rating',
     'risk_rating', 'equipment_rating', 'ice_rating', 'mixed_rating',

--- a/c2corg_api/models/route.py
+++ b/c2corg_api/models/route.py
@@ -145,7 +145,7 @@ class _RouteMixin(object):
     rock_types = Column(ArrayOfEnum(enums.rock_type))
 
     # type de voie
-    climbing_outdoor_types = Column(enums.climbing_outdoor_type)
+    climbing_outdoor_type = Column(enums.climbing_outdoor_type)
 
 
 attributes = [
@@ -160,7 +160,7 @@ attributes = [
     'aid_rating', 'via_ferrata_rating', 'hiking_rating',
     'hiking_mtb_exposition', 'snowshoe_rating', 'mtb_up_rating',
     'mtb_down_rating', 'mtb_length_asphalt', 'mtb_length_trail',
-    'mtb_height_diff_portages', 'rock_types', 'climbing_outdoor_types']
+    'mtb_height_diff_portages', 'rock_types', 'climbing_outdoor_type']
 
 
 class Route(_RouteMixin, Document):

--- a/c2corg_api/models/waypoint.py
+++ b/c2corg_api/models/waypoint.py
@@ -75,8 +75,8 @@ class _WaypointMixin(object):
     # pluie (climbing_outdoor/indoor)
     rain_proof = Column(enums.rain_proof_type)
 
-    # orientation (climbing_outdoor/indoor, paragliding_takeoff/landing)
-    orientation = Column(ArrayOfEnum(enums.orientation_type))
+    # orientations (climbing_outdoor/indoor, paragliding_takeoff/landing)
+    orientations = Column(ArrayOfEnum(enums.orientation_type))
 
     # meilleurs periodes (climbing_outdoor/indoor, paragliding_takeoff/landing)
     best_periods = Column(ArrayOfEnum(enums.month_type))
@@ -171,7 +171,7 @@ attributes = [
     'public_transportation_types', 'product_types', 'ground_types',
     'weather_station_types', 'rain_proof', 'public_transportation_rating',
     'paragliding_rating', 'children_proof', 'snow_clearance_rating',
-    'exposition_rating', 'rock_types', 'orientation',
+    'exposition_rating', 'rock_types', 'orientations',
     'best_periods', 'url', 'maps_info', 'phone', 'lift_access',
     'phone_custodian', 'custodianship', 'parking_fee', 'matress_unstaffed',
     'blanket_unstaffed', 'gas_unstaffed', 'heating_unstaffed',

--- a/c2corg_api/scripts/migration/documents/waypoints/sites.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/sites.py
@@ -87,7 +87,7 @@ class MigrateSites(MigrateWaypoints):
                 document_in.children_proof, MigrateSites.children_proof_types),
             rain_proof=self.convert_type(
                 document_in.rain_proof, MigrateSites.rain_proof_types),
-            orientation=self.convert_types(
+            orientations=self.convert_types(
                 document_in.facings, MigrateSites.orientation_types, [0]),
             best_periods=self.convert_types(
                 document_in.best_periods, MigrateSites.best_periods),

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -32,7 +32,7 @@ class TestRouteRest(BaseDocumentTestRest):
     def test_get_collection(self):
         body = self.get_collection()
         doc = body['documents'][0]
-        self.assertNotIn('climbing_outdoor_types', doc)
+        self.assertNotIn('climbing_outdoor_type', doc)
         self.assertNotIn('elevation_min', doc)
 
     def test_get_collection_paginated(self):
@@ -64,7 +64,7 @@ class TestRouteRest(BaseDocumentTestRest):
         self.assertEqual(
             body.get('activities'), self.route.activities)
         self._assert_geometry(body)
-        self.assertNotIn('climbing_outdoor_types', body)
+        self.assertNotIn('climbing_outdoor_type', body)
         self.assertIn('elevation_min', body)
 
         self.assertEqual(

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ git+https://github.com/tsauerwein/ColanderAlchemy.git@c2corg
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@b8e402d
+git+https://github.com/c2corg/v6_common.git@2b09a99
 
 # Discourse API client
 git+https://github.com/c2corg/pydiscourse.git@65e398343bbbc74fdb71cca4637c9f808e5adfb2

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ git+https://github.com/tsauerwein/ColanderAlchemy.git@c2corg
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@2b09a99
+git+https://github.com/c2corg/v6_common.git@f825f8f
 
 # Discourse API client
 git+https://github.com/c2corg/pydiscourse.git@65e398343bbbc74fdb71cca4637c9f808e5adfb2


### PR DESCRIPTION
Spotted by @ginold : a missing trailing "s" for routes' orientations => see e1ee3a4

For consistency reasons (it's a list), 370b3f5 renames "orientation" to "orientations" for WP as well.

Requires https://github.com/c2corg/v6_common/pull/21 