### PR TITLE
Add a script for checking v6 -> discourse communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ Forum integration (discourse)
 
 See https://github.com/c2corg/v6_forum
 
+
 Run the tests
 --------------
+
 Create a database that will be used to run the tests:
 
     scripts/create_user_db_test.sh
@@ -110,6 +112,17 @@ To run a specific test:
 To see the debug output:
 
     .build/venv/bin/nosetests -s
+
+
+Production checks
+-----------------
+
+Check the Discourse forum is up and available to the client API:
+  
+    scripts/check_discourse_connection.sh [id]
+
+"id" is a v6 user id. The script should return a 200OK.
+
 
 Developer Tips
 --------------

--- a/scripts/check_discourse_connection.sh
+++ b/scripts/check_discourse_connection.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# This script allows to test whether the connection with Discourse works.
+# It takse the v6 user id as only parameter.
+
+# The api key must be in Discourse api_keys table and created by user -1.
+# SSO users must be available in Discourse single_sign_on_records table.
+# The Discourse (internal url and api key must be in common.ini.
+
+# Extract a value from an ini file
+function ini
+{
+  awk -F "=" '/'$1'/ {print $2}' common.ini | tr -d ' '
+}
+
+id=${1:-2}
+api_key=$(ini 'discourse.api_key')
+discourse_url=$(ini 'discourse.url')
+
+url="$discourse_url//users/by-external/$id.json?api_key=$api_key&api_username=system"
+echo "Discourse url: $discourse_url"
+echo "API key: $api_key"
+echo "v6 user id: $id"
+echo
+echo "Test URL: $url"
+
+# The reply should be 200 OK
+curl -vv $url


### PR DESCRIPTION
This script should be run after each upgrade.

In production, testing v6 -> discourse communication should be part of the monitoring.