### PR TITLE
Support bbox filters in advanced search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
 
 install:
 - mkdir /tmp/elasticsearch
-- wget -O - https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.1.2/elasticsearch-2.1.2.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
+- wget -O - https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.2/elasticsearch-2.3.2.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
 - /tmp/elasticsearch/bin/elasticsearch --daemonize --path.data /tmp
 - make -f config/travis .build/dev-requirements.timestamp
 - make -f config/travis install

--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -8,7 +8,7 @@ from sqlalchemy import (
     func
     )
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, column_property
 from sqlalchemy.dialects import postgresql
 from geoalchemy2 import Geometry
 import geoalchemy2
@@ -369,6 +369,10 @@ class DocumentGeometry(Base, _DocumentGeometryMixin):
             raise HTTPInternalServerError('Bad projection')
 
         return g1.almost_equals(g2, decimals)
+
+DocumentGeometry.lon_lat = column_property(
+    func.ST_AsGeoJSON(func.ST_Transform(DocumentGeometry.geom, 4326)),
+    deferred=True)
 
 
 class ArchiveDocumentGeometry(Base, _DocumentGeometryMixin):

--- a/c2corg_api/scripts/es/sync.py
+++ b/c2corg_api/scripts/es/sync.py
@@ -1,6 +1,6 @@
 from c2corg_api.models import es_sync, document_types, document_locale_types
 from c2corg_api.models.area import Area
-from c2corg_api.models.document import Document
+from c2corg_api.models.document import Document, DocumentGeometry
 from c2corg_api.models.document_history import DocumentVersion, HistoryMetaData
 from c2corg_api.models.route import Route, ROUTE_TYPE
 from c2corg_api.models.waypoint import WAYPOINT_TYPE
@@ -97,7 +97,7 @@ def get_documents(session, doc_type, document_ids=None):
 
     base_query = base_query. \
         options(joinedload(clazz.locales.of_type(locales_clazz))). \
-        options(joinedload(clazz.geometry))
+        options(joinedload(clazz.geometry).load_only(DocumentGeometry.lon_lat))
 
     if clazz != Area:
         base_query = base_query. \

--- a/c2corg_api/scripts/migration/README.md
+++ b/c2corg_api/scripts/migration/README.md
@@ -41,7 +41,7 @@ Then start the import:
 
     .build/venv/bin/fill_es_index development.ini
 
-For productive instances rather use
+For production instances rather use
 
     .build/venv/bin/initialize_c2corg_api_es production.ini
     .build/venv/bin/fill_es_index production.ini

--- a/c2corg_api/tests/scripts/es/test_fill_index.py
+++ b/c2corg_api/tests/scripts/es/test_fill_index.py
@@ -74,6 +74,8 @@ class FillIndexTest(BaseTestCase):
         self.assertEqual(waypoint1.title_fr, 'Mont Granier')
         self.assertEqual(waypoint1.summary_fr, 'Le Mont  Granier ')
         self.assertEqual(waypoint1.doc_type, 'w')
+        self.assertAlmostEqual(waypoint1.geom[0], 5.71288994)
+        self.assertAlmostEqual(waypoint1.geom[1], 45.64476395)
 
         waypoint2 = SearchWaypoint.get(id=71172)
         self.assertIsNotNone(waypoint2)

--- a/c2corg_api/tests/scripts/es/test_sync.py
+++ b/c2corg_api/tests/scripts/es/test_sync.py
@@ -40,6 +40,9 @@ class SyncTest(BaseTestCase):
         search_documents = []
         batch_mock = self._create_mock_match(search_documents)(None, 1000)
 
+        self.route1.geometry = DocumentGeometry()
+        self.route1.geometry.lon_lat = \
+            '{"type": "Point", "coordinates": [6, 46]}'
         create_search_documents('r', [self.route1], batch_mock)
         doc = search_documents[0]
 
@@ -47,6 +50,7 @@ class SyncTest(BaseTestCase):
         self.assertEqual(doc['_id'], self.route1.document_id)
         self.assertEqual(doc['title_en'], 'Mont Blanc : Face N')
         self.assertEqual(doc['description_en'], '...')
+        self.assertEqual(doc['geom'], [6, 46])
 
     def test_create_search_documents_user_profile(self):
         search_documents = []
@@ -84,6 +88,14 @@ class SyncTest(BaseTestCase):
                 search_documents),
             None)
         self.assertEqual(redirected_doc['_op_type'], 'delete')
+
+        waypoint1_doc = next(
+            filter(
+                lambda doc: doc['_id'] == self.waypoint1.document_id,
+                search_documents),
+            None)
+        self.assertAlmostEqual(waypoint1_doc['geom'][0], 5.71288995)
+        self.assertAlmostEqual(waypoint1_doc['geom'][1], 45.64476395)
 
     def _create_mock_match(self, actions):
         class MockBatch(object):

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -84,6 +84,14 @@ class TestWaypointRest(BaseDocumentTestRest):
         body = self.get_collection_search({'we': '2000'})
         self.assertEqual(body.get('total'), 1)
 
+    def test_get_collection_search_bbox(self):
+        reset_search_index(self.session)
+
+        self.assertResultsEqual(
+            self.get_collection_search(
+                {'bbox': '659000,5694000,660000,5695000'}),
+            [self.waypoint4.document_id], 1)
+
     def test_get(self):
         body = self.get(self.waypoint)
         self._assert_geometry(body)
@@ -889,7 +897,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             waypoint_type='summit', elevation=4,
             protected=True,
             geometry=DocumentGeometry(
-                geom='SRID=3857;POINT(635956 5723604)'))
+                geom='SRID=3857;POINT(659775 5694854)'))
         self.waypoint4.locales.append(WaypointLocale(
             lang='en', title='Mont Granier', description='...',
             access='yep'))

--- a/c2corg_api/views/waypoint.py
+++ b/c2corg_api/views/waypoint.py
@@ -68,6 +68,9 @@ class WaypointRest(DocumentRest):
             `q=...` (optional)
             A search word.
 
+            `bbox=xmin,ymin,xmax,ymax` (optional)
+            A search bbox in EPSG:3857.
+
             `pl=...` (optional)
             When set only the given locale will be included (if available).
             Otherwise all locales will be returned.

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Shapely==1.5.13
 pyproj==1.9.5.1
 pyramid-jwtauth==0.1.3
 bcrypt==2.0.0
-elasticsearch==2.1.0
+elasticsearch==2.2.0
 elasticsearch_dsl==2.0.0
 pyramid_mailer==0.14.1
 # phpserialize is only required during the migration

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Shapely==1.5.13
 pyproj==1.9.5.1
 pyramid-jwtauth==0.1.3
 bcrypt==2.0.0
-elasticsearch==2.2.0
+elasticsearch==2.3.0
 elasticsearch_dsl==2.0.0
 pyramid_mailer==0.14.1
 # phpserialize is only required during the migration


### PR DESCRIPTION
The point geometry of documents is now indexed in ElasticSearch and bbox searches can be made on list views, e.g. `/waypoints?bbox=699398,5785365,799498,5885465`.