### PR TITLE
Use 'w' as code for waypoints in URL

### DIFF
--- a/c2corg_api/search/mapping_types.py
+++ b/c2corg_api/search/mapping_types.py
@@ -6,7 +6,7 @@ from elasticsearch_dsl import String, Long, Integer, Boolean
 meta_param_keys = ('pl', 'limit', 'offset')
 
 # parameters used for the search service that can not be used as query fields
-reserved_query_fields = meta_param_keys + ('q', 'bbox', 'r', 'wp')
+reserved_query_fields = meta_param_keys + ('q', 'bbox', 'r', 'w')
 
 
 class QueryableMixin(object):

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -53,7 +53,7 @@ class TestOutingRest(BaseDocumentTestRest):
 
     def test_get_collection_for_waypoint(self):
         response = self.app.get(
-            self._prefix + '?wp=' + str(self.waypoint.document_id), status=200)
+            self._prefix + '?w=' + str(self.waypoint.document_id), status=200)
 
         documents = response.json['documents']
 

--- a/c2corg_api/views/outing.py
+++ b/c2corg_api/views/outing.py
@@ -59,7 +59,7 @@ def validate_filter_params(request):
     Checks if a given optional waypoint id is an integer,
     if a given optional route id is an integer.
     """
-    check_get_for_integer_property(request, 'wp', False)
+    check_get_for_integer_property(request, 'w', False)
     check_get_for_integer_property(request, 'r', False)
 
 
@@ -86,10 +86,10 @@ class OutingRest(DocumentRest):
         validate_filter_params])
     def collection_get(self):
         custom_filter = None
-        if self.request.validated.get('wp'):
+        if self.request.validated.get('w'):
             # only show outings for the given waypoint
             custom_filter = self.filter_on_waypoint(
-                self.request.validated['wp'])
+                self.request.validated['w'])
         elif self.request.validated.get('r'):
             # only show outings for the given route
             custom_filter = self.filter_on_route(self.request.validated['r'])


### PR DESCRIPTION
and be consistent with the document type in https://github.com/c2corg/v6_common/blob/master/c2corg_common/document_types.py#L8