### PR TITLE
Create/delete associations when creating/updating a document

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ Updating a waypoint:
     -d '{"message": "Comment about change", "document": {"elevation": 4633, "maps_info": null, "version": 1, "document_id": 1, "waypoint_type": "summit", "locales": [{"lang": "fr", "version": 1, "title": "Mont Rose", "access": null, "description": null}]}}' \
     http://localhost:6543/waypoints/1
 
+API documentation
+-----------------
+
+- [Simple search](./c2corg_api/views/search.py)
+- [Guidebook API](./c2corg_api/views/waypoint.py)
 
 Forum integration (discourse)
 --------------------------

--- a/c2corg_api/models/area.py
+++ b/c2corg_api/models/area.py
@@ -1,9 +1,9 @@
 from c2corg_api.models import schema
 from c2corg_api.models.document import (
-    ArchiveDocument, Document, get_update_schema, geometry_schema_overrides,
+    ArchiveDocument, Document, geometry_schema_overrides,
     schema_document_locale, schema_attributes)
 from c2corg_api.models.enums import area_type
-from c2corg_api.models.schema_utils import restrict_schema
+from c2corg_api.models.schema_utils import restrict_schema, get_update_schema
 from c2corg_api.models.utils import copy_attributes
 from c2corg_common.fields_area import fields_area
 from colanderalchemy import SQLAlchemySchemaNode

--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -182,3 +182,18 @@ def add_association(
 
     DBSession.add(association)
     DBSession.add(association.get_log(user_id, is_creation=True))
+
+
+def create_associations(document, associations_for_document, user_id):
+    """ Create associations for a document that were provided when creating
+    a document.
+    """
+    main_id = document.document_id
+    for doc_key, docs in associations_for_document.items():
+        for doc in docs:
+            linked_document_id = doc['document_id']
+            is_parent = doc['is_parent']
+
+            parent_id = linked_document_id if is_parent else main_id
+            child_id = main_id if is_parent else linked_document_id
+            add_association(parent_id, child_id, user_id, check_first=False)

--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -145,7 +145,7 @@ def get_associations(document, lang):
         set_best_locale(child_waypoints, lang)
         set_best_locale(routes, lang)
 
-    return parent_waypoints + child_waypoints, routes
+    return parent_waypoints, child_waypoints, routes
 
 
 def exists_already(link):

--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -109,7 +109,8 @@ def get_associations(document, lang, editing_view):
         waypoint_parents = get_linked_waypoint_parents(document)
         waypoint_children = get_linked_waypoint_children(document)
         associations['waypoints'] = waypoint_parents + waypoint_children
-    elif 'waypoint_parents' in types_to_include:
+    elif 'waypoint_parents' in types_to_include and \
+            'waypoint_children' in types_to_include:
         associations['waypoint_parents'] = \
             get_linked_waypoint_parents(document)
         associations['waypoint_children'] = \

--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -1,4 +1,17 @@
+import enum
+
+import abc
+import geoalchemy2
+from c2corg_api.ext import colander_ext
+from c2corg_api.models import Base, schema, DBSession, enums
+from c2corg_api.models.utils import copy_attributes, extend_dict
+from c2corg_common import document_types
+from c2corg_common.attributes import quality_types
+from colander import null
 from colanderalchemy.schema import SQLAlchemySchemaNode
+from geoalchemy2 import Geometry
+from pyramid.httpexceptions import HTTPInternalServerError
+from shapely import wkt
 from sqlalchemy import (
     Column,
     Integer,
@@ -7,23 +20,9 @@ from sqlalchemy import (
     ForeignKey,
     func
     )
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import relationship, column_property
-from sqlalchemy.dialects import postgresql
-from geoalchemy2 import Geometry
-import geoalchemy2
-from shapely import wkt
-from colander import MappingSchema, SchemaNode, String as ColanderString, null
-
-import abc
-import enum
-
-from c2corg_api.models import Base, schema, DBSession, enums
-from c2corg_api.ext import colander_ext
-from c2corg_api.models.utils import copy_attributes, extend_dict
-from pyramid.httpexceptions import HTTPInternalServerError
-from c2corg_common import document_types
-from c2corg_common.attributes import quality_types
 
 UpdateType = enum.Enum(
     'UpdateType', 'FIGURES LANG GEOM')
@@ -410,17 +409,6 @@ geometry_schema_overrides = {
         }
     }
 }
-
-
-def get_update_schema(document_schema):
-    """Create a Colander schema for the update view which contains an update
-    message and the document.
-    """
-    class UpdateSchema(MappingSchema):
-        message = SchemaNode(ColanderString(), missing='')
-        document = document_schema.clone()
-
-    return UpdateSchema()
 
 
 def get_available_langs(document_id):

--- a/c2corg_api/models/image.py
+++ b/c2corg_api/models/image.py
@@ -128,3 +128,6 @@ schema_create_image = get_create_schema(schema_image)
 schema_update_image = get_update_schema(schema_image)
 schema_listing_image = restrict_schema(
     schema_image, fields_image.get('listing'))
+schema_association_image = restrict_schema(schema_image, [
+    'filename', 'locales.title'
+])

--- a/c2corg_api/models/image.py
+++ b/c2corg_api/models/image.py
@@ -1,4 +1,5 @@
-from c2corg_api.models.schema_utils import restrict_schema
+from c2corg_api.models.schema_utils import restrict_schema,\
+    get_update_schema, get_create_schema
 from c2corg_common.fields_image import fields_image
 from sqlalchemy import (
     Boolean,
@@ -16,7 +17,7 @@ from colanderalchemy import SQLAlchemySchemaNode
 from c2corg_api.models import schema, enums
 from c2corg_api.models.utils import copy_attributes, ArrayOfEnum
 from c2corg_api.models.document import (
-    ArchiveDocument, Document, get_update_schema, geometry_schema_overrides,
+    ArchiveDocument, Document, geometry_schema_overrides,
     schema_document_locale, schema_attributes)
 from c2corg_common import document_types
 
@@ -123,6 +124,7 @@ schema_image = SQLAlchemySchemaNode(
         'geometry': geometry_schema_overrides
     })
 
+schema_create_image = get_create_schema(schema_image)
 schema_update_image = get_update_schema(schema_image)
 schema_listing_image = restrict_schema(
     schema_image, fields_image.get('listing'))

--- a/c2corg_api/models/outing.py
+++ b/c2corg_api/models/outing.py
@@ -1,5 +1,6 @@
 import colander
-from c2corg_api.models.schema_utils import restrict_schema
+from c2corg_api.models.schema_utils import restrict_schema, \
+    get_update_schema, get_create_schema
 from sqlalchemy import (
     Column,
     Integer,
@@ -11,15 +12,13 @@ from sqlalchemy import (
     )
 
 from colanderalchemy import SQLAlchemySchemaNode
-from colander import MappingSchema, SchemaNode, Integer as ColanderInteger, \
-    Sequence
 
 from c2corg_api.models import schema
 from c2corg_api.models.utils import ArrayOfEnum
 from c2corg_api.models.utils import copy_attributes
 from c2corg_api.models.document import (
     ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale,
-    get_update_schema, geometry_schema_overrides, schema_locale_attributes,
+    geometry_schema_overrides, schema_locale_attributes,
     schema_attributes)
 from c2corg_api.models import enums
 from c2corg_common import document_types
@@ -227,17 +226,7 @@ schema_outing = SQLAlchemySchemaNode(
         'geometry': geometry_schema_overrides
     })
 
