### PR TITLE
Search for routes/outings given an associated document

### DIFF
--- a/c2corg_api/ext/sqa_view.py
+++ b/c2corg_api/ext/sqa_view.py
@@ -1,0 +1,52 @@
+from sqlalchemy.ext import compiler
+from sqlalchemy.sql.ddl import DDLElement
+from sqlalchemy.sql.schema import Table, Column, MetaData
+
+# Support for views in SQLAlchemy
+# See: https://bitbucket.org/zzzeek/sqlalchemy/wiki/UsageRecipes/Views
+# and: https://github.com/jeffwidman/sqlalchemy-postgresql-materialized-views
+
+
+class CreateView(DDLElement):
+    def __init__(self, name, schema, selectable):
+        self.name = name
+        self.schema = schema
+        self.selectable = selectable
+
+
+@compiler.compiles(CreateView)
+def compile_create_view(element, compiler, **kw):
+    return "CREATE VIEW %s.%s AS %s" % (
+        element.schema,
+        element.name,
+        compiler.sql_compiler.process(element.selectable)
+    )
+
+
+class DropView(DDLElement):
+    def __init__(self, name, schema):
+        self.name = name
+        self.schema = schema
+
+
+@compiler.compiles(DropView)
+def compile_drop_view(element, compiler, **kw):
+    return "DROP VIEW IF EXISTS %s.%s" % (element.schema, element.name)
+
+
+def view(name, schema, metadata, selectable):
+    """
+    Create a view for the given select. A table is returned which can be
+    used to query the view.
+    """
+    # a temporary MetaData object is used to avoid that this table is actually
+    # created
+    t = Table(name, MetaData(), schema=schema)
+
+    for c in selectable.c:
+        t.append_column(Column(c.name, c.type, primary_key=c.primary_key))
+
+    CreateView(name, schema, selectable).execute_at('after-create', metadata)
+    DropView(name, schema).execute_at('before-drop', metadata)
+
+    return t

--- a/c2corg_api/models/__init__.py
+++ b/c2corg_api/models/__init__.py
@@ -33,6 +33,7 @@ from c2corg_api.models import area_association  # noqa
 from c2corg_api.models import user_profile  # noqa
 from c2corg_api.models import outing  # noqa
 from c2corg_api.models import es_sync  # noqa
+from c2corg_api.models import association_views  # noqa
 
 document_types = {
     waypoint.WAYPOINT_TYPE: waypoint.Waypoint,

--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -37,17 +37,17 @@ class Association(Base):
 
     parent_document_id = Column(
         Integer, ForeignKey(schema + '.documents.document_id'),
-        nullable=False)
+        nullable=False, index=True)
     parent_document = relationship(
         Document, primaryjoin=parent_document_id == Document.document_id)
-    parent_document_type = Column(String(1), nullable=False)
+    parent_document_type = Column(String(1), nullable=False, index=True)
 
     child_document_id = Column(
         Integer, ForeignKey(schema + '.documents.document_id'),
-        nullable=False)
+        nullable=False, index=True)
     child_document = relationship(
         Document, primaryjoin=child_document_id == Document.document_id)
-    child_document_type = Column(String(1), nullable=False)
+    child_document_type = Column(String(1), nullable=False, index=True)
 
     __table_args__ = (
         PrimaryKeyConstraint(parent_document_id, child_document_id),

--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -57,9 +57,9 @@ class Association(Base):
     @staticmethod
     def create(parent_document, child_document):
         return Association(
-            parent_document=parent_document,
+            parent_document_id=parent_document.document_id,
             parent_document_type=parent_document.type,
-            child_document=child_document,
+            child_document_id=child_document.document_id,
             child_document_type=child_document.type)
 
     def get_log(self, user_id, is_creation=True):
@@ -86,14 +86,14 @@ class AssociationLog(Base):
         nullable=False)
     parent_document = relationship(
         Document, primaryjoin=parent_document_id == Document.document_id)
-    parent_document_type = Column(String(1))
+    parent_document_type = Column(String(1), nullable=False)
 
     child_document_id = Column(
         Integer, ForeignKey(schema + '.documents.document_id'),
         nullable=False)
     child_document = relationship(
         Document, primaryjoin=child_document_id == Document.document_id)
-    child_document_type = Column(String(1))
+    child_document_type = Column(String(1), nullable=False)
 
     user_id = Column(
         Integer, ForeignKey(users_schema + '.user.id'), nullable=False)
@@ -278,13 +278,16 @@ def add_association(
 
 
 def remove_association(
-        parent_document_id, child_document_id, user_id, check_first=False):
+        parent_document_id, parent_document_type,
+        child_document_id, child_document_type, user_id, check_first=False):
     """Remove an association between the two documents and create a log entry
     in the association history table with the given user id.
     """
     association = Association(
         parent_document_id=parent_document_id,
-        child_document_id=child_document_id)
+        parent_document_type=parent_document_type,
+        child_document_id=child_document_id,
+        child_document_type=child_document_type)
 
     if check_first and not exists_already(association):
         return
@@ -324,30 +327,22 @@ def synchronize_associations(document, new_associations, user_id):
     to_add, to_remove = _diff_associations(
         new_associations, current_associations)
 
-    _add_associations(to_add, document, user_id)
-    _remove_associations(to_remove, document, user_id)
+    _apply_operation(to_add, add_association, document, user_id)
+    _apply_operation(to_remove, remove_association, document, user_id)
 
 
-def _add_associations(to_add, document, user_id):
+def _apply_operation(docs, add_or_remove, document, user_id):
     main_doc_type = document.type
-    for doc in to_add:
+    for doc in docs:
         is_parent = doc['is_parent']
         parent_id = doc['document_id'] if is_parent else document.document_id
         parent_type = doc['doc_type'] if is_parent else main_doc_type
         child_id = document.document_id if is_parent else doc['document_id']
         child_type = main_doc_type if is_parent else doc['doc_type']
 
-        add_association(
+        add_or_remove(
             parent_id, parent_type, child_id, child_type,
             user_id, check_first=False)
-
-
-def _remove_associations(to_remove, document, user_id):
-    for doc in to_remove:
-        is_parent = doc['is_parent']
-        parent_id = doc['document_id'] if is_parent else document.document_id
-        child_id = document.document_id if is_parent else doc['document_id']
-        remove_association(parent_id, child_id, user_id, check_first=False)
 
 
 def _get_current_associations(document, new_associations):

--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -12,7 +12,8 @@ from sqlalchemy import (
     Column,
     Integer,
     DateTime,
-    ForeignKey
+    ForeignKey,
+    String
     )
 from sqlalchemy.schema import PrimaryKeyConstraint
 from sqlalchemy.orm import relationship, joinedload, load_only
@@ -39,22 +40,34 @@ class Association(Base):
         nullable=False)
     parent_document = relationship(
         Document, primaryjoin=parent_document_id == Document.document_id)
