### PR TITLE
Fix query to load route with `lang` filter

### DIFF
--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -216,6 +216,7 @@ class BaseDocumentTestRest(BaseTestRest):
         locale_en = locales[0]
         self.assertEqual(locale_en.get('lang'), self.locale_en.lang)
         self.assertIn('protected', body)
+        return body
 
     def get_new_lang(self, reference, user=None):
         headers = {} if not user else \

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -112,7 +112,14 @@ class TestRouteRest(BaseDocumentTestRest):
         self.get_version(self.route, self.route_version)
 
     def test_get_lang(self):
-        self.get_lang(self.route)
+        body = self.get_lang(self.route)
+
+        self.assertEqual(
+            'Mont Blanc from the air',
+            body.get('locales')[0].get('title'))
+        self.assertEqual(
+            'Main waypoint title',
+            body.get('locales')[0].get('title_prefix'))
 
     def test_get_new_lang(self):
         self.get_new_lang(self.route)

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -162,7 +162,11 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.get_version(self.waypoint, self.waypoint_version)
 
     def test_get_lang(self):
-        self.get_lang(self.waypoint)
+        body = self.get_lang(self.waypoint)
+
+        self.assertEqual(
+            'Mont Granier',
+            body.get('locales')[0].get('title'))
 
     def test_get_new_lang(self):
         self.get_new_lang(self.waypoint)


### PR DESCRIPTION
Always double-check the query SQLAlchemy is generating.. 

Closes https://github.com/c2corg/v6_api/issues/269