-
-class CreateOutingSchema(MappingSchema):
-    """The schema used for the web-service to create a new outing.
-    """
-    route_id = SchemaNode(ColanderInteger())
-    user_ids = SchemaNode(Sequence(),
-                          SchemaNode(ColanderInteger()),
-                          validator=colander.Length(min=1))
-    outing = schema_outing.clone()
-
-schema_create_outing = CreateOutingSchema()
+schema_create_outing = get_create_schema(schema_outing)
 schema_update_outing = get_update_schema(schema_outing)
 schema_association_outing = restrict_schema(schema_outing, [
     'locales.title', 'activities', 'date_start', 'date_end'

--- a/c2corg_api/models/route.py
+++ b/c2corg_api/models/route.py
@@ -1,4 +1,5 @@
-from c2corg_api.models.schema_utils import restrict_schema
+from c2corg_api.models.schema_utils import restrict_schema,\
+    get_update_schema, get_create_schema
 from sqlalchemy import (
     Column,
     Integer,
@@ -16,8 +17,7 @@ from c2corg_api.models.utils import ArrayOfEnum
 from c2corg_api.models.utils import copy_attributes
 from c2corg_api.models.document import (
     ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale,
-    get_update_schema, geometry_schema_overrides, schema_locale_attributes,
-    schema_attributes)
+    geometry_schema_overrides, schema_locale_attributes, schema_attributes)
 from c2corg_api.models import enums
 from sqlalchemy.orm import relationship
 from c2corg_common import document_types
@@ -312,6 +312,7 @@ schema_route = SQLAlchemySchemaNode(
         'geometry': geometry_schema_overrides
     })
 
+schema_create_route = get_create_schema(schema_route)
 schema_update_route = get_update_schema(schema_route)
 schema_association_route = restrict_schema(schema_route, [
     'locales.title', 'locales.title_prefix', 'elevation_min', 'elevation_max',

--- a/c2corg_api/models/schema_utils.py
+++ b/c2corg_api/models/schema_utils.py
@@ -96,10 +96,12 @@ def get_create_schema(document_schema):
 
 def get_update_schema(document_schema):
     """Create a Colander schema for the update view which contains an update
-    message and the document.
+    message and the document (with associations).
     """
+    document_schema_with_associations = get_create_schema(document_schema)
+
     class UpdateSchema(MappingSchema):
         message = SchemaNode(String(), missing='')
-        document = document_schema.clone()
+        document = document_schema_with_associations
 
     return UpdateSchema()

--- a/c2corg_api/models/schema_utils.py
+++ b/c2corg_api/models/schema_utils.py
@@ -1,3 +1,5 @@
+from colander import MappingSchema, SchemaNode, String, Integer, Sequence
+
 default_fields_doc = ['document_id', 'version', 'waypoint_type']
 default_fields_locale = ['version', 'lang']
 default_fields_geometry = ['version']
@@ -58,3 +60,46 @@ def filter_node(node, fields, default_fields):
         if child_node.name in fields or child_node.name in default_fields:
             children.append(child_node)
     node.children = children
+
+
+class SchemaAssociationDoc(MappingSchema):
+    document_id = SchemaNode(Integer())
+
+
+class SchemaAssociationUser(MappingSchema):
+    id = SchemaNode(Integer())
+
+
+class SchemaAssociations(MappingSchema):
+    users = SchemaNode(
+        Sequence(), SchemaAssociationUser(), missing=None)
+    routes = SchemaNode(
+        Sequence(), SchemaAssociationDoc(), missing=None)
+    waypoints = SchemaNode(
+        Sequence(), SchemaAssociationDoc(), missing=None)
+    waypoint_parents = SchemaNode(
+        Sequence(), SchemaAssociationDoc(), missing=None)
+    waypoint_children = SchemaNode(
+        Sequence(), SchemaAssociationDoc(), missing=None)
+    images = SchemaNode(
+        Sequence(), SchemaAssociationDoc(), missing=None)
+
+
+def get_create_schema(document_schema):
+    """ Create a Colander schema for the create view which contains
+    associations for the document.
+    """
+    schema = document_schema.clone()
+    schema.add(SchemaAssociations(name='associations', missing=None))
+    return schema
+
+
+def get_update_schema(document_schema):
+    """Create a Colander schema for the update view which contains an update
+    message and the document.
+    """
+    class UpdateSchema(MappingSchema):
+        message = SchemaNode(String(), missing='')
+        document = document_schema.clone()
+
+    return UpdateSchema()

--- a/c2corg_api/models/topo_map.py
+++ b/c2corg_api/models/topo_map.py
@@ -1,5 +1,5 @@
 from c2corg_api.models.enums import map_editor, map_scale
-from c2corg_api.models.schema_utils import restrict_schema
+from c2corg_api.models.schema_utils import restrict_schema, get_update_schema
 from c2corg_api.views import set_best_locale
 from c2corg_common.fields_topo_map import fields_topo_map
 from sqlalchemy import (
@@ -14,7 +14,7 @@ from colanderalchemy import SQLAlchemySchemaNode
 from c2corg_api.models import schema, DBSession
 from c2corg_api.models.utils import copy_attributes
 from c2corg_api.models.document import (
-    ArchiveDocument, Document, get_update_schema, geometry_schema_overrides,
+    ArchiveDocument, Document, geometry_schema_overrides,
     schema_document_locale, schema_attributes, DocumentGeometry,
     DocumentLocale)
 from sqlalchemy.orm import load_only, joinedload

--- a/c2corg_api/models/user_profile.py
+++ b/c2corg_api/models/user_profile.py
@@ -1,9 +1,9 @@
 from c2corg_api.models import schema
 from c2corg_api.models.document import (
-    ArchiveDocument, Document, get_update_schema, geometry_schema_overrides,
+    ArchiveDocument, Document, geometry_schema_overrides,
     schema_document_locale, schema_attributes, DocumentLocale)
 from c2corg_api.models.enums import user_category, activity_type
-from c2corg_api.models.schema_utils import restrict_schema
+from c2corg_api.models.schema_utils import restrict_schema, get_update_schema
 from c2corg_api.models.utils import copy_attributes, ArrayOfEnum
 from c2corg_common.fields_user_profile import fields_user_profile
 from colanderalchemy import SQLAlchemySchemaNode

--- a/c2corg_api/models/waypoint.py
+++ b/c2corg_api/models/waypoint.py
@@ -1,4 +1,5 @@
-from c2corg_api.models.schema_utils import restrict_schema
+from c2corg_api.models.schema_utils import restrict_schema, \
+    get_update_schema, get_create_schema
 from sqlalchemy import (
     Boolean,
     Column,
@@ -14,8 +15,7 @@ from c2corg_api.models import schema
 from c2corg_api.models.utils import copy_attributes, ArrayOfEnum
 from c2corg_api.models.document import (
     ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale,
-    get_update_schema, geometry_schema_overrides, schema_attributes,
-    schema_locale_attributes)
+    geometry_schema_overrides, schema_attributes, schema_locale_attributes)
 from c2corg_api.models import enums
 from c2corg_common import document_types
 
@@ -310,6 +310,7 @@ schema_waypoint = SQLAlchemySchemaNode(
         'geometry': geometry_schema_overrides
     })
 
+schema_create_waypoint = get_create_schema(schema_waypoint)
 schema_update_waypoint = get_update_schema(schema_waypoint)
 schema_association_waypoint = restrict_schema(schema_waypoint, [
     'elevation', 'locales.title'

--- a/c2corg_api/tests/models/test_association.py
+++ b/c2corg_api/tests/models/test_association.py
@@ -1,0 +1,225 @@
+from c2corg_api.models.association import _get_current_associations, \
+    Association, _diff_associations, synchronize_associations
+from c2corg_api.models.route import Route
+from c2corg_api.models.user_profile import UserProfile
+from c2corg_api.models.waypoint import Waypoint
+from c2corg_api.tests import BaseTestCase
+
+
+class TestAssociation(BaseTestCase):
+
+    def setUp(self):  # noqa
+        BaseTestCase.setUp(self)
+
+        self.waypoint1 = Waypoint(waypoint_type='summit')
+        self.waypoint2 = Waypoint(waypoint_type='summit')
+        self.route1 = Route(activities=['hiking'])
+        self.route2 = Route(activities=['hiking'])
+        self.user_profile1 = UserProfile()
+        self.user_profile2 = UserProfile()
+        self.session.add_all([
+            self.waypoint1, self.waypoint2, self.route1, self.route2,
+            self.user_profile1, self.user_profile2])
+        self.session.flush()
+
+    def _add_test_data_routes(self):
+        self.session.add_all([
+            Association(
+                parent_document=self.route1, child_document=self.route2),
+            Association(
+                parent_document=self.waypoint1, child_document=self.route1),
+            Association(
+                parent_document=self.waypoint2, child_document=self.route1),
+        ])
+        self.session.flush()
+
+    def test_get_current_associations_routes(self):
+        self._add_test_data_routes()
+
+        new_associations = {
+            'routes': [
+                {'document_id': 1, 'is_parent': True}
+            ],
+            'waypoints': [
+                {'document_id': 2, 'is_parent': True}
+            ]
+        }
+
+        current_associations = _get_current_associations(
+            self.route1, new_associations)
+
+        expected_current_associations = {
+            'routes': [
+                {'document_id': self.route2.document_id, 'is_parent': False}
+            ],
+            'waypoints': [
+                {
+                    'document_id': self.waypoint1.document_id,
+                    'is_parent': True
+                },
+                {
+                    'document_id': self.waypoint2.document_id,
+                    'is_parent': True
+                }
+            ]
+        }
+        self.assertEqual(current_associations, expected_current_associations)
+
+    def test_get_current_associations_routes_partial(self):
+        """ Check that only those types are loaded that are also given in the
+        new associations (e.g. waypoints are not loaded in this case because
+        the type is not given as input).
+        """
+        self._add_test_data_routes()
+
+        new_associations = {
+            'routes': [
+                {'document_id': 1, 'is_parent': True}
+            ]
+        }
+
+        current_associations = _get_current_associations(
+            self.route1, new_associations)
+
+        expected_current_associations = {
+            'routes': [
+                {'document_id': self.route2.document_id, 'is_parent': False}
+            ]
+        }
+        self.assertEqual(current_associations, expected_current_associations)
+
+    def test_get_current_associations_waypoints(self):
+        self.waypoint3 = Waypoint(waypoint_type='summit')
+        self.session.add_all([
+            Association(
+                parent_document=self.waypoint1, child_document=self.waypoint2),
+            Association(
+                parent_document=self.waypoint3, child_document=self.waypoint1),
+            Association(
+                parent_document=self.waypoint1, child_document=self.route1),
+            Association(
+                parent_document=self.waypoint1, child_document=self.route2),
+        ])
+        self.session.flush()
+
+        new_associations = {
+            # routes are ignored
+            'routes': [
+                {'document_id': 1, 'is_parent': True},
+                {'document_id': 2, 'is_parent': True}
+            ],
+            'waypoint_parents': [
+                {'document_id': 3, 'is_parent': True}
+            ],
+            'waypoint_children': [
+                {'document_id': 4, 'is_parent': False}
+            ]
+        }
+
+        current_associations = _get_current_associations(
+            self.waypoint1, new_associations)
+
+        expected_current_associations = {
+            'waypoint_parents': [
+                {
+                    'document_id': self.waypoint3.document_id,
+                    'is_parent': True
+                }
+            ],
+            'waypoint_children': [
+                {
+                    'document_id': self.waypoint2.document_id,
+                    'is_parent': False
+                }
+            ]
+        }
+        self.assertEqual(current_associations, expected_current_associations)
+
+    def test_get_current_associations_waypoints_partial(self):
+        self.session.add(Association(
+            parent_document=self.waypoint1, child_document=self.waypoint2)
+        )
+        self.session.flush()
+
+        new_associations = {}
+        current_associations = _get_current_associations(
+            self.waypoint1, new_associations)
+
+        expected_current_associations = {}
+        self.assertEqual(current_associations, expected_current_associations)
+
+    def test_diff_associations(self):
+        new_associations = {
+            'routes': [
+                {'document_id': 1, 'is_parent': True},
+                {'document_id': 2, 'is_parent': True}
+            ],
+            'waypoints': [
+                {'document_id': 3, 'is_parent': False}
+            ]
+        }
+        current_associations = {
+            'routes': [
+                {'document_id': 1, 'is_parent': True},
+                {'document_id': 4, 'is_parent': True}
+            ],
+            'waypoints': []
+        }
+
+        to_add, to_remove = _diff_associations(
+            new_associations, current_associations)
+
+        expected_to_add = [
+            {'document_id': 2, 'is_parent': True},
+            {'document_id': 3, 'is_parent': False}
+        ]
+
+        expected_to_remove = [
+            {'document_id': 4, 'is_parent': True}
+        ]
+
+        self.assertEqual(
+            _get_document_ids(to_add),
+            _get_document_ids(expected_to_add))
+        self.assertEqual(
+            _get_document_ids(to_remove),
+            _get_document_ids(expected_to_remove))
+
+    def test_synchronize_associations(self):
+        self.route3 = Route(activities=['hiking'])
+        self.route4 = Route(activities=['hiking'])
+        self.session.add_all([self.route3, self.route4])
+        self.session.add_all([
+            Association(
+                parent_document=self.route1, child_document=self.route2),
+            Association(
+                parent_document=self.route1, child_document=self.route3)
+        ])
+        self.session.flush()
+
+        new_associations = {
+            'routes': [
+                {'document_id': self.route2.document_id, 'is_parent': True},
+                {'document_id': self.route4.document_id, 'is_parent': True}
+            ],
+            'waypoints': [
+                {'document_id': self.waypoint1.document_id, 'is_parent': True}
+            ]
+        }
+        synchronize_associations(
+            self.route1, new_associations, self.global_userids['contributor'])
+
+        self.assertIsNotNone(self._get_association(self.route1, self.route2))
+        self.assertIsNotNone(self._get_association(self.route4, self.route1))
+        self.assertIsNone(self._get_association(self.route2, self.route1))
+        self.assertIsNone(self._get_association(self.route1, self.route3))
+        self.assertIsNotNone(
+            self._get_association(self.waypoint1, self.route1))
+
+    def _get_association(self, main_doc, child_doc):
+        return self.session.query(Association).get(
+            (main_doc.document_id, child_doc.document_id))
+
+
+def _get_document_ids(docs):
+    return {d['document_id'] for d in docs}

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -53,6 +53,13 @@ class BaseTestRest(BaseTestCase):
         self.assertEqual(error.get('description'), 'Required')
         self.assertEqual(error.get('name'), key)
 
+    def assertError(self, errors, name, description):  # noqa
+        for error in errors:
+            if description == error.get('description') and \
+                    name == error.get('name'):
+                return
+        self.fail('no error ({0}, {1})'.format(name, description))
+
     def post_json_with_token(self, url, token, body={}, status=200):
         headers = self.add_authorization_header(token=token)
         r = self.app_post_json(url, body, headers=headers, status=status)

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -278,7 +278,10 @@ class TestImageRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': 'New description',
                      'version': self.locale_en.version}
-                ]
+                ],
+                'associations': {
+                    'waypoints': [{'document_id': self.waypoint.document_id}]
+                }
             }
         }
         (body, image) = self.put_success_all(body, self.image)