+    parent_document_type = Column(String(1), nullable=False)
 
     child_document_id = Column(
         Integer, ForeignKey(schema + '.documents.document_id'),
         nullable=False)
     child_document = relationship(
         Document, primaryjoin=child_document_id == Document.document_id)
+    child_document_type = Column(String(1), nullable=False)
 
     __table_args__ = (
         PrimaryKeyConstraint(parent_document_id, child_document_id),
         Base.__table_args__
     )
 
+    @staticmethod
+    def create(parent_document, child_document):
+        return Association(
+            parent_document=parent_document,
+            parent_document_type=parent_document.type,
+            child_document=child_document,
+            child_document_type=child_document.type)
+
     def get_log(self, user_id, is_creation=True):
         return AssociationLog(
             parent_document_id=self.parent_document_id,
+            parent_document_type=self.parent_document_type,
             child_document_id=self.child_document_id,
+            child_document_type=self.child_document_type,
             user_id=user_id,
             is_creation=is_creation
         )
@@ -73,12 +86,14 @@ class AssociationLog(Base):
         nullable=False)
     parent_document = relationship(
         Document, primaryjoin=parent_document_id == Document.document_id)
+    parent_document_type = Column(String(1))
 
     child_document_id = Column(
         Integer, ForeignKey(schema + '.documents.document_id'),
         nullable=False)
     child_document = relationship(
         Document, primaryjoin=child_document_id == Document.document_id)
+    child_document_type = Column(String(1))
 
     user_id = Column(
         Integer, ForeignKey(users_schema + '.user.id'), nullable=False)
@@ -244,13 +259,16 @@ def exists_already(link):
 
 
 def add_association(
-        parent_document_id, child_document_id, user_id, check_first=False):
+        parent_document_id, parent_document_type,
+        child_document_id, child_document_type, user_id, check_first=False):
     """Create an association between the two documents and create a log entry
     in the association history table with the given user id.
     """
     association = Association(
         parent_document_id=parent_document_id,
-        child_document_id=child_document_id)
+        parent_document_type=parent_document_type,
+        child_document_id=child_document_id,
+        child_document_type=child_document_type)
 
     if check_first and exists_already(association):
         return
