### PR TITLE
Use a deterministic order for subqueryload

### DIFF
--- a/c2corg_api/search/search_filters.py
+++ b/c2corg_api/search/search_filters.py
@@ -43,7 +43,8 @@ def build_query(url_params, meta_params, doc_type):
         # if a search term is given, the documents are sorted by a relevance
         # score. if not explicitly sort by id/date.
         if doc_type == OUTING_TYPE:
-            search = search.sort({'date_end': {'order': 'desc'}})
+            search = search.sort(
+                {'date_end': {'order': 'desc'}}, {'id': {'order': 'desc'}})
         else:
             search = search.sort({'id': {'order': 'desc'}})
 

--- a/c2corg_api/tests/search/test_search_filters.py
+++ b/c2corg_api/tests/search/test_search_filters.py
@@ -80,7 +80,7 @@ class AdvancedSearchTest(BaseTestCase):
         expected_query = create_search('o'). \
             filter(Term(activities='skitouring')).\
             fields([]).\
-            sort({'date_end': {'order': 'desc'}}).\
+            sort({'date_end': {'order': 'desc'}}, {'id': {'order': 'desc'}}).\
             extra(from_=40, size=20)
         self.assertQueryEqual(query, expected_query)
 

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -84,7 +84,9 @@ class DocumentRest(object):
         base_query = base_query.options(joinedload(getattr(clazz, 'geometry')))
 
         if clazz == Outing:
-            base_query = base_query.order_by(clazz.date_end.desc())
+            base_query = base_query. \
+                order_by(clazz.date_end.desc()). \
+                order_by(clazz.document_id.desc())
         else:
             base_query = base_query.order_by(clazz.document_id.desc())
         base_query = add_load_for_profiles(base_query, clazz)


### PR DESCRIPTION
Closes https://github.com/c2corg/v6_api/issues/275

For outings ordering only by the date does not return the results in the same order, because there can be multiple outings for the same day. This is a problem when using `subqueryload`, see also:
http://docs.sqlalchemy.org/en/latest/faq/ormconfiguration.html#why-is-order-by-required-with-limit-especially-with-subqueryload