### PR TITLE
Check account is validated before allowing account actions

### DIFF
--- a/c2corg_api/models/user.py
+++ b/c2corg_api/models/user.py
@@ -19,6 +19,8 @@ import colander
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.sql.schema import ForeignKey
 
+from enum import Enum
+
 import os
 import binascii
 
@@ -42,6 +44,12 @@ class PasswordUtil():
         if isinstance(plain, str):
             plain = plain.encode('utf-8')
         return bcrypt.hashpw(plain, encrypted) == encrypted
+
+
+class Purpose(Enum):
+    registration = 'regemail'
+    new_password = 'newpass'
+    change_email = 'chgemail'
 
 
 class User(Base):
@@ -86,14 +94,18 @@ class User(Base):
         particular actions like changing password or validating an email. It
         must have a short lifespan to avoid unused nonces to become a security
         risk."""
+        if purpose != Purpose.registration and not self.email_validated:
+            # An account must be validated before any other action is tried.
+            raise Exception('Account not validated yet')
+
         now = datetime.datetime.utcnow()
         nonce = binascii.hexlify(os.urandom(32)).decode('ascii')
-        self.validation_nonce = purpose + '_' + nonce
+        self.validation_nonce = purpose.value + '_' + nonce
         self.validation_nonce_expire = now + datetime.timedelta(days=days)
 
     def validate_nonce_purpose(self, expected_purpose):
         nonce = self.validation_nonce
-        prefix = expected_purpose + '_'
+        prefix = expected_purpose.value + '_'
         return nonce is not None and nonce.startswith(prefix)
 
     def clear_validation_nonce(self):

--- a/c2corg_api/models/user.py
+++ b/c2corg_api/models/user.py
@@ -27,6 +27,11 @@ import binascii
 import datetime
 
 
+class AccountNotValidated(Exception):
+    def __init__(self):
+        Exception.__init__(self, 'Account not validated yet')
+
+
 class PasswordUtil():
     """
     Utility class abstracting low-level password primitives.
@@ -96,7 +101,7 @@ class User(Base):
         risk."""
         if purpose != Purpose.registration and not self.email_validated:
             # An account must be validated before any other action is tried.
-            raise Exception('Account not validated yet')
+            raise AccountNotValidated()
 
         now = datetime.datetime.utcnow()
         nonce = binascii.hexlify(os.urandom(32)).decode('ascii')

--- a/c2corg_api/tests/models/test_user.py
+++ b/c2corg_api/tests/models/test_user.py
@@ -1,4 +1,4 @@
-from c2corg_api.models.user import User
+from c2corg_api.models.user import User, Purpose
 
 from c2corg_api.tests import BaseTestCase
 
@@ -23,3 +23,15 @@ class Testuser(BaseTestCase):
 
         self.assertFalse(tony.validate_password('foobare'))
         self.assertTrue(tony.validate_password('foobar'))
+
+    def test_update_nonce(self):
+        tony = User(email_validated=False)
+        tony.update_validation_nonce(Purpose.registration, 2)
+
+        def change_email():
+            tony.update_validation_nonce(Purpose.change_email, 2)
+        self.assertRaisesRegexp(
+            Exception, 'Account not validated', change_email)
+
+        tony.email_validated = True
+        change_email()

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -2,6 +2,7 @@ import collections
 import datetime
 
 from c2corg_api.models import DBSession
+from c2corg_api.models.user import AccountNotValidated
 from c2corg_common.attributes import langs_priority
 from colander import null
 from pyramid.httpexceptions import HTTPError, HTTPNotFound, HTTPForbidden
@@ -45,6 +46,14 @@ def http_error_handler(exc, request):
 
     errors = Errors(request, exc.code)
     errors.add('request', exc.title, exc.detail)
+
+    return json_error(errors)
+
+
+@view_config(context=AccountNotValidated)
+def account_error_handler(exc, request):
+    errors = Errors(request, 400)
+    errors.add('request', 'Error', exc.args)
 
     return json_error(errors)
 


### PR DESCRIPTION
In addition, use enums instead of simple strings for purposes.