@@ -282,14 +300,20 @@ def create_associations(document, associations_for_document, user_id):
     a document.
     """
     main_id = document.document_id
+    main_doc_type = document.type
     for doc_key, docs in associations_for_document.items():
+        doc_type = association_keys[doc_key]
         for doc in docs:
             linked_document_id = doc['document_id']
             is_parent = doc['is_parent']
 
             parent_id = linked_document_id if is_parent else main_id
+            parent_type = doc_type if is_parent else main_doc_type
             child_id = main_id if is_parent else linked_document_id
-            add_association(parent_id, child_id, user_id, check_first=False)
+            child_type = main_doc_type if is_parent else doc_type
+            add_association(
+                parent_id, parent_type, child_id, child_type,
+                user_id, check_first=False)
 
 
 def synchronize_associations(document, new_associations, user_id):
@@ -300,17 +324,30 @@ def synchronize_associations(document, new_associations, user_id):
     to_add, to_remove = _diff_associations(
         new_associations, current_associations)
 
-    document_id = document.document_id
-    _apply_operation(to_add, add_association, document_id, user_id)
-    _apply_operation(to_remove, remove_association, document_id, user_id)
+    _add_associations(to_add, document, user_id)
+    _remove_associations(to_remove, document, user_id)
 
 
-def _apply_operation(docs, add_or_remove, document_id, user_id):
-    for doc in docs:
+def _add_associations(to_add, document, user_id):
+    main_doc_type = document.type
+    for doc in to_add:
         is_parent = doc['is_parent']
-        parent_id = doc['document_id'] if is_parent else document_id
-        child_id = document_id if is_parent else doc['document_id']
-        add_or_remove(parent_id, child_id, user_id, check_first=False)
+        parent_id = doc['document_id'] if is_parent else document.document_id
+        parent_type = doc['doc_type'] if is_parent else main_doc_type
+        child_id = document.document_id if is_parent else doc['document_id']
+        child_type = main_doc_type if is_parent else doc['doc_type']
+
+        add_association(
+            parent_id, parent_type, child_id, child_type,
+            user_id, check_first=False)
+
+
+def _remove_associations(to_remove, document, user_id):
+    for doc in to_remove:
+        is_parent = doc['is_parent']
+        parent_id = doc['document_id'] if is_parent else document.document_id
+        child_id = document.document_id if is_parent else doc['document_id']
+        remove_association(parent_id, child_id, user_id, check_first=False)
 
 
 def _get_current_associations(document, new_associations):
@@ -389,12 +426,14 @@ def _get_associations_to_add(new_associations, current_associations):
     to_add = []
 
     for typ, docs in new_associations.items():
+        doc_type = association_keys[typ]
         existing_docs = {
             d['document_id'] for d in current_associations.get(typ, [])
         }
 
         for doc in docs:
             if doc['document_id'] not in existing_docs:
+                doc['doc_type'] = doc_type
                 to_add.append(doc)
 
     return to_add

--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -384,26 +384,26 @@ def _get_load_associations_query(document, doc_types_to_load):
     query_parents = DBSession. \
         query(
             Association.parent_document_id.label('id'),
-            Document.type.label('t'),
+            Association.parent_document_type.label('t'),
             literal_column('1').label('p')). \
-        join(
-            Document,
+        filter(
             and_(
                 Association.child_document_id == document.document_id,
-                Association.parent_document_id == Document.document_id,
-                Document.type.in_(doc_types_to_load))). \
+                Association.parent_document_type.in_(doc_types_to_load)
+            )
+        ). \
         subquery()
     query_children = DBSession. \
         query(
             Association.child_document_id.label('id'),
-            Document.type.label('t'),
+            Association.child_document_type.label('t'),
             literal_column('0').label('p')). \
-        join(
-            Document,
+        filter(
             and_(
-                Association.child_document_id == Document.document_id,
                 Association.parent_document_id == document.document_id,
-                Document.type.in_(doc_types_to_load))). \
+                Association.child_document_type.in_(doc_types_to_load)
+            )
+        ). \
         subquery()
 
     return DBSession \

--- a/c2corg_api/models/association_views.py
+++ b/c2corg_api/models/association_views.py
@@ -1,0 +1,102 @@
+from c2corg_api.ext import sqa_view
+from c2corg_api.models import Base, schema
+from c2corg_api.models.association import Association
+from c2corg_api.models.route import ROUTE_TYPE, Route
+from c2corg_api.models.waypoint import WAYPOINT_TYPE
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql.expression import and_, union, select, text, join
+from sqlalchemy.sql.functions import func
+from sqlalchemy import Integer
+
+
+def _get_select_waypoints_for_routes():
+    """ Returns a select which retrieves for every route the ids for the
+    waypoints that are associated to the route. It also returns the parent
+    and grand-parent of waypoints, so that when searching for routes for a
+    waypoint, you also get the routes associated to child waypoints.
+
+    E.g. when searching for routes for Calanques, you also get the routes
+    associated to sub-sectors.
+    """
+    waypoint_type = text('\'' + WAYPOINT_TYPE + '\'')
+    route_type = text('\'' + ROUTE_TYPE + '\'')
+
+    select_linked_waypoints = \
+        select([
+            Association.child_document_id.label('route_id'),
+            Association.parent_document_id.label('waypoint_id')
+        ]). \
+        where(
+            and_(
+                Association.parent_document_type == waypoint_type,
+                Association.child_document_type == route_type)). \
+        cte('linked_waypoints')
+
+    select_waypoint_parents = \
+        select([
+            select_linked_waypoints.c.route_id,
+            Association.parent_document_id.label('waypoint_id')
+        ]). \
+        select_from(join(
+            select_linked_waypoints,
+            Association,
+            and_(
+                Association.child_document_id ==
+                select_linked_waypoints.c.waypoint_id,
+                Association.parent_document_type == waypoint_type
+            ))). \
+        cte('waypoint_parents')
+
+    select_waypoint_grandparents = \
+        select([
+            select_waypoint_parents.c.route_id,
+            Association.parent_document_id.label('waypoint_id')
+        ]). \
+        select_from(join(
+            select_waypoint_parents,
+            Association,
+            and_(
+                Association.child_document_id ==
+                select_waypoint_parents.c.waypoint_id,
+                Association.parent_document_type == waypoint_type
+            ))). \
+        cte('waypoint_grandparents')
+
+    all_waypoints = union(
+            select_linked_waypoints.select(),
+            select_waypoint_parents.select(),
+            select_waypoint_grandparents.select()
+        ). \
+        cte('all_waypoints')
+
+    return \
+        select([
+            all_waypoints.c.route_id.label('route_id'),
+            func.array_agg(
+                all_waypoints.c.waypoint_id,
+                type_=postgresql.ARRAY(Integer)).label('waypoint_ids')
+        ]). \
+        select_from(all_waypoints). \
+        group_by(all_waypoints.c.route_id)
+
+
+class WaypointsForRoutesView(Base):
+    """ A (non-materialized) view which contains the associated waypoints
+     for each route. This view is used when filling the search index for
+     routes.
+    """
+    __table__ = sqa_view.view(
+        'waypoints_for_routes',
+        schema,
+        Base.metadata,
+        _get_select_waypoints_for_routes())
+
+
+Route.associated_waypoints_ids = relationship(
+    WaypointsForRoutesView,
+    uselist=False,
+    primaryjoin=Route.document_id == WaypointsForRoutesView.route_id,
+    foreign_keys=WaypointsForRoutesView.route_id,
+    viewonly=True, cascade='expunge'
+)

--- a/c2corg_api/models/association_views.py
+++ b/c2corg_api/models/association_views.py
@@ -1,6 +1,7 @@
 from c2corg_api.ext import sqa_view
 from c2corg_api.models import Base, schema
 from c2corg_api.models.association import Association
+from c2corg_api.models.outing import OUTING_TYPE, Outing
 from c2corg_api.models.route import ROUTE_TYPE, Route
 from c2corg_api.models.waypoint import WAYPOINT_TYPE
 from sqlalchemy.dialects import postgresql
@@ -11,14 +12,6 @@ from sqlalchemy import Integer
 
 
 def _get_select_waypoints_for_routes():
-    """ Returns a select which retrieves for every route the ids for the
-    waypoints that are associated to the route. It also returns the parent
-    and grand-parent of waypoints, so that when searching for routes for a
-    waypoint, you also get the routes associated to child waypoints.
-
-    E.g. when searching for routes for Calanques, you also get the routes
-    associated to sub-sectors.
-    """
     waypoint_type = text('\'' + WAYPOINT_TYPE + '\'')
     route_type = text('\'' + ROUTE_TYPE + '\'')
 
@@ -63,13 +56,24 @@ def _get_select_waypoints_for_routes():
             ))). \
         cte('waypoint_grandparents')
 
-    all_waypoints = union(
+    return union(
             select_linked_waypoints.select(),
             select_waypoint_parents.select(),
             select_waypoint_grandparents.select()
         ). \
         cte('all_waypoints')
 
+
+def _get_select_waypoints_for_routes_aggregated():
+    """ Returns a select which retrieves for every route the ids for the
+    waypoints that are associated to the route. It also returns the parent
+    and grand-parent of waypoints, so that when searching for routes for a
+    waypoint, you also get the routes associated to child waypoints.
+
+    E.g. when searching for routes for Calanques, you also get the routes
+    associated to sub-sectors.
+    """
+    all_waypoints = _get_select_waypoints_for_routes()
     return \
         select([
             all_waypoints.c.route_id.label('route_id'),
@@ -90,7 +94,7 @@ class WaypointsForRoutesView(Base):
         'waypoints_for_routes',
         schema,
         Base.metadata,
-        _get_select_waypoints_for_routes())
+        _get_select_waypoints_for_routes_aggregated())
 
 
 Route.associated_waypoints_ids = relationship(
@@ -98,5 +102,65 @@ Route.associated_waypoints_ids = relationship(
     uselist=False,
     primaryjoin=Route.document_id == WaypointsForRoutesView.route_id,
     foreign_keys=WaypointsForRoutesView.route_id,
+    viewonly=True, cascade='expunge'
+)
+
+
+def _get_select_waypoints_for_outings_aggregated():
+    """ Returns a select which retrieves for every outing the ids for the
+    waypoints that are associated to routes associated to the outing. It
+    also returns the parent and grand-parent of waypoints, so that when
+    searching for outings for a waypoint, you also get the outings associated
+    to child waypoints.
+
+    E.g. when searching for outings in Calanques, you also get the outings
+    associated to sub-sectors.
+    """
+    outing_type = text('\'' + OUTING_TYPE + '\'')
+    route_type = text('\'' + ROUTE_TYPE + '\'')
+    all_waypoints_for_routes = _get_select_waypoints_for_routes()
+    waypoints_for_outings = \
+        select([
+            Association.child_document_id.label('outing_id'),
+            all_waypoints_for_routes.c.waypoint_id
+        ]). \
+        select_from(join(
+            Association,
+            all_waypoints_for_routes,
+            and_(
+                Association.parent_document_id ==
+                all_waypoints_for_routes.c.route_id,
+                Association.parent_document_type == route_type,
+                Association.child_document_type == outing_type
+            ))). \
+        cte('waypoints_for_outings')
+    return \
+        select([
+            waypoints_for_outings.c.outing_id.label('outing_id'),
+            func.array_agg(
+                waypoints_for_outings.c.waypoint_id,
+                type_=postgresql.ARRAY(Integer)).label('waypoint_ids')
+        ]). \
+        select_from(waypoints_for_outings). \
+        group_by(waypoints_for_outings.c.outing_id)
+
+
+class WaypointsForOutingsView(Base):
+    """ A (non-materialized) view which contains the associated waypoints
+     for each outing. This view is used when filling the search index for
+     outings.
+    """
+    __table__ = sqa_view.view(
+        'waypoints_for_outings',
+        schema,
+        Base.metadata,
+        _get_select_waypoints_for_outings_aggregated())
+
+
+Outing.associated_waypoints_ids = relationship(
+    WaypointsForOutingsView,
+    uselist=False,
+    primaryjoin=Outing.document_id == WaypointsForOutingsView.outing_id,
+    foreign_keys=WaypointsForOutingsView.outing_id,
     viewonly=True, cascade='expunge'
 )

--- a/c2corg_api/scripts/es/sync.py
+++ b/c2corg_api/scripts/es/sync.py
@@ -73,17 +73,6 @@ def get_changed_documents_for_associations(session, last_update):
     """ Check if associations have been created/removed. If so return the
     documents that have to be updated.
     """
-    association_types_to_check = {
-        # needed to update waypoint ids for routes
-        (WAYPOINT_TYPE, ROUTE_TYPE),
-        (WAYPOINT_TYPE, WAYPOINT_TYPE),
-        # needed to update waypoint ids for outings (+ the 2 types above)
-        # also needed to update route ids for outings
-        (ROUTE_TYPE, OUTING_TYPE),
-        # needed to update user ids for outings
-        (USERPROFILE_TYPE, OUTING_TYPE)
-    }
-
     associations_changed = session.query(AssociationLog). \
         filter(or_(*[
             and_(
@@ -322,3 +311,21 @@ def create_search_documents(doc_type, documents, batch):
         batch.add(to_search_document(doc, index))
         n += 1
     log.info('Sent {} document(s) of type {}'.format(n, doc_type))
+
+# association types that require an update
+association_types_to_check = {
+    # needed to update waypoint ids for routes
+    (WAYPOINT_TYPE, ROUTE_TYPE),
+    (WAYPOINT_TYPE, WAYPOINT_TYPE),
+    # needed to update waypoint ids for outings (+ the 2 types above)
+    # also needed to update route ids for outings
+    (ROUTE_TYPE, OUTING_TYPE),
+    # needed to update user ids for outings
+    (USERPROFILE_TYPE, OUTING_TYPE)
+}
+
+
+def requires_updates(association):
+    association_type = \
+        (association.parent_document_type, association.child_document_type)
+    return association_type in association_types_to_check

--- a/c2corg_api/scripts/es/sync.py
+++ b/c2corg_api/scripts/es/sync.py
@@ -78,6 +78,7 @@ def get_changed_documents_for_associations(session, last_update):
         (WAYPOINT_TYPE, ROUTE_TYPE),
         (WAYPOINT_TYPE, WAYPOINT_TYPE),
         # needed to update waypoint ids for outings (+ the 2 types above)
+        # also needed to update route ids for outings
         (ROUTE_TYPE, OUTING_TYPE),
         # needed to update user ids for outings
         (USERPROFILE_TYPE, OUTING_TYPE)
@@ -220,7 +221,8 @@ def get_changed_outings_ro_uo(session, last_update):
 
     E.g. when an association between outing O1 and route R1 is created,
     outing O1 has to be updated so that all waypoints associated to R1 are
-    listed under `associated_waypoints_ids`.
+    listed under `associated_waypoints_ids`, and so that R1 is listed under
+    `associated_routes_ids`.
     """
     return session. \
         query(

--- a/c2corg_api/search/mapping_types.py
+++ b/c2corg_api/search/mapping_types.py
@@ -6,7 +6,7 @@ from elasticsearch_dsl import String, Long, Integer, Boolean
 meta_param_keys = ('pl', 'limit', 'offset')
 
 # parameters used for the search service that can not be used as query fields
-reserved_query_fields = meta_param_keys + ('q', 'bbox', 'r')
+reserved_query_fields = meta_param_keys + ('q', 'bbox')
 
 
 class QueryableMixin(object):

--- a/c2corg_api/search/mapping_types.py
+++ b/c2corg_api/search/mapping_types.py
@@ -6,7 +6,7 @@ from elasticsearch_dsl import String, Long, Integer, Boolean
 meta_param_keys = ('pl', 'limit', 'offset')
 
 # parameters used for the search service that can not be used as query fields
-reserved_query_fields = meta_param_keys + ('q', 'bbox', 'r', 'w')
+reserved_query_fields = meta_param_keys + ('q', 'bbox', 'r')
 
 
 class QueryableMixin(object):

--- a/c2corg_api/search/mappings/outing_mapping.py
+++ b/c2corg_api/search/mappings/outing_mapping.py
@@ -16,6 +16,9 @@ class SearchOuting(SearchDocument):
     # array of waypoint ids
     waypoints = QLong('w', is_id=True)
 
+    # array of user ids
+    users = QLong('u', is_id=True)
+
     activities = QEnumArray(
         'act', model_field=Outing.activities)
     frequentation = QEnum(
@@ -70,6 +73,11 @@ class SearchOuting(SearchDocument):
             # and grand-parents of these waypoints
             search_document['waypoints'] = \
                 document.associated_waypoints_ids.waypoint_ids
+
+        if document.associated_users_ids:
+            # add the document ids of associated users
+            search_document['users'] = \
+                document.associated_users_ids.user_ids
 
         return search_document
 

--- a/c2corg_api/search/mappings/outing_mapping.py
+++ b/c2corg_api/search/mappings/outing_mapping.py
@@ -2,7 +2,7 @@ from c2corg_api.models.outing import OUTING_TYPE, Outing
 from c2corg_api.search.mapping import SearchDocument, BaseMeta, \
     QEnumArray, QEnum
 from c2corg_api.search.mapping_types import QueryableMixin, QDateRange, \
-    QInteger, QBoolean
+    QInteger, QBoolean, QLong
 from elasticsearch_dsl import Date
 
 
@@ -12,6 +12,9 @@ class SearchOuting(SearchDocument):
 
     date_start = Date()
     date_end = Date()
+
+    # array of waypoint ids
+    waypoints = QLong('w', is_id=True)
 
     activities = QEnumArray(
         'act', model_field=Outing.activities)
@@ -61,6 +64,12 @@ class SearchOuting(SearchDocument):
 
         SearchDocument.copy_fields(
             search_document, document, SearchOuting.FIELDS)
+
+        if document.associated_waypoints_ids:
+            # add the document ids of associated waypoints and of the parent
+            # and grand-parents of these waypoints
+            search_document['waypoints'] = \
+                document.associated_waypoints_ids.waypoint_ids
 
         return search_document
 

--- a/c2corg_api/search/mappings/outing_mapping.py
+++ b/c2corg_api/search/mappings/outing_mapping.py
@@ -19,6 +19,9 @@ class SearchOuting(SearchDocument):
     # array of user ids
     users = QLong('u', is_id=True)
 
+    # array of route ids
+    routes = QLong('r', is_id=True)
+
     activities = QEnumArray(
         'act', model_field=Outing.activities)
     frequentation = QEnum(
@@ -78,6 +81,11 @@ class SearchOuting(SearchDocument):
             # add the document ids of associated users
             search_document['users'] = \
                 document.associated_users_ids.user_ids
+
+        if document.associated_routes_ids:
+            # add the document ids of associated routes
+            search_document['routes'] = \
+                document.associated_routes_ids.route_ids
 
         return search_document
 

--- a/c2corg_api/search/mappings/route_mapping.py
+++ b/c2corg_api/search/mappings/route_mapping.py
@@ -1,13 +1,16 @@
 from c2corg_api.models.route import ROUTE_TYPE, Route
 from c2corg_api.search.mapping import SearchDocument, BaseMeta
 from c2corg_api.search.mapping_types import QueryableMixin, QInteger,\
-    QEnumArray, QEnum
+    QEnumArray, QEnum, QLong
 from c2corg_api.search.utils import get_title
 
 
 class SearchRoute(SearchDocument):
     class Meta(BaseMeta):
         doc_type = ROUTE_TYPE
+
+    # array of waypoint ids
+    waypoints = QLong('w', is_id=True)
 
     activities = QEnumArray(
         'act', model_field=Route.activities)
@@ -116,6 +119,12 @@ class SearchRoute(SearchDocument):
         for locale in document.locales:
             search_document['title_' + locale.lang] = \
                 get_title(locale.title, locale.title_prefix)
+
+        if document.associated_waypoints_ids:
+            # add the document ids of associated waypoints and of the parent
+            # and grand-parents of these waypoints
+            search_document['waypoints'] = \
+                document.associated_waypoints_ids.waypoint_ids
 
         return search_document
 

--- a/c2corg_api/search/notify_sync.py
+++ b/c2corg_api/search/notify_sync.py
@@ -7,8 +7,9 @@ log = logging.getLogger(__name__)
 
 
 def notify_es_syncer(queue_config):
-    """Notify the syncer script that a document has changed by pushing a
-    friendly message into the Redis queue.
+    """When the current transaction is committed successfully, notify the
+    syncer script that a document has changed by pushing a friendly message
+    into the Redis queue.
     """
     def push_notification():
         with producers[queue_config.connection].acquire(

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -185,6 +185,7 @@ class BaseTestCase(unittest.TestCase):
         self.session = self.Session(bind=self.connection)
 
         self.queue_config = registry.queue_config
+        reset_queue(self.queue_config)
 
     def tearDown(self):  # noqa
         # rollback - everything that happened with the Session above
@@ -220,3 +221,9 @@ class BaseTestCase(unittest.TestCase):
                 status,
                 errors))
         return res
+
+
+def reset_queue(queue_config):
+    queue = queue_config.queue(queue_config.connection)
+    while queue.get():
+        pass

--- a/c2corg_api/tests/models/test_association.py
+++ b/c2corg_api/tests/models/test_association.py
@@ -90,6 +90,8 @@ class TestAssociation(BaseTestCase):
 
     def test_get_current_associations_waypoints(self):
         self.waypoint3 = Waypoint(waypoint_type='summit')
+        self.session.add(self.waypoint3)
+        self.session.flush()
         self.session.add_all([
             Association.create(
                 parent_document=self.waypoint1, child_document=self.waypoint2),

--- a/c2corg_api/tests/models/test_association.py
+++ b/c2corg_api/tests/models/test_association.py
@@ -1,8 +1,8 @@
 from c2corg_api.models.association import _get_current_associations, \
     Association, _diff_associations, synchronize_associations
-from c2corg_api.models.route import Route
+from c2corg_api.models.route import Route, ROUTE_TYPE
 from c2corg_api.models.user_profile import UserProfile
-from c2corg_api.models.waypoint import Waypoint
+from c2corg_api.models.waypoint import Waypoint, WAYPOINT_TYPE
 from c2corg_api.tests import BaseTestCase
 
 
@@ -24,11 +24,11 @@ class TestAssociation(BaseTestCase):
 
     def _add_test_data_routes(self):
         self.session.add_all([
-            Association(
+            Association.create(
                 parent_document=self.route1, child_document=self.route2),
-            Association(
+            Association.create(
                 parent_document=self.waypoint1, child_document=self.route1),
-            Association(
+            Association.create(
                 parent_document=self.waypoint2, child_document=self.route1),
         ])
         self.session.flush()
@@ -91,13 +91,13 @@ class TestAssociation(BaseTestCase):
     def test_get_current_associations_waypoints(self):
         self.waypoint3 = Waypoint(waypoint_type='summit')
         self.session.add_all([
-            Association(
+            Association.create(
                 parent_document=self.waypoint1, child_document=self.waypoint2),
-            Association(
+            Association.create(
                 parent_document=self.waypoint3, child_document=self.waypoint1),
-            Association(
+            Association.create(
                 parent_document=self.waypoint1, child_document=self.route1),
-            Association(
+            Association.create(
                 parent_document=self.waypoint1, child_document=self.route2),
         ])
         self.session.flush()
@@ -136,7 +136,7 @@ class TestAssociation(BaseTestCase):
         self.assertEqual(current_associations, expected_current_associations)
 
     def test_get_current_associations_waypoints_partial(self):
-        self.session.add(Association(
+        self.session.add(Association.create(
             parent_document=self.waypoint1, child_document=self.waypoint2)
         )
         self.session.flush()
@@ -170,12 +170,12 @@ class TestAssociation(BaseTestCase):
             new_associations, current_associations)
 
         expected_to_add = [
-            {'document_id': 2, 'is_parent': True},
-            {'document_id': 3, 'is_parent': False}
+            {'document_id': 2, 'is_parent': True, 'doc_type': ROUTE_TYPE},
+            {'document_id': 3, 'is_parent': False, 'doc_type': WAYPOINT_TYPE}
         ]
 
         expected_to_remove = [
-            {'document_id': 4, 'is_parent': True}
+            {'document_id': 4, 'is_parent': True, 'doc_type': ROUTE_TYPE}
         ]
 
         self.assertEqual(
@@ -189,10 +189,11 @@ class TestAssociation(BaseTestCase):
         self.route3 = Route(activities=['hiking'])
         self.route4 = Route(activities=['hiking'])
         self.session.add_all([self.route3, self.route4])
+        self.session.flush()
         self.session.add_all([
-            Association(
+            Association.create(
                 parent_document=self.route1, child_document=self.route2),
-            Association(
+            Association.create(
                 parent_document=self.route1, child_document=self.route3)
         ])
         self.session.flush()

--- a/c2corg_api/tests/scripts/es/test_sync.py
+++ b/c2corg_api/tests/scripts/es/test_sync.py
@@ -258,12 +258,17 @@ class SyncTest(BaseTestCase):
         association_wr = Association.create(self.waypoint1, self.route1)
         association_ww = Association.create(self.waypoint2, self.waypoint1)
         association_ro = Association.create(self.route1, self.outing1)
+        user = self.session.query(UserProfile).get(
+            self.global_userids['contributor'])
+        association_uo = Association.create(user, self.outing1)
         self.session.add_all([
             association_wr,
             association_ww,
             association_ro,
+            association_uo,
             association_wr.get_log(user_id),
             association_ww.get_log(user_id),
-            association_ro.get_log(user_id)
+            association_ro.get_log(user_id),
+            association_uo.get_log(user_id)
         ])
         self.session.flush()

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -70,9 +70,17 @@ class BaseTestRest(BaseTestCase):
         r = self.app_post_json(url, body, headers=headers, status=status)
         return r.json
 
-    def sync_es(self):
+    def assertNotifiedEs(self):  # noqa
         queue = self.queue_config.queue(self.queue_config.connection)
         self.assertIsNotNone(queue.get(), 'no sync. notification sent for ES')
+
+    def assertNotNotifiedEs(self):  # noqa
+        queue = self.queue_config.queue(self.queue_config.connection)
+        self.assertIsNone(
+            queue.get(), 'unexpected sync. notification sent for ES')
+
+    def sync_es(self):
+        self.assertNotifiedEs()
         sync_es(self.session)
 
     def get_latest_version(self, lang, versions):

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -63,6 +63,17 @@ class TestOutingRest(BaseDocumentTestRest):
         self.assertEqual(documents[0]['document_id'], self.outing.document_id)
         self.assertEqual(response.json['total'], 1)
 
+    def test_get_collection_for_user(self):
+        reset_search_index(self.session)
+        response = self.app.get(
+            self._prefix + '?u=' + str(self.global_userids['contributor']),
+            status=200)
+
+        documents = response.json['documents']
+
+        self.assertEqual(documents[0]['document_id'], self.outing.document_id)
+        self.assertEqual(response.json['total'], 1)
+
     def test_get_collection_paginated(self):
         self.app.get("/outings?offset=invalid", status=400)
 

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -45,6 +45,7 @@ class TestOutingRest(BaseDocumentTestRest):
         self._add_test_data()
 
     def test_get_collection_for_route(self):
+        reset_search_index(self.session)
         response = self.app.get(
             self._prefix + '?r=' + str(self.route.document_id), status=200)
 

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -6,6 +6,7 @@ from c2corg_api.models.document_history import DocumentVersion
 from c2corg_api.models.image import Image
 from c2corg_api.models.outing import Outing, ArchiveOuting, \
     ArchiveOutingLocale, OutingLocale, OUTING_TYPE
+from c2corg_api.models.user_profile import USERPROFILE_TYPE
 from c2corg_api.models.waypoint import Waypoint, WaypointLocale
 from c2corg_api.tests.search import reset_search_index
 from c2corg_common.attributes import quality_types
@@ -932,17 +933,19 @@ class TestOutingRest(BaseDocumentTestRest):
             gear='paraglider'))
         self.session.add(self.route)
         self.session.flush()
-        self.session.add(Association(
-            parent_document_id=self.waypoint.document_id,
-            child_document_id=self.route.document_id))
-        self.session.add(Association(
-            parent_document_id=self.route.document_id,
-            child_document_id=self.outing.document_id))
+        self.session.add(Association.create(
+            parent_document=self.waypoint,
+            child_document=self.route))
+        self.session.add(Association.create(
+            parent_document=self.route,
+            child_document=self.outing))
 
         self.session.add(Association(
             parent_document_id=user_id,
-            child_document_id=self.outing.document_id))
-        self.session.add(Association(
-            parent_document_id=self.outing.document_id,
-            child_document_id=self.image.document_id))
+            parent_document_type=USERPROFILE_TYPE,
+            child_document_id=self.outing.document_id,
+            child_document_type=OUTING_TYPE))
+        self.session.add(Association.create(
+            parent_document=self.outing,
+            child_document=self.image))
         self.session.flush()

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -54,6 +54,7 @@ class TestOutingRest(BaseDocumentTestRest):
         self.assertEqual(response.json['total'], 1)
 
     def test_get_collection_for_waypoint(self):
+        reset_search_index(self.session)
         response = self.app.get(
             self._prefix + '?w=' + str(self.waypoint.document_id), status=200)
 

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -813,6 +813,74 @@ class TestOutingRest(BaseDocumentTestRest):
 
         self.assertEquals(route.get_locale('es').weather, 'soleado')
 
+    def test_put_success_association_update(self):
+        """Test updating a document by updating associations.
+        """
+        request_body = {
+            'message': 'Changing associations',
+            'document': {
+                'document_id': self.outing.document_id,
+                'version': self.outing.version,
+                'quality': quality_types[1],
+                'activities': ['skitouring'],
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-01',
+                'elevation_min': 700,
+                'elevation_max': 1500,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'locales': [
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
+                     'description': '...', 'weather': 'sunny',
+                     'version': self.locale_en.version}
+                ],
+                'associations': {
+                    'users': [{'id': self.global_userids['contributor2']}],
+                    'routes': [{'document_id': self.route.document_id}]
+                }
+            }
+        }
+
+        headers = self.add_authorization_header(username='moderator')
+        self.app_put_json(
+            self._prefix + '/' + str(self.outing.document_id), request_body,
+            headers=headers, status=200)
+
+        response = self.app.get(
+            self._prefix + '/' + str(self.outing.document_id), headers=headers,
+            status=200)
+        self.assertEqual(response.content_type, 'application/json')
+
+        body = response.json
+        document_id = body.get('document_id')
+        # document version does not change!
+        self.assertEquals(body.get('version'), self.outing.version)
+        self.assertEquals(body.get('document_id'), document_id)
+
+        # check that the document was updated correctly
+        self.session.expire_all()
+        document = self.session.query(self._model).get(document_id)
+        self.assertEquals(len(document.locales), 2)
+
+        # check that no new archive_document was created
+        archive_count = self.session.query(self._model_archive). \
+            filter(
+                getattr(self._model_archive, 'document_id') == document_id). \
+            count()
+        self.assertEqual(archive_count, 1)
+
+        # check that no new archive_document_locale was created
+        archive_locale_count = \
+            self.session.query(self._model_archive_locale). \
+            filter(
+                document_id == getattr(
+                    self._model_archive_locale, 'document_id')
+            ). \
+            count()
+        self.assertEqual(archive_locale_count, 2)
+
+        self.assertNotifiedEs()
+
     def test_history(self):
         id = self.outing.document_id
         langs = ['fr', 'en']

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -868,15 +868,15 @@ class TestRouteRest(BaseDocumentTestRest):
             access='yep'))
         self.session.add(self.waypoint2)
         self.session.flush()
-        self.session.add(Association(
-            parent_document_id=self.route.document_id,
-            child_document_id=self.route4.document_id))
-        self.session.add(Association(
-            parent_document_id=self.route4.document_id,
-            child_document_id=self.route.document_id))
-        self.session.add(Association(
-            parent_document_id=self.waypoint.document_id,
-            child_document_id=self.route.document_id))
+        self.session.add(Association.create(
+            parent_document=self.route,
+            child_document=self.route4))
+        self.session.add(Association.create(
+            parent_document=self.route4,
+            child_document=self.route))
+        self.session.add(Association.create(
+            parent_document=self.waypoint,
+            child_document=self.route))
 
         self.outing1 = Outing(
             activities=['skitouring'], date_start=datetime.date(2016, 1, 1),
@@ -889,9 +889,9 @@ class TestRouteRest(BaseDocumentTestRest):
         )
         self.session.add(self.outing1)
         self.session.flush()
-        self.session.add(Association(
-            parent_document_id=self.route.document_id,
-            child_document_id=self.outing1.document_id))
+        self.session.add(Association.create(
+            parent_document=self.route,
+            child_document=self.outing1))
 
         self.outing2 = Outing(
             redirects_to=self.outing1.document_id,
@@ -905,9 +905,9 @@ class TestRouteRest(BaseDocumentTestRest):
         )
         self.session.add(self.outing2)
         self.session.flush()
-        self.session.add(Association(
-            parent_document_id=self.route.document_id,
-            child_document_id=self.outing2.document_id))
+        self.session.add(Association.create(
+            parent_document=self.route,
+            child_document=self.outing2))
         self.session.flush()
 
         # add areas

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -55,6 +55,17 @@ class TestRouteRest(BaseDocumentTestRest):
     def test_get_collection_lang(self):
         self.get_collection_lang()
 
+    def test_get_collection_for_waypoint(self):
+        reset_search_index(self.session)
+
+        response = self.app.get(
+            self._prefix + '?w=' + str(self.waypoint.document_id), status=200)
+
+        documents = response.json['documents']
+
+        self.assertEqual(response.json['total'], 1)
+        self.assertEqual(documents[0]['document_id'], self.route.document_id)
+
     def test_get_collection_search(self):
         reset_search_index(self.session)
 

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -138,8 +138,14 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.assertEqual(2, recent_outings['total'])
         self.assertEqual(2, len(recent_outings['outings']))
         self.assertEqual(
-            self.outing1.document_id,
-            recent_outings['outings'][0].get('document_id'))
+            {
+                self.outing1.document_id,
+                self.outing3.document_id
+            },
+            {
+                recent_outings['outings'][0].get('document_id'),
+                recent_outings['outings'][1].get('document_id')
+            })
         self.assertIn('type', recent_outings['outings'][0])
 
     def test_get_with_empty_arrays(self):

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -985,21 +985,21 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.session.add(self.route2)
         self.session.add(self.route3)
         self.session.flush()
-        self.session.add(Association(
-            parent_document_id=self.waypoint.document_id,
-            child_document_id=self.waypoint4.document_id))
-        self.session.add(Association(
-            parent_document_id=self.waypoint.document_id,
-            child_document_id=self.waypoint5.document_id))
-        self.session.add(Association(
-            parent_document_id=self.waypoint.document_id,
-            child_document_id=self.route1.document_id))
-        self.session.add(Association(
-            parent_document_id=self.waypoint.document_id,
-            child_document_id=self.route2.document_id))
-        self.session.add(Association(
-            parent_document_id=self.waypoint4.document_id,
-            child_document_id=self.route3.document_id))
+        self.session.add(Association.create(
+            parent_document=self.waypoint,
+            child_document=self.waypoint4))
+        self.session.add(Association.create(
+            parent_document=self.waypoint,
+            child_document=self.waypoint5))
+        self.session.add(Association.create(
+            parent_document=self.waypoint,
+            child_document=self.route1))
+        self.session.add(Association.create(
+            parent_document=self.waypoint,
+            child_document=self.route2))
+        self.session.add(Association.create(
+            parent_document=self.waypoint4,
+            child_document=self.route3))
 
         self.outing1 = Outing(
             activities=['skitouring'], date_start=datetime.date(2016, 1, 1),
@@ -1012,9 +1012,9 @@ class TestWaypointRest(BaseDocumentTestRest):
         )
         self.session.add(self.outing1)
         self.session.flush()
-        self.session.add(Association(
-            parent_document_id=self.route1.document_id,
-            child_document_id=self.outing1.document_id))
+        self.session.add(Association.create(
+            parent_document=self.route1,
+            child_document=self.outing1))
 
         self.outing2 = Outing(
             redirects_to=self.outing1.document_id,
@@ -1039,12 +1039,12 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.session.add(self.outing2)
         self.session.add(self.outing3)
         self.session.flush()
-        self.session.add(Association(
-            parent_document_id=self.route1.document_id,
-            child_document_id=self.outing2.document_id))
-        self.session.add(Association(
-            parent_document_id=self.route3.document_id,
-            child_document_id=self.outing3.document_id))
+        self.session.add(Association.create(
+            parent_document=self.route1,
+            child_document=self.outing2))
+        self.session.add(Association.create(
+            parent_document=self.route3,
+            child_document=self.outing3))
 
         # add a map
         topo_map = TopoMap(

--- a/c2corg_api/views/association.py
+++ b/c2corg_api/views/association.py
@@ -35,6 +35,9 @@ def validate_association(request):
                 'body', 'child_document_id', 'child document does not exist')
 
     if parent_document_type and child_document_type:
+        request.validated['parent_document_type'] = parent_document_type
+        request.validated['child_document_type'] = child_document_type
+
         association_type = (parent_document_type, child_document_type)
         if association_type not in valid_associations:
             request.errors.add(
@@ -52,6 +55,10 @@ class AssociationRest(object):
         schema=schema_association, validators=[validate_association])
     def collection_post(self):
         association = schema_association.objectify(self.request.validated)
+        association.parent_document_type = \
+            self.request.validated['parent_document_type']
+        association.child_document_type = \
+            self.request.validated['child_document_type']
 
         if exists_already(association):
             raise HTTPBadRequest(

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -300,12 +300,13 @@ class DocumentRest(object):
             if after_update:
                 after_update(document, update_types, user_id=user_id)
 
-            # And the search updated
-            notify_es_syncer(self.request.registry.queue_config)
-
         associations = self.request.validated.get('associations', None)
         if associations:
             synchronize_associations(document, associations, user_id)
+
+        if update_types or associations:
+            # update search index
+            notify_es_syncer(self.request.registry.queue_config)
 
         return {}
 

--- a/c2corg_api/views/outing.py
+++ b/c2corg_api/views/outing.py
@@ -14,8 +14,7 @@ from c2corg_api.views.document import DocumentRest, make_validator_create, \
     make_validator_update, make_schema_adaptor, get_all_fields
 from c2corg_api.views.validation import validate_id, validate_pagination, \
     validate_lang, validate_version_id, validate_lang_param, \
-    validate_preferred_lang_param, check_get_for_integer_property, \
-    validate_associations
+    validate_preferred_lang_param, validate_associations
 from c2corg_common.attributes import activities
 from c2corg_common.fields_outing import fields_outing
 from cornice.resource import resource, view
@@ -59,13 +58,6 @@ def validate_required_associations(request):
             'body', 'associations.routes', 'at least one route required')
 
 
-def validate_filter_params(request):
-    """
-    Checks if a given optional route id is an integer.
-    """
-    check_get_for_integer_property(request, 'r', False)
-
-
 def adapt_schema_for_activities(activities, field_list_type):
     """Get the schema for a set of activities.
     `field_list_type` should be either "fields" or "listing".
@@ -85,18 +77,11 @@ listing_schema_adaptor = make_schema_adaptor(
 class OutingRest(DocumentRest):
 
     @view(validators=[
-        validate_pagination, validate_preferred_lang_param,
-        validate_filter_params])
+        validate_pagination, validate_preferred_lang_param])
     def collection_get(self):
-        custom_filter = None
-        if self.request.validated.get('r'):
-            # only show outings for the given route
-            custom_filter = self.filter_on_route(self.request.validated['r'])
-
         return self._collection_get(
             Outing, schema_outing, OUTING_TYPE,
-            adapt_schema=listing_schema_adaptor,
-            custom_filter=custom_filter, set_custom_fields=set_author)
+            adapt_schema=listing_schema_adaptor, set_custom_fields=set_author)
 
     @view(validators=[validate_id, validate_lang_param])
     def get(self):
@@ -142,15 +127,6 @@ class OutingRest(DocumentRest):
                 Association.parent_document_id == user_id,
                 Association.child_document_id == outing_id
             ))).scalar()