@@ -304,6 +307,11 @@ class TestImageRest(BaseDocumentTestRest):
         version_fr = self.get_latest_version('fr', versions)
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Mont Blanc du ciel')
+
+        # check that a link to the linked wp is created
+        association_wp = self.session.query(Association).get(
+            (self.waypoint.document_id, image.document_id))
+        self.assertIsNotNone(association_wp)
 
     def test_put_success_figures_only(self):
         body = {

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -1,5 +1,7 @@
 import json
 
+from c2corg_api.models.association import Association
+from c2corg_api.models.waypoint import Waypoint, WaypointLocale
 from c2corg_api.tests.search import reset_search_index
 from c2corg_common.attributes import quality_types
 from shapely.geometry import shape, Point
@@ -111,7 +113,10 @@ class TestImageRest(BaseDocumentTestRest):
             },
             'locales': [
                 {'lang': 'en', 'title': 'Some nice loop'}
-            ]
+            ],
+            'associations': {
+                'waypoints': [{'document_id': self.waypoint.document_id}]
+            }
         }
         body, doc = self.post_success(body)
         self._assert_geometry(body)
@@ -129,6 +134,11 @@ class TestImageRest(BaseDocumentTestRest):
         archive_geometry = version.document_geometry_archive
         self.assertEqual(archive_geometry.version, doc.geometry.version)
         self.assertIsNotNone(archive_geometry.geom)
