### PR TITLE
Store document types with associations

### DIFF
--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -12,7 +12,8 @@ from sqlalchemy import (
     Column,
     Integer,
     DateTime,
-    ForeignKey
+    ForeignKey,
+    String
     )
 from sqlalchemy.schema import PrimaryKeyConstraint
 from sqlalchemy.orm import relationship, joinedload, load_only
@@ -39,22 +40,34 @@ class Association(Base):
         nullable=False)
     parent_document = relationship(
         Document, primaryjoin=parent_document_id == Document.document_id)
+    parent_document_type = Column(String(1), nullable=False)
 
     child_document_id = Column(
         Integer, ForeignKey(schema + '.documents.document_id'),
         nullable=False)
     child_document = relationship(
         Document, primaryjoin=child_document_id == Document.document_id)
+    child_document_type = Column(String(1), nullable=False)
 
     __table_args__ = (
         PrimaryKeyConstraint(parent_document_id, child_document_id),
         Base.__table_args__
     )
 
+    @staticmethod
+    def create(parent_document, child_document):
+        return Association(
+            parent_document=parent_document,
+            parent_document_type=parent_document.type,
+            child_document=child_document,
+            child_document_type=child_document.type)
+
     def get_log(self, user_id, is_creation=True):
         return AssociationLog(
             parent_document_id=self.parent_document_id,
+            parent_document_type=self.parent_document_type,
             child_document_id=self.child_document_id,
+            child_document_type=self.child_document_type,
             user_id=user_id,
             is_creation=is_creation
         )
@@ -73,12 +86,14 @@ class AssociationLog(Base):
         nullable=False)
     parent_document = relationship(
         Document, primaryjoin=parent_document_id == Document.document_id)
+    parent_document_type = Column(String(1))
 
     child_document_id = Column(
         Integer, ForeignKey(schema + '.documents.document_id'),
         nullable=False)
     child_document = relationship(
         Document, primaryjoin=child_document_id == Document.document_id)
+    child_document_type = Column(String(1))
 
     user_id = Column(
         Integer, ForeignKey(users_schema + '.user.id'), nullable=False)
@@ -244,13 +259,16 @@ def exists_already(link):
 
 
 def add_association(
-        parent_document_id, child_document_id, user_id, check_first=False):
+        parent_document_id, parent_document_type,
+        child_document_id, child_document_type, user_id, check_first=False):
     """Create an association between the two documents and create a log entry
     in the association history table with the given user id.
     """
     association = Association(
         parent_document_id=parent_document_id,
-        child_document_id=child_document_id)
+        parent_document_type=parent_document_type,
+        child_document_id=child_document_id,
+        child_document_type=child_document_type)
 
     if check_first and exists_already(association):
         return
