### PR TITLE
Output API errors in unit tests

### DIFF
--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -193,6 +193,12 @@ class BaseTestCase(unittest.TestCase):
         self.connection.close()
 
     def app_post_json(self, *args, **kwargs):
+        return self.app_send_json('post', *args, **kwargs)
+
+    def app_put_json(self, *args, **kwargs):
+        return self.app_send_json('put', *args, **kwargs)
+
+    def app_send_json(self, action, *args, **kwargs):
         kwargs = dict(kwargs)
         status = 200
         if 'status' in kwargs:
@@ -200,7 +206,7 @@ class BaseTestCase(unittest.TestCase):
             del kwargs['status']
         kwargs['expect_errors'] = True
 
-        res = self.app.post_json(*args, **kwargs)
+        res = getattr(self.app, action + '_json')(*args, **kwargs)
         if status != '*' and res.status_code != status:
             errors = res.body if res.status_code == 400 else ''
             self.fail('Bad response: %s (not %d) : %s' % (

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -419,11 +419,11 @@ class BaseDocumentTestRest(BaseTestRest):
         return (body, doc)
 
     def put_wrong_document_id(self, request_body, user='contributor'):
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/-9999', request_body, status=403)
 
         headers = self.add_authorization_header(username=user)
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/-9999', request_body, headers=headers, status=404)
 
         body = response.json
@@ -431,11 +431,11 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(body['errors'][0]['name'], 'Not Found')
 
     def put_wrong_version(self, request_body, id, user='contributor'):
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(id), request_body, status=403)
 
         headers = self.add_authorization_header(username=user)
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(id), request_body, headers=headers,
             status=409)
 
@@ -447,11 +447,11 @@ class BaseDocumentTestRest(BaseTestRest):
         """The id given in the URL does not equal the document_id in the
         request body.
         """
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(id + 1), request_body, status=403)
 
         headers = self.add_authorization_header(username=user)
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(id + 1), request_body, headers=headers,
             status=400)
         body = response.json
@@ -462,11 +462,11 @@ class BaseDocumentTestRest(BaseTestRest):
         request_body = {
             'message': '...'
         }
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(id), request_body, status=403)
 
         headers = self.add_authorization_header(username=user)
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(id), request_body, headers=headers,
             status=400)
 
@@ -477,12 +477,12 @@ class BaseDocumentTestRest(BaseTestRest):
 
     def put_missing_field(
             self, request_body, document, field, user='contributor'):
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             status=403)
 
         headers = self.add_authorization_header(username=user)
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             headers=headers, status=400)
 
@@ -496,12 +496,12 @@ class BaseDocumentTestRest(BaseTestRest):
             self, request_body, document, user='contributor', check_es=True):
         """Test updating a document with changes to the figures and locales.
         """
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             status=403)
 
         headers = self.add_authorization_header(username=user)
-        self.app.put_json(
+        self.app_put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             headers=headers, status=200)
 
@@ -596,12 +596,12 @@ class BaseDocumentTestRest(BaseTestRest):
             self, request_body, document, user='contributor', check_es=True):
         """Test updating a document with changes to the figures only.
         """
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             status=403)
 
         headers = self.add_authorization_header(username=user)
-        self.app.put_json(
+        self.app_put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             headers=headers, status=200)
 
@@ -690,12 +690,12 @@ class BaseDocumentTestRest(BaseTestRest):
             self, request_body, document, user='contributor', check_es=True):
         """Test updating a document with only changes to a locale.
         """
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             status=403)
 
         headers = self.add_authorization_header(username=user)
-        self.app.put_json(
+        self.app_put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             headers=headers, status=200)
 
@@ -775,12 +775,12 @@ class BaseDocumentTestRest(BaseTestRest):
             self, request_body, document, user='contributor', check_es=True):
         """Test updating a document by adding a new locale.
         """
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             status=403)
 
         headers = self.add_authorization_header(username=user)