+
+        # check that a link to the linked wp is created
+        association_wp = self.session.query(Association).get(
+            (self.waypoint.document_id, doc.document_id))
+        self.assertIsNotNone(association_wp)
 
     def test_put_wrong_document_id(self):
         body = {
@@ -485,3 +495,13 @@ class TestImageRest(BaseDocumentTestRest):
         self.session.add(self.image4)
         self.session.flush()
         DocumentRest.create_new_version(self.image4, user_id)
+
+        self.waypoint = Waypoint(
+            waypoint_type='summit', elevation=4,
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POINT(635956 5723604)'))
+        self.waypoint.locales.append(WaypointLocale(
+            lang='en', title='Mont Granier (en)', description='...',
+            access='yep'))
+        self.session.add(self.waypoint)
+        self.session.flush()

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -67,6 +67,21 @@ class TestImageRest(BaseDocumentTestRest):
     def test_get_404(self):
         self.get_404()
 
+    def test_get_edit(self):
+        response = self.app.get(self._prefix + '/' +
+                                str(self.image.document_id) + '?e=1',
+                                status=200)
+        body = response.json
+
+        self.assertNotIn('maps', body)
+        self.assertNotIn('areas', body)
+        self.assertIn('associations', body)
+        associations = body['associations']
+        self.assertIn('waypoints', associations)
+        self.assertIn('routes', associations)
+        self.assertIn('images', associations)
+        self.assertIn('users', associations)
+
     def test_post_error(self):
         body = self.post_error({})
         errors = body.get('errors')

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -423,7 +423,11 @@ class TestOutingRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'weather': 'mostly sunny',
                      'version': self.locale_en.version}
-                ]
+                ],
+                'associations': {
+                    'users': [{'id': self.global_userids['contributor']}],
+                    'routes': [{'document_id': self.route.document_id}]
+                }
             }
         }
         self.put_wrong_document_id(body, user='moderator')
@@ -444,7 +448,11 @@ class TestOutingRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'weather': 'mostly sunny',
                      'version': self.locale_en.version}
-                ]
+                ],
+                'associations': {
+                    'users': [{'id': self.global_userids['contributor']}],
+                    'routes': [{'document_id': self.route.document_id}]
+                }
             }
         }
         self.put_wrong_version(body, self.outing.document_id, user='moderator')
@@ -465,7 +473,11 @@ class TestOutingRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'weather': 'mostly sunny',
                      'version': -9999}
-                ]
+                ],
+                'associations': {
+                    'users': [{'id': self.global_userids['contributor']}],
+                    'routes': [{'document_id': self.route.document_id}]
+                }
             }
         }
         self.put_wrong_version(body, self.outing.document_id, user='moderator')
@@ -486,7 +498,11 @@ class TestOutingRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'weather': 'mostly sunny',
                      'version': self.locale_en.version}
-                ]
+                ],
+                'associations': {
+                    'users': [{'id': self.global_userids['contributor']}],
+                    'routes': [{'document_id': self.route.document_id}]
+                }
             }
         }
         self.put_wrong_ids(body, self.outing.document_id, user='moderator')
@@ -514,7 +530,11 @@ class TestOutingRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'weather': 'mostly sunny',
                      'version': self.locale_en.version}
-                ]
+                ],
+                'associations': {
+                    'users': [{'id': self.global_userids['contributor']}],
+                    'routes': [{'document_id': self.route.document_id}]
+                }
             }
         }
         headers = self.add_authorization_header(username='contributor2')
@@ -543,7 +563,11 @@ class TestOutingRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'weather': 'mostly sunny',
                      'version': self.locale_en.version}
-                ]
+                ],
+                'associations': {
+                    'users': [{'id': self.global_userids['contributor']}],
+                    'routes': [{'document_id': self.route.document_id}]
+                }
             }
         }
         headers = self.add_authorization_header(username='contributor')
@@ -575,6 +599,13 @@ class TestOutingRest(BaseDocumentTestRest):
                     'geom_detail':
                         '{"type": "LineString", "coordinates": ' +
                         '[[635956, 5723604], [635976, 5723654]]}'
+                },
+                'associations': {
+                    'users': [
+                        {'id': self.global_userids['contributor']},
+                        {'id': self.global_userids['contributor2']}
+                    ],
+                    'routes': [{'document_id': self.route.document_id}]
                 }
             }
         }
@@ -609,6 +640,14 @@ class TestOutingRest(BaseDocumentTestRest):
         self.assertEqual(archive_locale.title, 'Mont Blanc du ciel')
         self.assertEqual(archive_locale.weather, 'grand beau')
 
+        # test that there are now 2 associated users
+        association_user = self.session.query(Association).get(
+            (self.global_userids['contributor'], outing.document_id))
+        self.assertIsNotNone(association_user)
+        association_user2 = self.session.query(Association).get(
+            (self.global_userids['contributor2'], outing.document_id))
+        self.assertIsNotNone(association_user2)
+
     def test_put_success_figures_only(self):
         body = {
             'message': 'Changing figures',
@@ -627,7 +666,11 @@ class TestOutingRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'weather': 'sunny',
                      'version': self.locale_en.version}
-                ]
+                ],
+                'associations': {
+                    'users': [{'id': self.global_userids['contributor']}],
+                    'routes': [{'document_id': self.route.document_id}]
+                }
             }
         }
         (body, route) = self.put_success_figures_only(
@@ -663,6 +706,10 @@ class TestOutingRest(BaseDocumentTestRest):
                         '[[635956, 5723604], [635976, 5723654]]}',
                     'geom':
                         '{"type": "Point", "coordinates": [635000, 5723000]}'
+                },
+                'associations': {
+                    'users': [{'id': self.global_userids['contributor']}],
+                    'routes': [{'document_id': self.route.document_id}]
                 }
             }
         }
@@ -688,7 +735,11 @@ class TestOutingRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'weather': 'mostly sunny',
                      'version': self.locale_en.version}
-                ]
+                ],
+                'associations': {
+                    'users': [{'id': self.global_userids['contributor']}],
+                    'routes': [{'document_id': self.route.document_id}]
+                }
             }
         }
         (body, route) = self.put_success_lang_only(
@@ -715,7 +766,11 @@ class TestOutingRest(BaseDocumentTestRest):
                 'locales': [
                     {'lang': 'es', 'title': 'Mont Blanc del cielo',
                      'description': '...', 'weather': 'soleado'}
-                ]
+                ],
+                'associations': {
+                    'users': [{'id': self.global_userids['contributor']}],
+                    'routes': [{'document_id': self.route.document_id}]
+                }
             }
         }
         (body, route) = self.put_success_new_lang(

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -235,7 +235,10 @@ class TestRouteRest(BaseDocumentTestRest):
             'locales': [
                 {'lang': 'en', 'title': 'Some nice loop',
                  'gear': 'shoes'}
-            ]
+            ],
+            'associations': {
+                'waypoints': [{'document_id': self.waypoint.document_id}]
+            }
         }
         body, doc = self.post_success(body)
         self._assert_geometry(body)
@@ -305,7 +308,10 @@ class TestRouteRest(BaseDocumentTestRest):
             'locales': [
                 {'lang': 'en', 'title': 'Some nice loop',
                  'gear': 'shoes'}
-            ]
+            ],
+            'associations': {
+                'waypoints': [{'document_id': self.waypoint.document_id}]
+            }
         }
         body, doc = self.post_success(body)
         self.assertIsNotNone(doc.geometry.geom)
@@ -324,12 +330,36 @@ class TestRouteRest(BaseDocumentTestRest):
             'locales': [
                 {'lang': 'en', 'title': 'Some nice loop',
                  'gear': 'shoes'}
-            ]
+            ],
+            'associations': {
+                'waypoints': [{'document_id': self.waypoint.document_id}]
+            }
         }
         body, doc = self.post_success(body)
         self.assertIsNotNone(doc.geometry.geom)
         self.assertIsNone(doc.geometry.geom_detail)
         self._assert_default_geometry(body, x=635956, y=5723604)
