### PR TITLE
Improve performance of simple search

### DIFF
--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -207,7 +207,7 @@ class _DocumentLocaleMixin(object):
     def document_id(self):
         return Column(
             Integer, ForeignKey(schema + '.documents.document_id'),
-            nullable=False)
+            nullable=False, index=True)
 
     @declared_attr
     def lang(self):

--- a/c2corg_api/tests/models/test_waypoint.py
+++ b/c2corg_api/tests/models/test_waypoint.py
@@ -379,7 +379,7 @@ class TestWaypoint(BaseTestCase):
         self.session.flush()
 
         set_available_langs([waypoint])
-        self.assertEqual(waypoint.available_langs, ['en', 'fr'])
+        self.assertEqual(set(waypoint.available_langs), set(['en', 'fr']))
 
     def test_array_handling_non_empty(self):
         waypoint = Waypoint(

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -68,6 +68,16 @@ class BaseTestRest(BaseTestCase):
         self.assertIsNotNone(queue.get(), 'no sync. notification sent for ES')
         sync_es(self.session)
 
+    def get_latest_version(self, lang, versions):
+        versions_in_lang = [v for v in versions if v.lang == lang]
+        versions_in_lang.sort(key=lambda v: v.id, reverse=True)
+        return versions_in_lang[0]
+
+    def get_locale(self, lang, locales):
+        return next(
+            filter(lambda locale: locale['lang'] == lang, locales),
+            None)
+
 
 class BaseDocumentTestRest(BaseTestRest):
 
@@ -580,7 +590,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(len(versions), 4)
 
         # version with lang 'en'
-        version_en = versions[2]
+        version_en = self.get_latest_version('en', versions)
 
         self.assertEqual(version_en.lang, 'en')
 
@@ -599,7 +609,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(archive_locale.lang, 'en')
 
         # version with lang 'fr'
-        version_fr = versions[3]
+        version_fr = self.get_latest_version('fr', versions)
 
         self.assertEqual(version_fr.lang, 'fr')
 
@@ -679,7 +689,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(len(versions), 4)
 
         # version with lang 'en'
-        version_en = versions[2]
+        version_en = self.get_latest_version('en', versions)
 
         self.assertEqual(version_en.lang, 'en')
 
@@ -688,7 +698,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertIsNotNone(meta_data_en.written_at)
 
         # version with lang 'fr'
-        version_fr = versions[3]
+        version_fr = self.get_latest_version('fr', versions)
 
         self.assertEqual(version_fr.lang, 'fr')
 
@@ -774,7 +784,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(len(versions), 3)
 
         # version with lang 'en'
-        version_en = versions[2]
+        version_en = self.get_latest_version('en', versions)
 
         self.assertEqual(version_en.lang, 'en')
 
@@ -783,7 +793,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertIsNotNone(meta_data_en.written_at)
 
         # version with lang 'fr'
-        version_fr = versions[1]
+        version_fr = self.get_latest_version('fr', versions)
 
         self.assertEqual(version_fr.lang, 'fr')
 
@@ -860,15 +870,13 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertEqual(len(versions), 3)
 
         # version with lang 'en'
-        version_en = versions[0]
-
+        version_en = self.get_latest_version('en', versions)
         self.assertEqual(version_en.lang, 'en')
 
         meta_data_en = version_en.history_metadata
 
         # version with lang 'fr'
-        version_fr = versions[1]
-
+        version_fr = self.get_latest_version('fr', versions)
         self.assertEqual(version_fr.lang, 'fr')
 
         meta_data_fr = version_fr.history_metadata
@@ -879,8 +887,7 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertIs(archive_document_en, archive_document_fr)
 
         # version with lang 'es'
-        version_es = versions[2]
-
+        version_es = self.get_latest_version('es', versions)
         self.assertEqual(version_es.lang, 'es')
 
         meta_data_es = version_es.history_metadata

--- a/c2corg_api/tests/views/test_area.py
+++ b/c2corg_api/tests/views/test_area.py
@@ -256,7 +256,7 @@ class TestAreaRest(BaseDocumentTestRest):
 
         # version with lang 'en'
         versions = map1.versions
-        version_en = versions[2]
+        version_en = self.get_latest_version('en', versions)
         archive_locale = version_en.document_locales_archive
         self.assertEqual(archive_locale.title, 'New title')
 
@@ -269,7 +269,7 @@ class TestAreaRest(BaseDocumentTestRest):
         self.assertEqual(archive_geometry_en.version, 1)
 
         # version with lang 'fr'
-        version_fr = versions[3]
+        version_fr = self.get_latest_version('fr', versions)
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Chartreuse')
 

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -279,7 +279,7 @@ class TestImageRest(BaseDocumentTestRest):
 
         # version with lang 'en'
         versions = image.versions
-        version_en = versions[2]
+        version_en = self.get_latest_version('en', versions)
         archive_locale = version_en.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Blanc from the air')
 
@@ -291,7 +291,7 @@ class TestImageRest(BaseDocumentTestRest):
         self.assertEqual(archive_geometry_en.version, 2)
 
         # version with lang 'fr'
-        version_fr = versions[3]
+        version_fr = self.get_latest_version('fr', versions)
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Blanc du ciel')
 

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -582,7 +582,7 @@ class TestOutingRest(BaseDocumentTestRest):
 
         # version with lang 'en'
         versions = outing.versions
-        version_en = versions[2]
+        version_en = self.get_latest_version('en', versions)
         archive_locale = version_en.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Blanc from the air')
         self.assertEqual(archive_locale.weather, 'mostly sunny')
@@ -595,7 +595,7 @@ class TestOutingRest(BaseDocumentTestRest):
         self.assertEqual(archive_geometry_en.version, 2)
 
         # version with lang 'fr'
-        version_fr = versions[3]
+        version_fr = self.get_latest_version('fr', versions)
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Blanc du ciel')
         self.assertEqual(archive_locale.weather, 'grand beau')

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -77,9 +77,10 @@ class TestRouteRest(BaseDocumentTestRest):
         self.assertNotIn('climbing_outdoor_type', body)
         self.assertIn('elevation_min', body)
 
+        locale_en = self.get_locale('en', body.get('locales'))
         self.assertEqual(
             'Main waypoint title',
-            body.get('locales')[0].get('title_prefix'))
+            locale_en.get('title_prefix'))
 
         self.assertIn('main_waypoint_id', body)
         self.assertIn('associations', body)