-
-    def filter_on_route(self, route_id):
-        def filter_query(query):
-            return query. \
-                join(
-                    Association,
-                    Outing.document_id == Association.child_document_id). \
-                filter(Association.parent_document_id == route_id)
-        return filter_query
 
 
 def set_author(outings, lang):

--- a/c2corg_api/views/outing.py
+++ b/c2corg_api/views/outing.py
@@ -1,8 +1,7 @@
 import functools
 from c2corg_api.models import DBSession
 from c2corg_api.models.association import Association
-from c2corg_api.models.document import ArchiveDocument, Document, \
-    DocumentGeometry
+from c2corg_api.models.document import ArchiveDocument, DocumentGeometry
 from c2corg_api.models.document_history import HistoryMetaData, DocumentVersion
 from c2corg_api.models.outing import schema_outing, Outing, \
     schema_create_outing, schema_update_outing, ArchiveOuting, \
@@ -165,23 +164,19 @@ class OutingRest(DocumentRest):
         def filter_query(query):
             t_outing_route = aliased(Association, name='a1')
             t_route_wp = aliased(Association, name='a2')
-            t_route = aliased(Document, name='r')
 
             return query. \
                 join(
                     t_outing_route,
                     Outing.document_id == t_outing_route.child_document_id). \
                 join(
-                    t_route,
-                    and_(
-                        t_outing_route.parent_document_id ==
-                        t_route.document_id,
-                        t_route.type == ROUTE_TYPE)). \
-                join(
                     t_route_wp,
                     and_(
-                        t_route_wp.parent_document_id == waypoint_id,
-                        t_route_wp.child_document_id == t_route.document_id))
+                        t_route_wp.child_document_id ==
+                        t_outing_route.parent_document_id,
+                        t_route_wp.child_document_type == ROUTE_TYPE,
+                        t_route_wp.parent_document_id == waypoint_id
+                    ))
         return filter_query
 
 


### PR DESCRIPTION
Todo

* [x] Search a route given a waypoint id (including parent waypoints)
* [x] Search an outing
  * [x] given a waypoint id (including parent waypoints)
  * [x] an user id
  * [x] a route id
* [x] Make sure the search index is updated when associations are created/updated (only if needed) 

Closes https://github.com/c2corg/v6_api/issues/297