+
+    def test_post_main_wp_without_association(self):
+        body_post = {
+            'main_waypoint_id': self.waypoint.document_id,
+            'activities': ['hiking', 'skitouring'],
+            'elevation_min': 700,
+            'elevation_max': 1500,
+            'height_diff_up': 800,
+            'height_diff_down': 800,
+            'durations': ['1'],
+            'locales': [
+                {'lang': 'en', 'title': 'Some nice loop',
+                 'gear': 'shoes'}
+            ]
+            # no association for the main waypoint
+        }
+        body = self.post_error(body_post)
+        errors = body.get('errors')
+        self.assertEqual(len(errors), 1)
+        self.assertError(
+            errors, 'main_waypoint_id', 'no association for the main waypoint')
 
     def test_put_wrong_document_id(self):
         body = {

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -128,6 +128,21 @@ class TestRouteRest(BaseDocumentTestRest):
     def test_get_404(self):
         self.get_404()
 
+    def test_get_edit(self):
+        response = self.app.get(self._prefix + '/' +
+                                str(self.route.document_id) + '?e=1',
+                                status=200)
+        body = response.json
+
+        self.assertIn('maps', body)
+        self.assertNotIn('areas', body)
+        self.assertIn('associations', body)
+        associations = body['associations']
+        self.assertIn('waypoints', associations)
+        self.assertIn('routes', associations)
+        self.assertNotIn('images', associations)
+        self.assertNotIn('users', associations)
+
     def test_post_error(self):
         body = self.post_error({})
         errors = body.get('errors')

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -9,7 +9,7 @@ from c2corg_api.models.outing import Outing, OutingLocale
 from c2corg_api.models.topo_map import TopoMap
 from c2corg_api.models.waypoint import Waypoint, WaypointLocale
 from c2corg_api.tests.search import reset_search_index
-from c2corg_api.views.route import update_title_prefix
+from c2corg_api.views.route import check_title_prefix
 from c2corg_common.attributes import quality_types
 from shapely.geometry import shape, LineString
 
@@ -579,7 +579,12 @@ class TestRouteRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'paraglider',
                      'version': self.route2.locales[0].version}
-                ]
+                ],
+                'associations': {
+                    'waypoints': [
+                        {'document_id': self.waypoint.document_id}
+                    ]
+                }
             }
         }
         (body, route) = self.put_success_figures_only(body, self.route2)
@@ -603,7 +608,12 @@ class TestRouteRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'paraglider',
                      'version': self.locale_en.version}
-                ]
+                ],
+                'associations': {
+                    'waypoints': [
+                        {'document_id': self.waypoint2.document_id}
+                    ]
+                }
             }
         }
         (body, route) = self.put_success_figures_only(body, self.route)
@@ -736,7 +746,7 @@ class TestRouteRest(BaseDocumentTestRest):
         self.route.main_waypoint_id = self.waypoint.document_id
         self.session.flush()
         self.session.refresh(self.route)
-        update_title_prefix(self.route, create=False)
+        check_title_prefix(self.route, create=False)
         self.session.expire_all()
 
         route = self.session.query(Route).get(self.route.document_id)

--- a/c2corg_api/tests/views/test_validation.py
+++ b/c2corg_api/tests/views/test_validation.py
@@ -1,0 +1,175 @@
+from c2corg_api.models.outing import OUTING_TYPE
+from c2corg_api.models.route import Route, ROUTE_TYPE
+from c2corg_api.models.user_profile import UserProfile
+from c2corg_api.models.waypoint import Waypoint, WAYPOINT_TYPE
+from c2corg_api.tests import BaseTestCase
+from c2corg_api.views.validation import _validate_associations
+from cornice.errors import Errors
+
+
+class TestValidation(BaseTestCase):
+
+    def setUp(self):  # noqa
+        BaseTestCase.setUp(self)
+
+        self.waypoint1 = Waypoint(waypoint_type='summit')
+        self.waypoint2 = Waypoint(waypoint_type='summit')
+        self.route1 = Route(activities=['hiking'])
+        self.route2 = Route(activities=['hiking'])
+        self.user_profile1 = UserProfile()
+        self.user_profile2 = UserProfile()
+        self.session.add_all([
+            self.waypoint1, self.waypoint2, self.route1, self.route2,
+            self.user_profile1, self.user_profile2])
+        self.session.flush()
+
+    def test_validate_associations_outing(self):
+        associations_in = {
+            'routes': [
+                {'document_id': self.route1.document_id},
+                {'document_id': self.route2.document_id}
+            ],
+            'users': [
+                {'id': self.user_profile1.document_id}
+            ],
+            'waypoints': [
+                {'document_id': self.waypoint1.document_id}
+            ]
+        }
+
+        errors = Errors()
+        associations = _validate_associations(
+            associations_in, OUTING_TYPE, errors)
+
+        self.assertEquals(len(errors), 0)
+
+        expected_associations = {
+            'users': [
+                {'document_id': self.user_profile1.document_id,
+                 'is_parent': True}
+            ],
+            'routes': [
+                {'document_id': self.route1.document_id, 'is_parent': True},
+                {'document_id': self.route2.document_id, 'is_parent': True}
+            ],
+            'waypoints': [
+                {'document_id': self.waypoint1.document_id, 'is_parent': True}
+            ]
+        }
+        self.assertEqual(associations, expected_associations)
+
+    def test_validate_associations_waypoint(self):
+        associations_in = {
+            'routes': [
+                {'document_id': self.route1.document_id}
+            ],
+            'waypoint_parents': [
+                {'document_id': self.waypoint1.document_id}
+            ],
+            'waypoint_children': [
+                {'document_id': self.waypoint2.document_id}
+            ],
+            'outings': [
+                {'document_id': 'outings are ignored'}
+            ]
+        }
+
+        errors = Errors()
+        associations = _validate_associations(
+            associations_in, WAYPOINT_TYPE, errors)
+
+        self.assertEquals(len(errors), 0)
+
+        expected_associations = {
+            'routes': [
+                {'document_id': self.route1.document_id, 'is_parent': False}
+            ],
+            'waypoint_parents': [
+                {'document_id': self.waypoint1.document_id, 'is_parent': True}
+            ],
+            'waypoint_children': [
+                {'document_id': self.waypoint2.document_id, 'is_parent': False}
+            ]
+        }
+        self.assertEqual(associations, expected_associations)
+
+    def test_validate_associations_route(self):
+        associations_in = {
+            'routes': [
+                {'document_id': self.route1.document_id},
+                {'document_id': self.route2.document_id}
+            ],
+            'waypoints': [
+                {'document_id': self.waypoint1.document_id}
+            ]
+        }
+
+        errors = Errors()
+        associations = _validate_associations(
+            associations_in, ROUTE_TYPE, errors)
+
+        self.assertEquals(len(errors), 0)
+
+        expected_associations = {
+            'routes': [
+                {'document_id': self.route1.document_id, 'is_parent': False},
+                {'document_id': self.route2.document_id, 'is_parent': False}
+            ],
+            'waypoints': [
+                {'document_id': self.waypoint1.document_id, 'is_parent': True}
+            ]
+        }
+        self.assertEqual(associations, expected_associations)
+
+    def test_validate_associations_invalid_type(self):
+        associations_in = {
+            'users': [
+                {'document_id': self.user_profile1.document_id,
+                 'is_parent': True}
+            ]
+        }
+
+        errors = Errors()
+        associations = _validate_associations(
+            associations_in, WAYPOINT_TYPE, errors)
+
+        # users are ignored for waypoints
+        self.assertEquals(associations, {})
+
+    def test_validate_associations_invalid_document_id(self):
+        associations_in = {
+            'routes': [
+                {'document_id': -99999}
+            ]
+        }
+
+        errors = Errors()
+        associations = _validate_associations(
+            associations_in, WAYPOINT_TYPE, errors)
+
+        self.assertIsNone(associations)
+        self.assertEquals(len(errors), 1)
+        error = errors[0]
+        self.assertEqual(error['name'], 'associations.routes')
+        self.assertEqual(
+            error['description'], 'document "-99999" does not exist')
+
+    def test_validate_associations_invalid_document_type(self):
+        associations_in = {
+            'routes': [
+                {'document_id': self.waypoint1.document_id}
+            ]
+        }
+
+        errors = Errors()
+        associations = _validate_associations(
+            associations_in, WAYPOINT_TYPE, errors)
+
+        self.assertIsNone(associations)
+        self.assertEquals(len(errors), 1)
+        error = errors[0]
+        self.assertEqual(error['name'], 'associations.routes')
+        self.assertEqual(
+            error['description'],
+            'document "' + str(self.waypoint1.document_id) +
+            '" is not of type "r"')