@@ -449,7 +450,7 @@ class TestRouteRest(BaseDocumentTestRest):
 
         # version with lang 'en'
         versions = route.versions
-        version_en = versions[2]
+        version_en = self.get_latest_version('en', versions)
         archive_locale = version_en.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Blanc from the air')
         self.assertEqual(archive_locale.gear, 'none')
@@ -462,7 +463,7 @@ class TestRouteRest(BaseDocumentTestRest):
         self.assertEqual(archive_geometry_en.version, 2)
 
         # version with lang 'fr'
-        version_fr = versions[3]
+        version_fr = self.get_latest_version('fr', versions)
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Blanc du ciel')
         self.assertEqual(archive_locale.gear, 'paraglider')

--- a/c2corg_api/tests/views/test_topo_map.py
+++ b/c2corg_api/tests/views/test_topo_map.py
@@ -242,7 +242,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
 
         # version with lang 'en'
         versions = map1.versions
-        version_en = versions[2]
+        version_en = self.get_latest_version('en', versions)
         archive_locale = version_en.document_locales_archive
         self.assertEqual(archive_locale.title, 'New title')
 
@@ -254,7 +254,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
         self.assertEqual(archive_geometry_en.version, 2)
 
         # version with lang 'fr'
-        version_fr = versions[3]
+        version_fr = self.get_latest_version('fr', versions)
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Lac d\'Annecy')
 

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -182,7 +182,7 @@ class TestWaypointRest(BaseDocumentTestRest):
 
         self.assertIn('redirects_to', body)
         self.assertEqual(body['redirects_to'], self.waypoint.document_id)
-        self.assertEqual(body['available_langs'], ['en', 'fr'])
+        self.assertEqual(set(body['available_langs']), set(['en', 'fr']))
 
     def test_post_error(self):
         body = self.post_error({})
@@ -455,7 +455,7 @@ class TestWaypointRest(BaseDocumentTestRest):
 
         # version with lang 'en'
         versions = waypoint.versions
-        version_en = versions[2]
+        version_en = self.get_latest_version('en', versions)
         archive_locale = version_en.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Granier!')
         self.assertEqual(archive_locale.access, 'n')
@@ -468,7 +468,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.assertEqual(archive_geometry_en.version, 2)
 
         # version with lang 'fr'
