### PR TITLE
Make fill_index script more memory friendly

### DIFF
--- a/c2corg_api/scripts/es/fill_index.py
+++ b/c2corg_api/scripts/es/fill_index.py
@@ -1,3 +1,5 @@
+import logging
+
 import os
 import sys
 
@@ -35,6 +37,7 @@ def main(argv=sys.argv):
     config_uri = argv[1]
     options = parse_vars(argv[2:])
     setup_logging(config_uri)
+    logging.getLogger('sqlalchemy.engine').setLevel(logging.ERROR)
     settings = get_appsettings(config_uri, options=options)
     engine = engine_from_config(settings, 'sqlalchemy.')
     Session = sessionmaker(extension=ZopeTransactionExtension())  # noqa

--- a/c2corg_api/scripts/es/sync.py
+++ b/c2corg_api/scripts/es/sync.py
@@ -5,6 +5,7 @@ from c2corg_api.models.document_history import DocumentVersion, HistoryMetaData
 from c2corg_api.models.route import Route, ROUTE_TYPE
 from c2corg_api.models.user import User
 from c2corg_api.models.user_profile import USERPROFILE_TYPE
+from c2corg_api.models.utils import windowed_query
 from c2corg_api.models.waypoint import WAYPOINT_TYPE
 from c2corg_api.scripts.es.es_batch import ElasticBatch
 from c2corg_api.search import elasticsearch_config, batch_size, \
@@ -120,7 +121,7 @@ def get_documents(session, doc_type, document_ids=None):
 
     base_query = add_load_for_profiles(base_query, clazz)
 
-    return base_query
+    return windowed_query(base_query, Document.document_id, batch_size)
 
 
 def create_search_documents(doc_type, documents, batch):


### PR DESCRIPTION
After the latest changes to the fill_index script, the data was no longer streamed from the database. Instead all documents for a document type were first loaded in memory and then pushed to ElasticSearch.

This PR makes sure that the documents are streamed.