--- a/c2corg_api/tests/views/test_validation.py
+++ b/c2corg_api/tests/views/test_validation.py
@@ -60,6 +60,7 @@ class TestValidation(BaseTestCase):
 
     def test_validate_associations_waypoint(self):
         associations_in = {
+            # routes are ignored
             'routes': [
                 {'document_id': self.route1.document_id}
             ],
@@ -81,9 +82,6 @@ class TestValidation(BaseTestCase):
         self.assertEquals(len(errors), 0)
 
         expected_associations = {
-            'routes': [
-                {'document_id': self.route1.document_id, 'is_parent': False}
-            ],
             'waypoint_parents': [
                 {'document_id': self.waypoint1.document_id, 'is_parent': True}
             ],
@@ -138,7 +136,7 @@ class TestValidation(BaseTestCase):
 
     def test_validate_associations_invalid_document_id(self):
         associations_in = {
-            'routes': [
+            'waypoint_parents': [
                 {'document_id': -99999}
             ]
         }
@@ -150,7 +148,7 @@ class TestValidation(BaseTestCase):
         self.assertIsNone(associations)
         self.assertEquals(len(errors), 1)
         error = errors[0]
-        self.assertEqual(error['name'], 'associations.routes')
+        self.assertEqual(error['name'], 'associations.waypoint_parents')
         self.assertEqual(
             error['description'], 'document "-99999" does not exist')
 
@@ -163,7 +161,7 @@ class TestValidation(BaseTestCase):
 
         errors = Errors()
         associations = _validate_associations(
-            associations_in, WAYPOINT_TYPE, errors)
+            associations_in, ROUTE_TYPE, errors)
 
         self.assertIsNone(associations)
         self.assertEquals(len(errors), 1)

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -314,7 +314,9 @@ class TestWaypointRest(BaseDocumentTestRest):
                  'access': 'y'}
             ],
             'associations': {
-                'routes': [{'document_id': self.route1.document_id}]
+                'waypoint_children': [
+                    {'document_id': self.waypoint2.document_id}
+                ]
             }
         }
         body, doc = self.post_success(body)
@@ -353,10 +355,10 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.assertEqual(len(links), 1)
         self.assertEqual(links[0].area_id, self.area1.document_id)
 
-        # check that a link to the route is created
-        association_route = self.session.query(Association).get(
-            (doc.document_id, self.route1.document_id))
-        self.assertIsNotNone(association_route)
+        # check that a link to the child waypoint is created
+        association_wp = self.session.query(Association).get(
+            (doc.document_id, self.waypoint2.document_id))
+        self.assertIsNotNone(association_wp)
 
     def test_put_wrong_document_id(self):
         body = {
@@ -452,6 +454,14 @@ class TestWaypointRest(BaseDocumentTestRest):
                 'geometry': {
                     'version': self.waypoint.geometry.version,
                     'geom': '{"type": "Point", "coordinates": [635957, 5723605]}'  # noqa
+                },
+                'associations': {
+                    'waypoint_children': [
+                        {'document_id': self.waypoint2.document_id}
+                    ],
+                    'routes': [
+                        {'document_id': self.route1.document_id}
+                    ]
                 }
             }
         }
@@ -502,6 +512,11 @@ class TestWaypointRest(BaseDocumentTestRest):
             all()
         self.assertEqual(len(links), 1)
         self.assertEqual(links[0].area_id, self.area1.document_id)
+
+        # check that a link to the child waypoint is created
+        association_wp = self.session.query(Association).get(
+            (waypoint.document_id, self.waypoint2.document_id))
+        self.assertIsNotNone(association_wp)
 
     def test_put_success_figures_and_lang_only(self):
         body_put = {

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -101,7 +101,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.assertIn('associations', body)
         associations = body.get('associations')
 
-        linked_waypoints = associations.get('waypoints')
+        linked_waypoints = associations.get('waypoint_children')
         self.assertEqual(1, len(linked_waypoints))
         self.assertEqual(
             self.waypoint4.document_id, linked_waypoints[0].get('document_id'))
@@ -150,11 +150,12 @@ class TestWaypointRest(BaseDocumentTestRest):
 
     def test_get_no_associations(self):
         response = self.app.get(self._prefix + '/' +
-                                str(self.waypoint.document_id) + '?a=0',
+                                str(self.waypoint.document_id) + '?e=1',
                                 status=200)
         body = response.json
 
-        self.assertNotIn('associations', body)
+        self.assertIn('associations', body)
+        self.assertNotIn('recent_outings', body['associations'])
         self.assertIn('maps', body)
         self.assertNotIn('areas', body)
 

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -312,7 +312,10 @@ class TestWaypointRest(BaseDocumentTestRest):
                 {'id': 3456, 'version': 4567,
                  'lang': 'en', 'title': 'Mont Pourri',
                  'access': 'y'}
-            ]
+            ],
+            'associations': {
+                'routes': [{'document_id': self.route1.document_id}]
+            }
         }
         body, doc = self.post_success(body)
         self._assert_geometry(body, 'geom')
@@ -349,6 +352,11 @@ class TestWaypointRest(BaseDocumentTestRest):
             all()
         self.assertEqual(len(links), 1)
         self.assertEqual(links[0].area_id, self.area1.document_id)
+
+        # check that a link to the route is created
+        association_route = self.session.query(Association).get(
+            (doc.document_id, self.route1.document_id))
+        self.assertIsNotNone(association_route)
 
     def test_put_wrong_document_id(self):
         body = {

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -148,16 +148,22 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.assertIn('rock_types', body)
         self.assertEqual(body['rock_types'], [])
 
-    def test_get_no_associations(self):
+    def test_get_edit(self):
         response = self.app.get(self._prefix + '/' +
                                 str(self.waypoint.document_id) + '?e=1',
                                 status=200)
         body = response.json
 
-        self.assertIn('associations', body)
         self.assertNotIn('recent_outings', body['associations'])
         self.assertIn('maps', body)
         self.assertNotIn('areas', body)
+        self.assertIn('associations', body)
+        associations = body['associations']
+        self.assertIn('waypoint_parents', associations)
+        self.assertIn('waypoint_children', associations)
+        self.assertNotIn('waypoints', associations)
+        self.assertNotIn('routes', associations)
+        self.assertNotIn('images', associations)
 
     def test_get_version(self):
         self.get_version(self.waypoint, self.waypoint_version)

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -6,7 +6,8 @@ from c2corg_api.models import DBSession
 from c2corg_api.models.area import AREA_TYPE, schema_listing_area
 from c2corg_api.models.area_association import update_areas_for_document, \
     get_areas
-from c2corg_api.models.association import get_associations, create_associations
+from c2corg_api.models.association import get_associations, \
+    create_associations, synchronize_associations
 from c2corg_api.models.document import (
     UpdateType, DocumentLocale, ArchiveDocumentLocale, ArchiveDocument,
     ArchiveDocumentGeometry, set_available_langs, get_available_langs)
@@ -312,6 +313,10 @@ class DocumentRest(object):
 
             # And the search updated
             notify_es_syncer(self.request.registry.queue_config)
+
+        associations = self.request.validated.get('associations', None)
+        if associations:
+            synchronize_associations(document, associations, user_id)
 
         return {}
 

--- a/c2corg_api/views/image.py
+++ b/c2corg_api/views/image.py
@@ -1,7 +1,9 @@
+import functools
+
 from c2corg_api.models import DBSession
 from c2corg_api.models.document_history import has_been_created_by
 from c2corg_api.models.image import Image, schema_image, schema_update_image, \
-    schema_listing_image, IMAGE_TYPE
+    schema_listing_image, IMAGE_TYPE, schema_create_image
 from c2corg_common.fields_image import fields_image
 from cornice.resource import resource, view
 
@@ -9,12 +11,15 @@ from c2corg_api.views.document import DocumentRest, make_validator_create, \
     make_validator_update
 from c2corg_api.views import cors_policy, restricted_json_view
 from c2corg_api.views.validation import validate_id, validate_pagination, \
-    validate_lang_param, validate_preferred_lang_param
+    validate_lang_param, validate_preferred_lang_param, \
+    validate_associations_create
 
 from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound, HTTPBadRequest
 
 validate_image_create = make_validator_create(fields_image.get('required'))
 validate_image_update = make_validator_update(fields_image.get('required'))
+validate_associations = functools.partial(
+    validate_associations_create, IMAGE_TYPE)
 
 
 @resource(collection_path='/images', path='/images/{id}',
@@ -30,7 +35,8 @@ class ImageRest(DocumentRest):
         return self._get(Image, schema_image)
 
     @restricted_json_view(
-            schema=schema_image, validators=validate_image_create)
+            schema=schema_create_image, validators=[validate_image_create,
+                                                    validate_associations])
     def collection_post(self):
         return self._collection_post(schema_image)
 

--- a/c2corg_api/views/image.py
+++ b/c2corg_api/views/image.py
@@ -12,14 +12,16 @@ from c2corg_api.views.document import DocumentRest, make_validator_create, \
 from c2corg_api.views import cors_policy, restricted_json_view
 from c2corg_api.views.validation import validate_id, validate_pagination, \
     validate_lang_param, validate_preferred_lang_param, \
-    validate_associations_create
+    validate_associations
 
 from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound, HTTPBadRequest
 
 validate_image_create = make_validator_create(fields_image.get('required'))
 validate_image_update = make_validator_update(fields_image.get('required'))
-validate_associations = functools.partial(
-    validate_associations_create, IMAGE_TYPE)
+validate_associations_create = functools.partial(
+    validate_associations, IMAGE_TYPE, True)
+validate_associations_update = functools.partial(
+    validate_associations, IMAGE_TYPE, False)
 
 
 @resource(collection_path='/images', path='/images/{id}',
@@ -35,14 +37,16 @@ class ImageRest(DocumentRest):
         return self._get(Image, schema_image)
 
     @restricted_json_view(
-            schema=schema_create_image, validators=[validate_image_create,
-                                                    validate_associations])
+            schema=schema_create_image,
+            validators=[validate_image_create, validate_associations_create])
     def collection_post(self):
         return self._collection_post(schema_image)
 
     @restricted_json_view(
             schema=schema_update_image,
-            validators=[validate_id, validate_image_update])
+            validators=[validate_id,
+                        validate_image_update,
+                        validate_associations_update])
     def put(self):
         if not self.request.has_permission('moderator'):
             image_id = self.request.validated['id']

