### PR TITLE
Make sure user is loaded together with profile (search)

### DIFF
--- a/c2corg_api/search/search.py
+++ b/c2corg_api/search/search.py
@@ -69,7 +69,7 @@ def get_documents(document_ids, model, locale_model, lang):
         filter(model.document_id.in_(document_ids)).\
         options(joinedload(model.locales.of_type(locale_model))). \
         options(joinedload(model.geometry))
-    add_load_for_profiles(documents_query, model)
+    documents_query = add_load_for_profiles(documents_query, model)
 
     documents = documents_query.all()
 


### PR DESCRIPTION
Currently a separate request had to be made for each user profile to get the associated user. Now it is really done with one request.