-        self.app.put_json(
+        self.app_put_json(
             self._prefix + '/' + str(document.document_id), request_body,
             headers=headers, status=200)
 

--- a/c2corg_api/tests/views/test_area.py
+++ b/c2corg_api/tests/views/test_area.py
@@ -220,7 +220,7 @@ class TestAreaRest(BaseDocumentTestRest):
             }
         }
         headers = self.add_authorization_header(username='contributor')
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(self.area1.document_id), body,
             headers=headers, status=400)
 

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -218,7 +218,7 @@ class TestImageRest(BaseDocumentTestRest):
             }
         }
         headers = self.add_authorization_header(username='contributor2')
-        self.app.put_json(
+        self.app_put_json(
             self._prefix + '/' + str(self.image4.document_id), body,
             headers=headers, status=403)
 
@@ -243,7 +243,7 @@ class TestImageRest(BaseDocumentTestRest):
             }
         }
         headers = self.add_authorization_header(username='contributor')
-        self.app.put_json(
+        self.app_put_json(
             self._prefix + '/' + str(self.image4.document_id), body,
             headers=headers, status=200)
 
@@ -378,7 +378,7 @@ class TestImageRest(BaseDocumentTestRest):
             }
         }
         headers = self.add_authorization_header(username='contributor')
-        self.app.put_json(
+        self.app_put_json(
             self._prefix + '/' + str(self.image.document_id), body,
             headers=headers, status=400)
 
@@ -403,7 +403,7 @@ class TestImageRest(BaseDocumentTestRest):
             }
         }
         headers = self.add_authorization_header(username='moderator')
-        self.app.put_json(
+        self.app_put_json(
             self._prefix + '/' + str(self.image.document_id), body,
             headers=headers, status=200)
 
@@ -427,7 +427,7 @@ class TestImageRest(BaseDocumentTestRest):
             }
         }
         headers = self.add_authorization_header(username='contributor')
-        self.app.put_json(
+        self.app_put_json(
             self._prefix + '/' + str(self.image4.document_id), body,
             headers=headers, status=200)
 

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -498,7 +498,7 @@ class TestOutingRest(BaseDocumentTestRest):
             }
         }
         headers = self.add_authorization_header(username='contributor2')
-        self.app.put_json(
+        self.app_put_json(
             self._prefix + '/' + str(self.outing.document_id), body,
             headers=headers, status=403)
 
@@ -527,7 +527,7 @@ class TestOutingRest(BaseDocumentTestRest):
             }
         }
         headers = self.add_authorization_header(username='contributor')
-        self.app.put_json(
+        self.app_put_json(
             self._prefix + '/' + str(self.outing.document_id), body,
             headers=headers, status=200)
 

--- a/c2corg_api/tests/views/test_user_profile.py
+++ b/c2corg_api/tests/views/test_user_profile.py
@@ -107,7 +107,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
         }
 
         headers = self.add_authorization_header(username='contributor2')
-        self.app.put_json(
+        self.app_put_json(
             self._prefix + '/' + str(self.profile1.document_id), body,
             headers=headers, status=403)
 

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -625,12 +625,12 @@ class TestWaypointRest(BaseDocumentTestRest):
                 'locales': []
             }
         }
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(waypoint.document_id), body_put,
             status=403)
 
         headers = self.add_authorization_header(username='contributor')
-        self.app.put_json(
+        self.app_put_json(
             self._prefix + '/' + str(waypoint.document_id), body_put,
             headers=headers, status=200)
 
@@ -700,7 +700,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         }
 
         headers = self.add_authorization_header(username='contributor')
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(self.waypoint5.document_id), body_put,
             headers=headers, status=400)
 
@@ -726,7 +726,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         }
 
         headers = self.add_authorization_header(username='contributor')
-        response = self.app.put_json(
+        response = self.app_put_json(
             self._prefix + '/' + str(self.waypoint4.document_id), body_put,
             headers=headers, status=403)
 
@@ -753,7 +753,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         }
 
         headers = self.add_authorization_header(username='moderator')
-        self.app.put_json(
+        self.app_put_json(
             self._prefix + '/' + str(self.waypoint4.document_id), body_put,
             headers=headers, status=200)
 


### PR DESCRIPTION
So far API errors were not directly visible in failing unit tests. Now, they are shown without further interaction.

Credits to @gberaudo for the idea!