### PR TITLE
Require resolved captcha for creating account

### DIFF
--- a/c2corg_api/security/discourse_client.py
+++ b/c2corg_api/security/discourse_client.py
@@ -14,16 +14,12 @@ from urllib.parse import parse_qs
 
 log = logging.getLogger(__name__)
 
-# 10 seconds timeout for requests to discourse API
-# Using a large value to take into account a possible slow restart (caching)
-# of discourse.
-TIMEOUT = 10
-
 
 class APIDiscourseClient(object):
 
     def __init__(self, settings):
         self.settings = settings
+        self.timeout = settings['url.timeout']
         self.discourse_base_url = settings['discourse.url']
         self.discourse_public_url = settings['discourse.public_url']
         self.api_key = settings['discourse.api_key']
@@ -37,7 +33,7 @@ class APIDiscourseClient(object):
                 self.discourse_base_url,
                 api_username='system',  # the built-in Discourse user
                 api_key=self.api_key,
-                timeout=TIMEOUT)
+                timeout=self.timeout)
 
     def get_userid(self, userid):
         discourse_userid = self.discourse_userid_cache.get(userid)
@@ -92,7 +88,7 @@ class APIDiscourseClient(object):
     def request_nonce(self):
         url = '%s/session/sso' % self.discourse_base_url
         try:
-            r = requests.get(url, allow_redirects=False, timeout=TIMEOUT)
+            r = requests.get(url, allow_redirects=False, timeout=self.timeout)
             assert r.status_code == 302
         except Exception:
             log.error('Could not request nonce', exc_info=True)

--- a/common.ini.in
+++ b/common.ini.in
@@ -39,3 +39,12 @@ mail.from = {mail_from}
 mail.host = {mail_host}
 mail.port = {mail_port}
 mail.debug = {mail_debug}
+
+# Number of seconds to wait for response bytes on the requests sockets.
+# At the expiration of this timeout, the request is considered failed.
+# Using a large value to take into account a possible slow restart (caching).
+# This value is used globally in the application.
+url.timeout = 10
+
+recaptcha.secret.key = {recaptcha_secret_key}
+skip.captcha.validation = {skip_captcha_validation}

--- a/config/default
+++ b/config/default
@@ -61,3 +61,6 @@ export mail_debug = 0
 # FIXME
 export discourse_sso_secret = d836444a9e4084d5b224a60c208dce14
 export discourse_api_key = 4647c0d98e8beb793da099ff103b9793d8d4f94fff7cdd52d58391c6fa025845
+
+export skip_captcha_validation = False
+export recaptcha_secret_key = 6LdWkR4TAAAAALcZLh54HFlAWFHiMQhZR5jR4p3F

--- a/config/dev
+++ b/config/dev
@@ -3,3 +3,4 @@ include Makefile
 export version = 0
 
 host = c2corgv6-demo.gis.internal
+export recaptcha_secret_key = 6LdWkR4TAAAAALcZLh54HFlAWFHiMQhZR5jR4p3F

--- a/test.ini.in
+++ b/test.ini.in
@@ -15,3 +15,4 @@ redis.url = memory:///
 discourse.url = {tests_discourse_url}
 discourse.api_key = {discourse_api_key}
 discourse.sso_secret = {discourse_sso_secret}
+skip.captcha.validation = True


### PR DESCRIPTION
- read requests timeout constant from settings;
- add some recaptcha credentials for development;
- add code to check a captcha response with google;
- recaptcha is disabled in tests.

Related to https://github.com/c2corg/v6_api/issues/218.