@@ -282,14 +300,20 @@ def create_associations(document, associations_for_document, user_id):
     a document.
     """
     main_id = document.document_id
+    main_doc_type = document.type
     for doc_key, docs in associations_for_document.items():
+        doc_type = association_keys[doc_key]
         for doc in docs:
             linked_document_id = doc['document_id']
             is_parent = doc['is_parent']
 
             parent_id = linked_document_id if is_parent else main_id
+            parent_type = doc_type if is_parent else main_doc_type
             child_id = main_id if is_parent else linked_document_id
-            add_association(parent_id, child_id, user_id, check_first=False)
+            child_type = main_doc_type if is_parent else doc_type
+            add_association(
+                parent_id, parent_type, child_id, child_type,
+                user_id, check_first=False)
 
 
 def synchronize_associations(document, new_associations, user_id):
@@ -300,17 +324,30 @@ def synchronize_associations(document, new_associations, user_id):
     to_add, to_remove = _diff_associations(
         new_associations, current_associations)
 
-    document_id = document.document_id
-    _apply_operation(to_add, add_association, document_id, user_id)
-    _apply_operation(to_remove, remove_association, document_id, user_id)
+    _add_associations(to_add, document, user_id)
+    _remove_associations(to_remove, document, user_id)
 
 
-def _apply_operation(docs, add_or_remove, document_id, user_id):
-    for doc in docs:
+def _add_associations(to_add, document, user_id):
+    main_doc_type = document.type
+    for doc in to_add:
         is_parent = doc['is_parent']
-        parent_id = doc['document_id'] if is_parent else document_id
-        child_id = document_id if is_parent else doc['document_id']
-        add_or_remove(parent_id, child_id, user_id, check_first=False)
+        parent_id = doc['document_id'] if is_parent else document.document_id
+        parent_type = doc['doc_type'] if is_parent else main_doc_type
+        child_id = document.document_id if is_parent else doc['document_id']
+        child_type = main_doc_type if is_parent else doc['doc_type']
+
+        add_association(
+            parent_id, parent_type, child_id, child_type,
+            user_id, check_first=False)
+
+
+def _remove_associations(to_remove, document, user_id):
+    for doc in to_remove:
+        is_parent = doc['is_parent']
+        parent_id = doc['document_id'] if is_parent else document.document_id
+        child_id = document.document_id if is_parent else doc['document_id']
+        remove_association(parent_id, child_id, user_id, check_first=False)
 
 
 def _get_current_associations(document, new_associations):
@@ -389,12 +426,14 @@ def _get_associations_to_add(new_associations, current_associations):
     to_add = []
 
     for typ, docs in new_associations.items():
+        doc_type = association_keys[typ]
         existing_docs = {
             d['document_id'] for d in current_associations.get(typ, [])
         }
 
         for doc in docs:
             if doc['document_id'] not in existing_docs:
+                doc['doc_type'] = doc_type
                 to_add.append(doc)
 
     return to_add

--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -384,26 +384,26 @@ def _get_load_associations_query(document, doc_types_to_load):
     query_parents = DBSession. \
         query(
             Association.parent_document_id.label('id'),
-            Document.type.label('t'),
+            Association.parent_document_type.label('t'),
             literal_column('1').label('p')). \
-        join(
-            Document,
+        filter(
             and_(
                 Association.child_document_id == document.document_id,
-                Association.parent_document_id == Document.document_id,
-                Document.type.in_(doc_types_to_load))). \
+                Association.parent_document_type.in_(doc_types_to_load)
+            )
+        ). \
         subquery()
     query_children = DBSession. \
         query(
             Association.child_document_id.label('id'),
-            Document.type.label('t'),
+            Association.child_document_type.label('t'),
             literal_column('0').label('p')). \
-        join(
-            Document,
+        filter(
             and_(
-                Association.child_document_id == Document.document_id,
                 Association.parent_document_id == document.document_id,
-                Document.type.in_(doc_types_to_load))). \
+                Association.child_document_type.in_(doc_types_to_load)
+            )
+        ). \
         subquery()
 
     return DBSession \

--- a/c2corg_api/tests/models/test_association.py
+++ b/c2corg_api/tests/models/test_association.py
@@ -1,8 +1,8 @@
 from c2corg_api.models.association import _get_current_associations, \
     Association, _diff_associations, synchronize_associations
-from c2corg_api.models.route import Route
+from c2corg_api.models.route import Route, ROUTE_TYPE
 from c2corg_api.models.user_profile import UserProfile
-from c2corg_api.models.waypoint import Waypoint
+from c2corg_api.models.waypoint import Waypoint, WAYPOINT_TYPE
 from c2corg_api.tests import BaseTestCase
 
 
@@ -24,11 +24,11 @@ class TestAssociation(BaseTestCase):
 
     def _add_test_data_routes(self):
         self.session.add_all([
-            Association(
+            Association.create(
                 parent_document=self.route1, child_document=self.route2),
-            Association(
+            Association.create(
                 parent_document=self.waypoint1, child_document=self.route1),
-            Association(
+            Association.create(
                 parent_document=self.waypoint2, child_document=self.route1),
         ])
         self.session.flush()
@@ -91,13 +91,13 @@ class TestAssociation(BaseTestCase):
     def test_get_current_associations_waypoints(self):
         self.waypoint3 = Waypoint(waypoint_type='summit')
         self.session.add_all([
-            Association(
+            Association.create(
                 parent_document=self.waypoint1, child_document=self.waypoint2),
-            Association(
+            Association.create(
                 parent_document=self.waypoint3, child_document=self.waypoint1),
-            Association(
+            Association.create(
                 parent_document=self.waypoint1, child_document=self.route1),
-            Association(
+            Association.create(
                 parent_document=self.waypoint1, child_document=self.route2),
         ])
         self.session.flush()
@@ -136,7 +136,7 @@ class TestAssociation(BaseTestCase):
         self.assertEqual(current_associations, expected_current_associations)
 
     def test_get_current_associations_waypoints_partial(self):
-        self.session.add(Association(
+        self.session.add(Association.create(
             parent_document=self.waypoint1, child_document=self.waypoint2)
         )
         self.session.flush()
@@ -170,12 +170,12 @@ class TestAssociation(BaseTestCase):
             new_associations, current_associations)
 
         expected_to_add = [
-            {'document_id': 2, 'is_parent': True},
-            {'document_id': 3, 'is_parent': False}
+            {'document_id': 2, 'is_parent': True, 'doc_type': ROUTE_TYPE},
+            {'document_id': 3, 'is_parent': False, 'doc_type': WAYPOINT_TYPE}
         ]
 
         expected_to_remove = [
-            {'document_id': 4, 'is_parent': True}
+            {'document_id': 4, 'is_parent': True, 'doc_type': ROUTE_TYPE}
         ]
 
         self.assertEqual(
@@ -189,10 +189,11 @@ class TestAssociation(BaseTestCase):
         self.route3 = Route(activities=['hiking'])
         self.route4 = Route(activities=['hiking'])
         self.session.add_all([self.route3, self.route4])
+        self.session.flush()
         self.session.add_all([
-            Association(
+            Association.create(
                 parent_document=self.route1, child_document=self.route2),
-            Association(
+            Association.create(
                 parent_document=self.route1, child_document=self.route3)
         ])
         self.session.flush()

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -6,6 +6,7 @@ from c2corg_api.models.document_history import DocumentVersion
 from c2corg_api.models.image import Image
 from c2corg_api.models.outing import Outing, ArchiveOuting, \
     ArchiveOutingLocale, OutingLocale, OUTING_TYPE
+from c2corg_api.models.user_profile import USERPROFILE_TYPE
 from c2corg_api.models.waypoint import Waypoint, WaypointLocale
 from c2corg_api.tests.search import reset_search_index
 from c2corg_common.attributes import quality_types
@@ -932,17 +933,19 @@ class TestOutingRest(BaseDocumentTestRest):
             gear='paraglider'))
         self.session.add(self.route)
         self.session.flush()
-        self.session.add(Association(
-            parent_document_id=self.waypoint.document_id,
-            child_document_id=self.route.document_id))
-        self.session.add(Association(
-            parent_document_id=self.route.document_id,
-            child_document_id=self.outing.document_id))
+        self.session.add(Association.create(
+            parent_document=self.waypoint,
+            child_document=self.route))
+        self.session.add(Association.create(
+            parent_document=self.route,
+            child_document=self.outing))
 
         self.session.add(Association(
             parent_document_id=user_id,
-            child_document_id=self.outing.document_id))
-        self.session.add(Association(
-            parent_document_id=self.outing.document_id,
-            child_document_id=self.image.document_id))
+            parent_document_type=USERPROFILE_TYPE,
+            child_document_id=self.outing.document_id,
+            child_document_type=OUTING_TYPE))
+        self.session.add(Association.create(
+            parent_document=self.outing,
+            child_document=self.image))
         self.session.flush()

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -868,15 +868,15 @@ class TestRouteRest(BaseDocumentTestRest):
             access='yep'))
         self.session.add(self.waypoint2)
         self.session.flush()
-        self.session.add(Association(
-            parent_document_id=self.route.document_id,
-            child_document_id=self.route4.document_id))
-        self.session.add(Association(
-            parent_document_id=self.route4.document_id,
-            child_document_id=self.route.document_id))
-        self.session.add(Association(
-            parent_document_id=self.waypoint.document_id,
-            child_document_id=self.route.document_id))
+        self.session.add(Association.create(
+            parent_document=self.route,
+            child_document=self.route4))
+        self.session.add(Association.create(
+            parent_document=self.route4,
+            child_document=self.route))
+        self.session.add(Association.create(
+            parent_document=self.waypoint,
+            child_document=self.route))
 
         self.outing1 = Outing(
             activities=['skitouring'], date_start=datetime.date(2016, 1, 1),
@@ -889,9 +889,9 @@ class TestRouteRest(BaseDocumentTestRest):
         )
         self.session.add(self.outing1)
         self.session.flush()
-        self.session.add(Association(
-            parent_document_id=self.route.document_id,
-            child_document_id=self.outing1.document_id))
+        self.session.add(Association.create(
+            parent_document=self.route,
+            child_document=self.outing1))
 
         self.outing2 = Outing(
             redirects_to=self.outing1.document_id,
@@ -905,9 +905,9 @@ class TestRouteRest(BaseDocumentTestRest):
         )
         self.session.add(self.outing2)
         self.session.flush()
-        self.session.add(Association(
-            parent_document_id=self.route.document_id,
-            child_document_id=self.outing2.document_id))
+        self.session.add(Association.create(
+            parent_document=self.route,
+            child_document=self.outing2))
         self.session.flush()
 
         # add areas

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -985,21 +985,21 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.session.add(self.route2)
         self.session.add(self.route3)
         self.session.flush()
-        self.session.add(Association(
-            parent_document_id=self.waypoint.document_id,
-            child_document_id=self.waypoint4.document_id))
-        self.session.add(Association(
-            parent_document_id=self.waypoint.document_id,
-            child_document_id=self.waypoint5.document_id))
-        self.session.add(Association(
-            parent_document_id=self.waypoint.document_id,
-            child_document_id=self.route1.document_id))
-        self.session.add(Association(
-            parent_document_id=self.waypoint.document_id,
-            child_document_id=self.route2.document_id))
-        self.session.add(Association(
-            parent_document_id=self.waypoint4.document_id,
-            child_document_id=self.route3.document_id))
+        self.session.add(Association.create(
+            parent_document=self.waypoint,
+            child_document=self.waypoint4))
+        self.session.add(Association.create(
+            parent_document=self.waypoint,
+            child_document=self.waypoint5))
+        self.session.add(Association.create(
+            parent_document=self.waypoint,
+            child_document=self.route1))
+        self.session.add(Association.create(
+            parent_document=self.waypoint,
+            child_document=self.route2))
+        self.session.add(Association.create(
+            parent_document=self.waypoint4,
+            child_document=self.route3))
 
         self.outing1 = Outing(
             activities=['skitouring'], date_start=datetime.date(2016, 1, 1),
@@ -1012,9 +1012,9 @@ class TestWaypointRest(BaseDocumentTestRest):
         )
         self.session.add(self.outing1)
         self.session.flush()
-        self.session.add(Association(
-            parent_document_id=self.route1.document_id,
-            child_document_id=self.outing1.document_id))
+        self.session.add(Association.create(
+            parent_document=self.route1,
+            child_document=self.outing1))
 
         self.outing2 = Outing(
             redirects_to=self.outing1.document_id,
@@ -1039,12 +1039,12 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.session.add(self.outing2)
         self.session.add(self.outing3)
         self.session.flush()
-        self.session.add(Association(
-            parent_document_id=self.route1.document_id,
-            child_document_id=self.outing2.document_id))
-        self.session.add(Association(
-            parent_document_id=self.route3.document_id,
-            child_document_id=self.outing3.document_id))
+        self.session.add(Association.create(
+            parent_document=self.route1,
+            child_document=self.outing2))
+        self.session.add(Association.create(
+            parent_document=self.route3,
+            child_document=self.outing3))
 
         # add a map
         topo_map = TopoMap(

--- a/c2corg_api/views/association.py
+++ b/c2corg_api/views/association.py
@@ -35,6 +35,9 @@ def validate_association(request):
                 'body', 'child_document_id', 'child document does not exist')
 
     if parent_document_type and child_document_type:
+        request.validated['parent_document_type'] = parent_document_type
+        request.validated['child_document_type'] = child_document_type
+
         association_type = (parent_document_type, child_document_type)
         if association_type not in valid_associations:
             request.errors.add(
@@ -52,6 +55,10 @@ class AssociationRest(object):
         schema=schema_association, validators=[validate_association])
     def collection_post(self):
         association = schema_association.objectify(self.request.validated)
+        association.parent_document_type = \
+            self.request.validated['parent_document_type']
+        association.child_document_type = \
+            self.request.validated['child_document_type']
 
         if exists_already(association):
             raise HTTPBadRequest(

--- a/c2corg_api/views/outing.py
+++ b/c2corg_api/views/outing.py
@@ -1,8 +1,7 @@
 import functools
 from c2corg_api.models import DBSession
 from c2corg_api.models.association import Association
-from c2corg_api.models.document import ArchiveDocument, Document, \
-    DocumentGeometry
+from c2corg_api.models.document import ArchiveDocument, DocumentGeometry
 from c2corg_api.models.document_history import HistoryMetaData, DocumentVersion
 from c2corg_api.models.outing import schema_outing, Outing, \
     schema_create_outing, schema_update_outing, ArchiveOuting, \
@@ -165,23 +164,19 @@ class OutingRest(DocumentRest):
         def filter_query(query):
             t_outing_route = aliased(Association, name='a1')
             t_route_wp = aliased(Association, name='a2')
-            t_route = aliased(Document, name='r')
 
             return query. \
                 join(
                     t_outing_route,
                     Outing.document_id == t_outing_route.child_document_id). \
                 join(
-                    t_route,
-                    and_(
-                        t_outing_route.parent_document_id ==
-                        t_route.document_id,
-                        t_route.type == ROUTE_TYPE)). \
-                join(
                     t_route_wp,
                     and_(
-                        t_route_wp.parent_document_id == waypoint_id,
-                        t_route_wp.child_document_id == t_route.document_id))
+                        t_route_wp.child_document_id ==
+                        t_outing_route.parent_document_id,
+                        t_route_wp.child_document_type == ROUTE_TYPE,
+                        t_route_wp.parent_document_id == waypoint_id
+                    ))
         return filter_query
 
 


### PR DESCRIPTION
To simplify queries on associations, the document type is now stored with the association (similar to how it was in v5).

Related to https://github.com/c2corg/v6_api/issues/297