### PR TITLE
Make sure climbing_indoor WP geom are made available in listings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ git+https://github.com/tsauerwein/cornice.git@nested-none
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@f825f8f
+git+https://github.com/c2corg/v6_common.git@ea45883
 
 # Discourse API client
 git+https://github.com/c2corg/pydiscourse.git@65e398343bbbc74fdb71cca4637c9f808e5adfb2


### PR DESCRIPTION
Fixes #259 
using https://github.com/c2corg/v6_common/commit/ea45883af5da573c9839d03f0b18de5d2bae318e