--- a/c2corg_api/views/route.py
+++ b/c2corg_api/views/route.py
@@ -1,7 +1,7 @@
 import functools
 
 from c2corg_api.models import DBSession
-from c2corg_api.models.association import Association, add_association
+from c2corg_api.models.association import Association
 from c2corg_api.models.document import DocumentLocale, DocumentGeometry
 from c2corg_api.models.outing import schema_association_outing, Outing
 from c2corg_api.views.outing import set_author
@@ -19,7 +19,7 @@ from c2corg_api.views import cors_policy, restricted_json_view, \
     get_best_locale, to_json_dict, set_best_locale
 from c2corg_api.views.validation import validate_id, validate_pagination, \
     validate_lang, validate_version_id, validate_lang_param, \
-    validate_preferred_lang_param, validate_associations_create
+    validate_preferred_lang_param, validate_associations
 from c2corg_common.fields_route import fields_route
 from c2corg_common.attributes import activities
 from sqlalchemy.orm import load_only, joinedload
@@ -28,15 +28,18 @@ validate_route_create = make_validator_create(
     fields_route, 'activities', activities)
 validate_route_update = make_validator_update(
     fields_route, 'activities', activities)
-validate_associations = functools.partial(
-    validate_associations_create, ROUTE_TYPE)
+validate_associations_create = functools.partial(
+    validate_associations, ROUTE_TYPE, True)
+validate_associations_update = functools.partial(
+    validate_associations, ROUTE_TYPE, False)
 
 
-def validate_main_waypoint(request):
+def validate_main_waypoint(is_on_create, request):
     """ Check that the document given as main waypoint is also listed as
     association.
     """
-    doc = request.validated
+    doc = request.validated if is_on_create else \
+        request.validated.get('document', {})
     main_waypoint_id = doc.get('main_waypoint_id', None)
 
     if not main_waypoint_id:
@@ -86,17 +89,22 @@ class RouteRest(DocumentRest):
             adapt_schema=schema_adaptor, include_maps=True,
             set_custom_associations=RouteRest.set_recent_outings)
 
-    @restricted_json_view(schema=schema_create_route,
-                          validators=[validate_route_create,
-                                      validate_associations,
-                                      validate_main_waypoint])
+    @restricted_json_view(
+        schema=schema_create_route,
+        validators=[validate_route_create,
+                    validate_associations_create,
+                    functools.partial(validate_main_waypoint, True)])
     def collection_post(self):
         return self._collection_post(
             schema_route, before_add=set_default_geometry,
             after_add=init_title_prefix)
 
-    @restricted_json_view(schema=schema_update_route,
-                          validators=[validate_id, validate_route_update])
+    @restricted_json_view(
+        schema=schema_update_route,
+        validators=[validate_id,
+                    validate_route_update,
+                    validate_associations_update,
+                    functools.partial(validate_main_waypoint, False)])
     def put(self):
         old_main_waypoint_id = DBSession.query(Route.main_waypoint_id). \
             filter(Route.document_id == self.request.validated['id']).scalar()
@@ -104,7 +112,7 @@ class RouteRest(DocumentRest):
             Route, schema_route,
             before_update=functools.partial(
                 update_default_geometry, old_main_waypoint_id),
-            after_update=after_route_update)
+            after_update=update_title_prefix)
 
     @staticmethod
     def set_recent_outings(route, lang):
@@ -203,26 +211,15 @@ def main_waypoint_has_changed(route, old_main_waypoint_id):
         return old_main_waypoint_id != route.main_waypoint_id
 
 
-def create_main_waypoint_association(route, user_id, check_first=False):
-    """Create an association between the newly created route and the main
-    waypoint.
-    """
-    if route.main_waypoint_id:
-        add_association(
-            route.main_waypoint_id, route.document_id, user_id,
-            check_first=check_first)
-
-
 def init_title_prefix(route, user_id):