-        version_fr = versions[3]
+        version_fr = self.get_latest_version('fr', versions)
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Granier')
         self.assertEqual(archive_locale.access, 'ouai')
@@ -547,7 +547,7 @@ class TestWaypointRest(BaseDocumentTestRest):
 
         # version with lang 'en'
         versions = waypoint.versions
-        version_en = versions[2]
+        version_en = self.get_latest_version('en', versions)
         archive_locale = version_en.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Granier')
         self.assertEqual(archive_locale.access, 'n')
@@ -560,7 +560,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.assertEqual(archive_geometry_en.version, 1)
 
         # version with lang 'fr'
-        version_fr = versions[3]
+        version_fr = self.get_latest_version('fr', versions)
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Granier')
         self.assertEqual(archive_locale.access, 'ouai')
@@ -750,7 +750,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.assertEqual(len(versions), 2)
 
         # version with lang 'en'
-        version_en = versions[1]
+        version_en = self.get_latest_version('en', versions)
 
         self.assertEqual(version_en.lang, 'en')
 

--- a/c2corg_api/views/search.py
+++ b/c2corg_api/views/search.py
@@ -62,44 +62,44 @@ class SearchRest(object):
         types_to_include = self._parse_types_to_include(
             self.request.params.get('t'))
 
-        results = {}
+        search_types = []
         if self._include_type(WAYPOINT_TYPE, types_to_include):
-            results['waypoints'] = search.search_for_type(
-                search_term, WAYPOINT_TYPE, Waypoint, DocumentLocale,
-                schema_waypoint, waypoint_adaptor, limit, lang)
+            search_types.append(
+                ('waypoints', WAYPOINT_TYPE, Waypoint, DocumentLocale,
+                 schema_waypoint, waypoint_adaptor))
 
         if self._include_type(ROUTE_TYPE, types_to_include):
-            results['routes'] = search.search_for_type(
-                search_term, ROUTE_TYPE, Route, RouteLocale,
-                schema_route, route_adaptor, limit, lang)
+            search_types.append(
+                ('routes', ROUTE_TYPE, Route, RouteLocale,
+                 schema_route, route_adaptor))
 
         if self._include_type(OUTING_TYPE, types_to_include):
-            results['outings'] = search.search_for_type(
-                search_term, OUTING_TYPE, Outing, DocumentLocale,
-                schema_outing, outing_adaptor, limit, lang)
+            search_types.append(
+                ('outings', OUTING_TYPE, Outing, DocumentLocale,
+                 schema_outing, outing_adaptor))
 
         if self._include_type(AREA_TYPE, types_to_include):
-            results['areas'] = search.search_for_type(
-                search_term, AREA_TYPE, Area, DocumentLocale,
-                schema_listing_area, None, limit, lang)
+            search_types.append(
+                ('areas', AREA_TYPE, Area, DocumentLocale,
+                 schema_listing_area, None))
 
         if self._include_type(MAP_TYPE, types_to_include):
-            results['maps'] = search.search_for_type(
-                search_term, MAP_TYPE, TopoMap, DocumentLocale,
-                schema_listing_topo_map, None, limit, lang)
+            search_types.append(
+                ('maps', MAP_TYPE, TopoMap, DocumentLocale,
+                 schema_listing_topo_map, None))
 
         if self._include_type(IMAGE_TYPE, types_to_include):
-            results['images'] = search.search_for_type(
-                search_term, IMAGE_TYPE, Image, DocumentLocale,
-                schema_listing_image, None, limit, lang)
+            search_types.append(
+                ('images', IMAGE_TYPE, Image, DocumentLocale,
+                 schema_listing_image, None))
 
         if self._include_type(USERPROFILE_TYPE, types_to_include) and \
                 self.request.has_permission('authenticated'):
-            results['users'] = search.search_for_type(
-                search_term, USERPROFILE_TYPE, UserProfile, DocumentLocale,
-                schema_listing_user_profile, None, limit, lang)
+            search_types.append(
+                ('users', USERPROFILE_TYPE, UserProfile, DocumentLocale,
+                 schema_listing_user_profile, None))
 
-        return results
+        return search.search_for_types(search_types, search_term, limit, lang)
 
     def _parse_types_to_include(self, types_in):
         if not types_in:


### PR DESCRIPTION
* Create an index for column `DocumentLocale.document_id` to speed up the queries to load the documents
* Do the queries for ElasticSearch in a single request instead of doing a request for each document type