-    update_title_prefix(route, create=True)
+    check_title_prefix(route, create=True)
 
 
-def after_route_update(route, update_types, user_id):
-    create_main_waypoint_association(route, user_id, check_first=True)
-    update_title_prefix(route)
+def update_title_prefix(route, update_types, user_id):
+    check_title_prefix(route)
 
 
-def update_title_prefix(route, create=False):
+def check_title_prefix(route, create=False):
     """The field `main_waypoint_id` indicates the main waypoint of a
      route. If given, the title of this waypoint is cached in
      RouteLocale.title_prefix. This method takes care of setting this field.

--- a/c2corg_api/views/validation.py
+++ b/c2corg_api/views/validation.py
@@ -143,8 +143,13 @@ def validate_required_json_string(key, request):
         request.errors.add('body', key, 'Invalid')
 
 
-def validate_associations_create(document_type, request):
-    associations_in = request.validated.get('associations', None)
+def validate_associations(document_type, is_on_create, request):
+    if is_on_create:
+        associations_in = request.validated.get('associations', None)
+    else:
+        associations_in = request.validated. \
+            get('document', {}).get('associations', None)
+
     if not associations_in:
         return
 

--- a/c2corg_api/views/validation.py
+++ b/c2corg_api/views/validation.py
@@ -281,11 +281,18 @@ association_keys = {
     'images': IMAGE_TYPE
 }
 
+association_keys_for_types = {
+    ROUTE_TYPE: 'routes',
+    WAYPOINT_TYPE: 'waypoints',
+    USERPROFILE_TYPE: 'users',
+    IMAGE_TYPE: 'images'
+}
+
 # associations that can be updated/created when updating/creating a document
 # e.g. when creating a route, route and waypoint associations can be created
 updatable_associations = {
     ROUTE_TYPE: {'routes', 'waypoints'},
-    WAYPOINT_TYPE: {'routes', 'waypoint_parents', 'waypoint_children'},
+    WAYPOINT_TYPE: {'waypoint_parents', 'waypoint_children'},
     OUTING_TYPE: {'routes', 'users', 'waypoints'},
     IMAGE_TYPE: {'routes', 'waypoints', 'images', 'users'}
 }

--- a/c2corg_api/views/validation.py
+++ b/c2corg_api/views/validation.py
@@ -1,5 +1,15 @@
+from c2corg_api.models import DBSession
+from c2corg_api.models.document import Document
+from c2corg_api.models.image import IMAGE_TYPE
+from c2corg_api.models.outing import OUTING_TYPE
+from c2corg_api.models.route import ROUTE_TYPE
+from c2corg_api.models.user_profile import USERPROFILE_TYPE
+from c2corg_api.models.waypoint import WAYPOINT_TYPE
+from c2corg_common.associations import valid_associations
 from c2corg_common.attributes import default_langs
 from colander import null
+from cornice.errors import Errors
+
 
 # Validation functions
 
@@ -131,3 +141,151 @@ def validate_required_json_string(key, request):
         request.validated[key] = value
     else:
         request.errors.add('body', key, 'Invalid')
+
+
+def validate_associations_create(document_type, request):
+    associations_in = request.validated.get('associations', None)
+    if not associations_in:
+        return
+
+    request.validated['associations'] = _validate_associations(
+        associations_in, document_type, request.errors)
+
+
+def _validate_associations(associations_in, document_type, errors):
+    """Validate the provided associations:
+
+        - Check that the linked documents exist.
+        - Check that the linked documents have the right document type (e.g. a
+          document listed as route association must really be a route).
+        - Check that only valid association combinations are given.
+
+    Returns the validated associations.
+    """
+    new_errors = Errors()
+    associations = {}
+
+    _add_associations(associations, associations_in, document_type,
+                      'users', USERPROFILE_TYPE, new_errors)
+    _add_associations(associations, associations_in, document_type,
+                      'routes', ROUTE_TYPE, new_errors)
+    _add_associations(associations, associations_in, document_type,
+                      'waypoints', WAYPOINT_TYPE, new_errors)
+    _add_associations(associations, associations_in, document_type,
+                      'images', IMAGE_TYPE, new_errors)
+    _add_associations(associations, associations_in, document_type,
+                      'waypoint_parents', WAYPOINT_TYPE, new_errors)
+    _add_associations(associations, associations_in, document_type,
+                      'waypoint_children', WAYPOINT_TYPE, new_errors)
+
+    if new_errors:
+        errors.extend(new_errors)
+        return None
+
+    _check_for_valid_documents_ids(associations, new_errors)
+
+    if new_errors:
+        errors.extend(new_errors)
+        return None
+    else:
+        return associations
+
+
+def _check_for_valid_documents_ids(associations, errors):
+    """ Check that the given documents do exists and that they are of the
+    correct type (e.g. a document listed as route association must really be
+    a route).
+    """
+    linked_documents_id = _get_linked_document_ids(associations)
+
+    # load the type for each linked document
+    if linked_documents_id:
+        query_documents_with_type = DBSession. \
+            query(Document.document_id, Document.type). \
+            filter(Document.document_id.in_(linked_documents_id))
+        type_for_document_id = {
+            str(document_id): doc_type
+            for document_id, doc_type in query_documents_with_type
+        }
+    else:
+        type_for_document_id = {}
+
+    for document_key, docs in associations.items():
+        doc_type = association_keys[document_key]
+        for doc in docs:
+            document_id = doc['document_id']
+            if str(document_id) not in type_for_document_id:
+                errors.add(
+                    'body', 'associations.' + document_key,
+                    'document "{0:n}" does not exist'.format(document_id))
+                continue
+            if doc_type != type_for_document_id[str(document_id)]:
+                errors.add(
+                    'body', 'associations.' + document_key,
+                    'document "{0:n}" is not of type "{1}"'.format(
+                        document_id, doc_type))
+
+
+def _get_linked_document_ids(associations):
+    """ Get a list of document ids of all linked documents.
+    """
+    return set().union(*[
+        [
+            doc['document_id'] for doc in docs
+        ] for docs in associations.values()
+    ])
+
+
+def _add_associations(
+        associations, associations_in, main_document_type,
+        document_key, other_document_type, errors):
+    valid_types = updatable_associations.get(main_document_type, set())
+    if document_key in valid_types and associations_in.get(document_key, None):
+        is_parent = _is_parent_of_association(
+            main_document_type, other_document_type)
+
+        if is_parent is None:
+            errors.add(
+                'body', 'associations.' + document_key,
+                'invalid association type')
+        else:
+            if document_key == 'waypoint_parents':
+                is_parent = True
+            elif document_key == 'waypoint_children':
+                is_parent = False
+
+            associations[document_key] = [
+                {
+                    'document_id':
+                        doc['id'] if other_document_type == USERPROFILE_TYPE
+                        else doc['document_id'],
+                    'is_parent': is_parent
+                } for doc in associations_in[document_key]
+            ]
+
+
+def _is_parent_of_association(main_document_type, other_document_type):
+    if (main_document_type, other_document_type) in valid_associations:
+        return False
+    elif (other_document_type, main_document_type) in valid_associations:
+        return True
+    else:
+        return None
+
+association_keys = {
+    'routes': ROUTE_TYPE,
+    'waypoints': WAYPOINT_TYPE,
+    'waypoint_parents': WAYPOINT_TYPE,
+    'waypoint_children': WAYPOINT_TYPE,
+    'users': USERPROFILE_TYPE,
+    'images': IMAGE_TYPE
+}
+
+# associations that can be updated/created when updating/creating a document
+# e.g. when creating a route, route and waypoint associations can be created
+updatable_associations = {
+    ROUTE_TYPE: {'routes', 'waypoints'},
+    WAYPOINT_TYPE: {'routes', 'waypoint_parents', 'waypoint_children'},
+    OUTING_TYPE: {'routes', 'users', 'waypoints'},
+    IMAGE_TYPE: {'routes', 'waypoints', 'images', 'users'}
+}

--- a/c2corg_api/views/waypoint.py
+++ b/c2corg_api/views/waypoint.py
@@ -22,7 +22,7 @@ from c2corg_api.views import cors_policy, restricted_json_view, \
     to_json_dict, set_best_locale
 from c2corg_api.views.validation import validate_id, validate_pagination, \
     validate_lang, validate_version_id, validate_lang_param, \
-    validate_preferred_lang_param, validate_associations_create
+    validate_preferred_lang_param, validate_associations
 from c2corg_common.fields_waypoint import fields_waypoint
 from c2corg_common.attributes import waypoint_types
 from functools import lru_cache
@@ -34,8 +34,10 @@ validate_waypoint_create = make_validator_create(
     fields_waypoint, 'waypoint_type', waypoint_types)
 validate_waypoint_update = make_validator_update(
     fields_waypoint, 'waypoint_type', waypoint_types)
-validate_associations = functools.partial(
-    validate_associations_create, WAYPOINT_TYPE)
+validate_associations_create = functools.partial(
+    validate_associations, WAYPOINT_TYPE, True)
+validate_associations_update = functools.partial(
+    validate_associations, WAYPOINT_TYPE, False)
 
 
 @lru_cache(maxsize=None)
@@ -134,12 +136,14 @@ class WaypointRest(DocumentRest):
 
     @restricted_json_view(schema=schema_create_waypoint,
                           validators=[validate_waypoint_create,
-                                      validate_associations])
+                                      validate_associations_create])
     def collection_post(self):
         return self._collection_post(schema_waypoint)
 
     @restricted_json_view(schema=schema_update_waypoint,
-                          validators=[validate_id, validate_waypoint_update])
+                          validators=[validate_id,
+                                      validate_waypoint_update,
+                                      validate_associations_update])
     def put(self):
         return self._put(
             Waypoint, schema_waypoint, after_update=update_linked_route_titles)


### PR DESCRIPTION
Closes https://github.com/c2corg/v6_api/issues/274
Closes https://github.com/c2corg/v6_api/issues/180
Closes https://github.com/c2corg/v6_api/issues/212

When creating or updating a document, the associations can now be passed together with the document:

```json
{
    "message": "Update",
    "document": {
        "document_id": 123,
        
        "associations": {
            "users": [
                {"id": 45},
                {"id": 67}
            ],
            "routes": [
                {"document_id": 89}
            ]
        }
    }
}
```

A few remarks:

- For the edit page, a document should now be requested with `...&e=1` to get only the information needed (before there was a parameter `&a=0` to exclude associations, but that name is no longer appropriate).
- For waypoints, parent and child waypoints are returned in two different collections `waypoint_parents` and `waypoint_children`.
- The association types that can be created/updated for a certain document types are listed [here](https://github.com/c2corg/v6_api/blob/associations-edit/c2corg_api/views/validation.py#L296-L303). E.g. for a route you can update associations to other routes and waypoints.
