### PR TITLE
Support enum range filters

### DIFF
--- a/c2corg_api/search/mapping.py
+++ b/c2corg_api/search/mapping.py
@@ -1,9 +1,11 @@
 import json
 
 from c2corg_api.models.document import Document
-from c2corg_api.search.mapping_types import Enum, QEnum, QEnumArray, QLong
+from c2corg_api.search.mapping_types import Enum, QEnumArray, QLong, \
+    QEnumRange
 from c2corg_api.search.utils import strip_bbcodes
 from c2corg_common.attributes import default_langs
+from c2corg_common.sortable_search_attributes import sortable_quality_types
 from elasticsearch_dsl import DocType, String, MetaField, Long, GeoPoint
 
 
@@ -33,7 +35,8 @@ class SearchDocument(DocType):
 
     id = Long()
     doc_type = Enum()
-    quality = QEnum('qa', model_field=Document.quality)
+    quality = QEnumRange(
+        'qa', model_field=Document.quality, enum_mapper=sortable_quality_types)
     available_locales = QEnumArray('l', enum=default_langs)
     geom = GeoPoint()
 
@@ -121,6 +124,10 @@ class SearchDocument(DocType):
                 search_document['description_' + locale.lang] = \
                     strip_bbcodes(locale.description)
             search_document['available_locales'] = available_locales
+
+            if document.quality:
+                search_document['quality'] = \
+                    sortable_quality_types[document.quality]
 
             if document.geometry:
                 search_document['geom'] = SearchDocument.get_geometry(

--- a/c2corg_api/search/mapping.py
+++ b/c2corg_api/search/mapping.py
@@ -164,7 +164,10 @@ class SearchDocument(DocType):
             val = getattr(document, field)
 
             if val:
-                search_document[field] = enum_mapper[val]
+                if not isinstance(val, str):
+                    search_document[field] = [enum_mapper[v] for v in val]
+                else:
+                    search_document[field] = enum_mapper[val]
 
 
 """To support partial-matching required for the autocomplete search, we

--- a/c2corg_api/search/mapping.py
+++ b/c2corg_api/search/mapping.py
@@ -154,6 +154,18 @@ class SearchDocument(DocType):
         for field in fields:
             search_document[field] = getattr(document, field)
 
+    @staticmethod
+    def copy_enum_range_fields(
+            search_document, document, fields, search_model):
+        search_fields = search_model._doc_type.mapping
+        for field in fields:
+            search_field = search_fields[field]
+            enum_mapper = search_field._enum_mapper
+            val = getattr(document, field)
+
+            if val:
+                search_document[field] = enum_mapper[val]
+
 
 """To support partial-matching required for the autocomplete search, we
 have to set up a n-gram filter for each language analyzer. See also:

--- a/c2corg_api/search/mapping_types.py
+++ b/c2corg_api/search/mapping_types.py
@@ -32,6 +32,9 @@ class QueryableMixin(object):
         if 'date_range' in kwargs:
             self._date_range = kwargs['date_range']
             del kwargs['date_range']
+        if 'enum_range' in kwargs:
+            self._enum_range = kwargs['enum_range']
+            del kwargs['enum_range']
         if 'is_bool' in kwargs:
             self._is_bool = kwargs['is_bool']
             del kwargs['is_bool']
@@ -96,3 +99,20 @@ class QDateRange(QueryableMixin):
         self.field_date_end = field_date_end
         kwargs['date_range'] = True
         super(QDateRange, self).__init__(query_name, *args, **kwargs)
+
+
+class QEnumRange(QueryableMixin, Integer):
+    """Search field for enum ranges. To make it more convenient to search
+    for ranges with enum fields (e.g. to search a route with a rating between
+    'AD' and 'ED') the enum values are converted to integer values and
+    stored as such in ElasticSearch. When doing a search, a filter using these
+    numbers is used.
+    The enums are converted to integers using the mappers defined in
+    `c2corg_common.sortable_search_attributes`.
+    """
+    def __init__(self, query_name, model_field, enum_mapper,
+                 *args, **kwargs):
+        self._enum_mapper = enum_mapper
+        kwargs['model_field'] = model_field
+        kwargs['enum_range'] = True
+        super(QEnumRange, self).__init__(query_name, *args, **kwargs)

--- a/c2corg_api/search/mapping_types.py
+++ b/c2corg_api/search/mapping_types.py
@@ -35,6 +35,9 @@ class QueryableMixin(object):
         if 'enum_range' in kwargs:
             self._enum_range = kwargs['enum_range']
             del kwargs['enum_range']
+        if 'enum_range_min_max' in kwargs:
+            self._enum_range_min_max = kwargs['enum_range_min_max']
+            del kwargs['enum_range_min_max']
         if 'is_bool' in kwargs:
             self._is_bool = kwargs['is_bool']
             del kwargs['is_bool']
@@ -116,3 +119,17 @@ class QEnumRange(QueryableMixin, Integer):
         kwargs['model_field'] = model_field
         kwargs['enum_range'] = True
         super(QEnumRange, self).__init__(query_name, *args, **kwargs)
+
+
+class QEnumRangeMinMax(QueryableMixin):
+    """Search field for combined enums. For example the fields
+    `climbing_rating_min` and `climbing_rating_max` are combined into a single
+    search field.
+    """
+    def __init__(self, query_name, field_min, field_max, enum_mapper,
+                 *args, **kwargs):
+        self.field_min = field_min
+        self.field_max = field_max
+        self._enum_mapper = enum_mapper
+        kwargs['enum_range_min_max'] = True
+        super(QEnumRangeMinMax, self).__init__(query_name, *args, **kwargs)

--- a/c2corg_api/search/mapping_types.py
+++ b/c2corg_api/search/mapping_types.py
@@ -32,6 +32,9 @@ class QueryableMixin(object):
         if 'date_range' in kwargs:
             self._date_range = kwargs['date_range']
             del kwargs['date_range']
+        if 'integer_range' in kwargs:
+            self._integer_range = kwargs['integer_range']
+            del kwargs['integer_range']
         if 'enum_range' in kwargs:
             self._enum_range = kwargs['enum_range']
             del kwargs['enum_range']
@@ -102,6 +105,17 @@ class QDateRange(QueryableMixin):
         self.field_date_end = field_date_end
         kwargs['date_range'] = True
         super(QDateRange, self).__init__(query_name, *args, **kwargs)
+
+
+class QNumberRange(QueryableMixin):
+    """Search field for number ranges. Used for elevation_min/elevation_max
+    for routes.
+    """
+    def __init__(self, query_name, field_min, field_max, *args, **kwargs):
+        self.field_min = field_min
+        self.field_max = field_max
+        kwargs['integer_range'] = True
+        super(QNumberRange, self).__init__(query_name, *args, **kwargs)
 
 
 class QEnumRange(QueryableMixin, Integer):

--- a/c2corg_api/search/mappings/outing_mapping.py
+++ b/c2corg_api/search/mappings/outing_mapping.py
@@ -1,7 +1,10 @@
 from c2corg_api.models.outing import OUTING_TYPE, Outing
 from c2corg_api.search.mapping import SearchDocument, BaseMeta
 from c2corg_api.search.mapping_types import QueryableMixin, QDateRange, \
-    QInteger, QBoolean, QLong, QEnum, QEnumArray
+    QInteger, QBoolean, QLong, QEnumArray, QEnumRange
+from c2corg_common.sortable_search_attributes import \
+    sortable_frequentation_types, sortable_condition_ratings, \
+    sortable_glacier_ratings
 from elasticsearch_dsl import Date
 
 
@@ -23,8 +26,9 @@ class SearchOuting(SearchDocument):
 
     activities = QEnumArray(
         'act', model_field=Outing.activities)
-    frequentation = QEnum(
-        'ofreq', model_field=Outing.frequentation)
+    frequentation = QEnumRange(
+        'ofreq', model_field=Outing.frequentation,
+        enum_mapper=sortable_frequentation_types)
     elevation_max = QInteger(
         'oalt', range=True)
     height_diff_up = QInteger(
@@ -39,23 +43,31 @@ class SearchOuting(SearchDocument):
         'swlu', range=True)
     elevation_down_snow = QInteger(
         'swld', range=True)
-    condition_rating = QEnum(
-        'ocond', model_field=Outing.condition_rating)
-    snow_quantity = QEnum(
-        'swquan', model_field=Outing.snow_quantity)
-    snow_quality = QEnum(
-        'swqual', model_field=Outing.snow_quality)
-    glacier_rating = QEnum(
-        'oglac', model_field=Outing.glacier_rating)
+    condition_rating = QEnumRange(
+        'ocond', model_field=Outing.condition_rating,
+        enum_mapper=sortable_condition_ratings)
+    snow_quantity = QEnumRange(
+        'swquan', model_field=Outing.snow_quantity,
+        enum_mapper=sortable_condition_ratings)
+    snow_quality = QEnumRange(
+        'swqual', model_field=Outing.snow_quality,
+        enum_mapper=sortable_condition_ratings)
+    glacier_rating = QEnumRange(
+        'oglac', model_field=Outing.glacier_rating,
+        enum_mapper=sortable_glacier_ratings)
     avalanche_signs = QEnumArray(
         'avdate', model_field=Outing.avalanche_signs)
 
     FIELDS = [
-        'activities', 'date_start', 'date_end', 'frequentation',
+        'activities', 'date_start', 'date_end',
         'elevation_max', 'height_diff_up', 'length_total', 'public_transport',
         'elevation_access', 'elevation_up_snow', 'elevation_down_snow',
-        'condition_rating', 'snow_quantity', 'snow_quality',
-        'glacier_rating', 'avalanche_signs'
+        'avalanche_signs'
+    ]
+
+    ENUM_RANGE_FIELDS = [
+        'frequentation', 'condition_rating', 'snow_quantity', 'snow_quality',
+        'glacier_rating'
     ]
 
     @staticmethod
@@ -67,6 +79,10 @@ class SearchOuting(SearchDocument):
 
         SearchDocument.copy_fields(
             search_document, document, SearchOuting.FIELDS)
+
+        SearchDocument.copy_enum_range_fields(
+            search_document, document, SearchOuting.ENUM_RANGE_FIELDS,
+            SearchOuting)
 
         if document.associated_waypoints_ids:
             # add the document ids of associated waypoints and of the parent

--- a/c2corg_api/search/mappings/outing_mapping.py
+++ b/c2corg_api/search/mappings/outing_mapping.py
@@ -1,8 +1,7 @@
 from c2corg_api.models.outing import OUTING_TYPE, Outing
-from c2corg_api.search.mapping import SearchDocument, BaseMeta, \
-    QEnumArray, QEnum
+from c2corg_api.search.mapping import SearchDocument, BaseMeta
 from c2corg_api.search.mapping_types import QueryableMixin, QDateRange, \
-    QInteger, QBoolean, QLong
+    QInteger, QBoolean, QLong, QEnum, QEnumArray
 from elasticsearch_dsl import Date
 
 

--- a/c2corg_api/search/mappings/route_mapping.py
+++ b/c2corg_api/search/mappings/route_mapping.py
@@ -1,8 +1,18 @@
 from c2corg_api.models.route import ROUTE_TYPE, Route
 from c2corg_api.search.mapping import SearchDocument, BaseMeta
 from c2corg_api.search.mapping_types import QueryableMixin, QInteger,\
-    QEnumArray, QEnum, QLong
+    QEnumArray, QEnum, QLong, QEnumRange
 from c2corg_api.search.utils import get_title
+from c2corg_common.sortable_search_attributes import \
+    sortable_route_duration_types, sortable_ski_ratings, \
+    sortable_exposition_ratings, sortable_labande_ski_ratings, \
+    sortable_global_ratings, sortable_engagement_ratings, \
+    sortable_risk_ratings, sortable_equipment_ratings, sortable_ice_ratings, \
+    sortable_mixed_ratings, sortable_exposition_rock_ratings, \
+    sortable_aid_ratings, sortable_via_ferrata_ratings, \
+    sortable_hiking_ratings, sortable_snowshoe_ratings, \
+    sortable_mtb_up_ratings, sortable_mtb_down_ratings, \
+    sortable_climbing_ratings
 
 
 class SearchRoute(SearchDocument):
@@ -34,52 +44,73 @@ class SearchRoute(SearchDocument):
          'rtyp', model_field=Route.route_types)
     orientations = QEnumArray(
          'fac', model_field=Route.orientations)
-    durations = QEnumArray(
-         'time', model_field=Route.durations)
+    durations = QEnumRange(
+        'time', model_field=Route.durations,
+        enum_mapper=sortable_route_duration_types)
     glacier_gear = QEnum(
          'glac', model_field=Route.glacier_gear)
     configuration = QEnumArray(
          'conf', model_field=Route.configuration)
-    ski_rating = QEnum(
-         'trat', model_field=Route.ski_rating)
-    ski_exposition = QEnum(
-         'sexpo', model_field=Route.ski_exposition)
-    labande_ski_rating = QEnum(
-         'srat', model_field=Route.labande_ski_rating)
-    labande_global_rating = QEnum(
-         'lrat', model_field=Route.labande_global_rating)
-    global_rating = QEnum(
-         'grat', model_field=Route.global_rating)
-    engagement_rating = QEnum(
-         'erat', model_field=Route.engagement_rating)
-    risk_rating = QEnum(
-         'orrat', model_field=Route.risk_rating)
-    equipment_rating = QEnum(
-         'prat', model_field=Route.equipment_rating)
-    ice_rating = QEnum(
-         'irat', model_field=Route.ice_rating)
-    mixed_rating = QEnum(
-         'mrat', model_field=Route.mixed_rating)
-    exposition_rock_rating = QEnum(
-         'rexpo', model_field=Route.exposition_rock_rating)
-    rock_free_rating = QEnum(
-         'frat', model_field=Route.rock_free_rating)
-    rock_required_rating = QEnum(
-         'rrat', model_field=Route.rock_required_rating)
-    aid_rating = QEnum(
-         'arat', model_field=Route.aid_rating)
-    via_ferrata_rating = QEnum(
-         'krat', model_field=Route.via_ferrata_rating)
-    hiking_rating = QEnum(
-         'hrat', model_field=Route.hiking_rating)
-    hiking_mtb_exposition = QEnum(
-         'hexpo', model_field=Route.hiking_mtb_exposition)
-    snowshoe_rating = QEnum(
-         'wrat', model_field=Route.snowshoe_rating)
-    mtb_up_rating = QEnum(
-         'mbur', model_field=Route.mtb_up_rating)
-    mtb_down_rating = QEnum(
-         'mbdr', model_field=Route.mtb_down_rating)
+    ski_rating = QEnumRange(
+        'trat', model_field=Route.ski_rating,
+        enum_mapper=sortable_ski_ratings)
+    ski_exposition = QEnumRange(
+        'sexpo', model_field=Route.ski_exposition,
+        enum_mapper=sortable_exposition_ratings)
+    labande_ski_rating = QEnumRange(
+        'srat', model_field=Route.labande_ski_rating,
+        enum_mapper=sortable_labande_ski_ratings)
+    labande_global_rating = QEnumRange(
+        'lrat', model_field=Route.labande_global_rating,
+        enum_mapper=sortable_global_ratings)
+    global_rating = QEnumRange(
+        'grat', model_field=Route.global_rating,
+        enum_mapper=sortable_global_ratings)
+    engagement_rating = QEnumRange(
+        'erat', model_field=Route.engagement_rating,
+        enum_mapper=sortable_engagement_ratings)
+    risk_rating = QEnumRange(
+        'orrat', model_field=Route.risk_rating,
+        enum_mapper=sortable_risk_ratings)
+    equipment_rating = QEnumRange(
+        'prat', model_field=Route.equipment_rating,
+        enum_mapper=sortable_equipment_ratings)
+    ice_rating = QEnumRange(
+        'irat', model_field=Route.ice_rating,
+        enum_mapper=sortable_ice_ratings)
+    mixed_rating = QEnumRange(
+        'mrat', model_field=Route.mixed_rating,
+        enum_mapper=sortable_mixed_ratings)
+    exposition_rock_rating = QEnumRange(
+        'rexpo', model_field=Route.exposition_rock_rating,
+        enum_mapper=sortable_exposition_rock_ratings)
+    rock_free_rating = QEnumRange(
+        'frat', model_field=Route.rock_free_rating,
+        enum_mapper=sortable_climbing_ratings)
+    rock_required_rating = QEnumRange(
+        'rrat', model_field=Route.rock_required_rating,
+        enum_mapper=sortable_climbing_ratings)
+    aid_rating = QEnumRange(
+        'arat', model_field=Route.aid_rating,
+        enum_mapper=sortable_aid_ratings)
+    via_ferrata_rating = QEnumRange(
+        'krat', model_field=Route.via_ferrata_rating,
+        enum_mapper=sortable_via_ferrata_ratings)
+    hiking_rating = QEnumRange(
+        'hrat', model_field=Route.hiking_rating,
+        enum_mapper=sortable_hiking_ratings)
+    hiking_mtb_exposition = QEnumRange(
+        'hexpo', model_field=Route.hiking_mtb_exposition,
+        enum_mapper=sortable_exposition_ratings)
+    snowshoe_rating = QEnumRange(
+        'wrat', model_field=Route.snowshoe_rating,
+        enum_mapper=sortable_snowshoe_ratings)
+    mtb_up_rating = QEnumRange(
+        'mbur', model_field=Route.mtb_up_rating,
+        enum_mapper=sortable_mtb_up_ratings)
+    mtb_down_rating = QEnumRange(
+        'mbdr', model_field=Route.mtb_down_rating,
+        enum_mapper=sortable_mtb_down_ratings)
     mtb_length_asphalt = QInteger(
         'mbroad', range=True)
     mtb_length_trail = QInteger(
@@ -95,15 +126,19 @@ class SearchRoute(SearchDocument):
         'activities', 'elevation_min', 'elevation_max', 'height_diff_up',
         'height_diff_down', 'route_length', 'difficulties_height',
         'height_diff_access', 'height_diff_difficulties', 'route_types',
-        'orientations', 'durations', 'glacier_gear', 'configuration',
-        'ski_rating', 'ski_exposition', 'labande_ski_rating',
+        'orientations', 'glacier_gear', 'configuration',
+        'mtb_length_asphalt', 'mtb_length_trail',
+        'mtb_height_diff_portages', 'rock_types', 'climbing_outdoor_type'
+    ]
+
+    ENUM_RANGE_FIELDS = [
+        'durations', 'ski_rating', 'ski_exposition', 'labande_ski_rating',
         'labande_global_rating', 'global_rating', 'engagement_rating',
         'risk_rating', 'equipment_rating', 'ice_rating', 'mixed_rating',
         'exposition_rock_rating', 'rock_free_rating', 'rock_required_rating',
         'aid_rating', 'via_ferrata_rating', 'hiking_rating',
         'hiking_mtb_exposition', 'snowshoe_rating', 'mtb_up_rating',
-        'mtb_down_rating', 'mtb_length_asphalt', 'mtb_length_trail',
-        'mtb_height_diff_portages', 'rock_types', 'climbing_outdoor_type'
+        'mtb_down_rating',
     ]
 
     @staticmethod
@@ -115,6 +150,10 @@ class SearchRoute(SearchDocument):
 
         SearchDocument.copy_fields(
             search_document, document, SearchRoute.FIELDS)
+
+        SearchDocument.copy_enum_range_fields(
+            search_document, document, SearchRoute.ENUM_RANGE_FIELDS,
+            SearchRoute)
 
         for locale in document.locales:
             search_document['title_' + locale.lang] = \

--- a/c2corg_api/search/mappings/route_mapping.py
+++ b/c2corg_api/search/mappings/route_mapping.py
@@ -1,7 +1,7 @@
 from c2corg_api.models.route import ROUTE_TYPE, Route
 from c2corg_api.search.mapping import SearchDocument, BaseMeta
 from c2corg_api.search.mapping_types import QueryableMixin, QInteger,\
-    QEnumArray, QEnum, QLong, QEnumRange
+    QEnumArray, QEnum, QLong, QEnumRange, QNumberRange
 from c2corg_api.search.utils import get_title
 from c2corg_common.sortable_search_attributes import \
     sortable_route_duration_types, sortable_ski_ratings, \
@@ -169,3 +169,5 @@ class SearchRoute(SearchDocument):
 
 SearchRoute.queryable_fields = QueryableMixin.get_queryable_fields(
     SearchRoute)
+SearchRoute.queryable_fields['ele'] = QNumberRange(
+    'elevation', 'elevation_min', 'elevation_max')

--- a/c2corg_api/search/mappings/waypoint_mapping.py
+++ b/c2corg_api/search/mappings/waypoint_mapping.py
@@ -1,7 +1,7 @@
 from c2corg_api.models.waypoint import WAYPOINT_TYPE, Waypoint
 from c2corg_api.search.mapping import SearchDocument, BaseMeta
 from c2corg_api.search.mapping_types import QueryableMixin, QInteger,\
-    QEnumArray, QEnum, QBoolean, QEnumRange
+    QEnumArray, QEnum, QBoolean, QEnumRange, QEnumRangeMinMax
 from c2corg_common.sortable_search_attributes import sortable_access_times, \
     sortable_climbing_ratings, sortable_paragliding_ratings, \
     sortable_exposition_ratings, sortable_equipment_ratings
@@ -118,3 +118,6 @@ class SearchWaypoint(SearchDocument):
 
 SearchWaypoint.queryable_fields = QueryableMixin.get_queryable_fields(
     SearchWaypoint)
+SearchWaypoint.queryable_fields['crat'] = QEnumRangeMinMax(
+    'climbing_rating', 'climbing_rating_min', 'climbing_rating_max',
+    sortable_climbing_ratings)

--- a/c2corg_api/search/mappings/waypoint_mapping.py
+++ b/c2corg_api/search/mappings/waypoint_mapping.py
@@ -1,7 +1,10 @@
 from c2corg_api.models.waypoint import WAYPOINT_TYPE, Waypoint
 from c2corg_api.search.mapping import SearchDocument, BaseMeta
 from c2corg_api.search.mapping_types import QueryableMixin, QInteger,\
-    QEnumArray, QEnum, QBoolean
+    QEnumArray, QEnum, QBoolean, QEnumRange
+from c2corg_common.sortable_search_attributes import sortable_access_times, \
+    sortable_climbing_ratings, sortable_paragliding_ratings, \
+    sortable_exposition_ratings, sortable_equipment_ratings
 
 
 class SearchWaypoint(SearchDocument):
@@ -26,14 +29,18 @@ class SearchWaypoint(SearchDocument):
         'hsta', model_field=Waypoint.custodianship)
     climbing_styles = QEnumArray(
         'tcsty', model_field=Waypoint.climbing_styles)
-    access_time = QEnum(
-        'tappt', model_field=Waypoint.access_time)
-    climbing_rating_max = QEnum(
-        'tmaxr', model_field=Waypoint.climbing_rating_max)
-    climbing_rating_min = QEnum(
-        'tminr', model_field=Waypoint.climbing_rating_min)
-    climbing_rating_median = QEnum(
-        'tmedr', model_field=Waypoint.climbing_rating_median)
+    access_time = QEnumRange(
+        'tappt', model_field=Waypoint.access_time,
+        enum_mapper=sortable_access_times)
+    climbing_rating_max = QEnumRange(
+        'tmaxr', model_field=Waypoint.climbing_rating_max,
+        enum_mapper=sortable_climbing_ratings)
+    climbing_rating_min = QEnumRange(
+        'tminr', model_field=Waypoint.climbing_rating_min,
+        enum_mapper=sortable_climbing_ratings)
+    climbing_rating_median = QEnumRange(
+        'tmedr', model_field=Waypoint.climbing_rating_median,
+        enum_mapper=sortable_climbing_ratings)
     height_max = QInteger(
         'tmaxh', range=True)
     height_min = QInteger(
@@ -50,10 +57,12 @@ class SearchWaypoint(SearchDocument):
         'ctout', model_field=Waypoint.climbing_outdoor_types)
     climbing_indoor_types = QEnumArray(
         'ctin', model_field=Waypoint.climbing_indoor_types)
-    paragliding_rating = QEnum(
-        'pgrat', model_field=Waypoint.paragliding_rating)
-    exposition_rating = QEnum(
-        'pglexp', model_field=Waypoint.exposition_rating)
+    paragliding_rating = QEnumRange(
+        'pgrat', model_field=Waypoint.paragliding_rating,
+        enum_mapper=sortable_paragliding_ratings)
+    exposition_rating = QEnumRange(
+        'pglexp', model_field=Waypoint.exposition_rating,
+        enum_mapper=sortable_exposition_ratings)
     length = QInteger(
         'len', range=True)
     weather_station_types = QEnumArray(
@@ -62,8 +71,9 @@ class SearchWaypoint(SearchDocument):
         'hucap', range=True)
     capacity_staffed = QInteger(
         'hscap', range=True)
-    equipment_ratings = QEnumArray(
-        'anchq', model_field=Waypoint.equipment_ratings)
+    equipment_ratings = QEnumRange(
+        'anchq', model_field=Waypoint.equipment_ratings,
+        enum_mapper=sortable_equipment_ratings)
     public_transportation_types = QEnumArray(
         'tpty', model_field=Waypoint.public_transportation_types)
     public_transportation_rating = QEnum(
@@ -77,14 +87,17 @@ class SearchWaypoint(SearchDocument):
         'elevation', 'prominence', 'waypoint_type', 'rock_types',
         'orientations', 'climbing_outdoor_types', 'climbing_indoor_types',
         'best_periods', 'lift_access', 'custodianship', 'climbing_styles',
-        'access_time', 'climbing_rating_max', 'climbing_rating_min',
-        'climbing_rating_median', 'height_max', 'height_min', 'height_median',
+        'height_max', 'height_min', 'height_median',
         'routes_quantity', 'children_proof', 'rain_proof',
-        'paragliding_rating', 'exposition_rating', 'length',
-        'weather_station_types', 'capacity', 'capacity_staffed',
-        'equipment_ratings', 'public_transportation_types',
-        'public_transportation_rating', 'snow_clearance_rating',
-        'product_types'
+        'length', 'weather_station_types', 'capacity', 'capacity_staffed',
+        'public_transportation_types', 'public_transportation_rating',
+        'snow_clearance_rating', 'product_types'
+    ]
+
+    ENUM_RANGE_FIELDS = [
+        'access_time', 'climbing_rating_max', 'climbing_rating_min',
+        'climbing_rating_median', 'paragliding_rating', 'exposition_rating',
+        'equipment_ratings'
     ]
 
     @staticmethod
@@ -96,6 +109,10 @@ class SearchWaypoint(SearchDocument):
 
         SearchDocument.copy_fields(
             search_document, document, SearchWaypoint.FIELDS)
+
+        SearchDocument.copy_enum_range_fields(
+            search_document, document, SearchWaypoint.ENUM_RANGE_FIELDS,
+            SearchWaypoint)
 
         return search_document
 

--- a/c2corg_api/search/search_filters.py
+++ b/c2corg_api/search/search_filters.py
@@ -8,7 +8,8 @@ from functools import partial
 
 from c2corg_api.search import create_search, search_documents, \
     get_text_query
-from elasticsearch_dsl.query import Range, Term, Terms, Bool, GeoBoundingBox
+from elasticsearch_dsl.query import Range, Term, Terms, Bool, GeoBoundingBox, \
+    Missing
 
 
 def build_query(url_params, meta_params, doc_type):
@@ -156,7 +157,11 @@ def create_enum_range_min_max_filter(field, query_term):
     kwargs_end = {field.field_max: {'lt': range_values[0]}}
     return Bool(must_not=Bool(should=[
         Range(**kwargs_start),
-        Range(**kwargs_end)
+        Range(**kwargs_end),
+        Bool(must=[
+            Missing(field=field.field_min),
+            Missing(field=field.field_max)
+        ])
     ]))
 
 
@@ -264,7 +269,11 @@ def create_number_range_filter(field, query_term):
     kwargs_end = {field.field_max: {'lt': range_values[0]}}
     return Bool(must_not=Bool(should=[
         Range(**kwargs_start),
-        Range(**kwargs_end)
+        Range(**kwargs_end),
+        Bool(must=[
+            Missing(field=field.field_min),
+            Missing(field=field.field_max)
+        ])
     ]))
 
 

--- a/c2corg_api/search/search_filters.py
+++ b/c2corg_api/search/search_filters.py
@@ -65,6 +65,8 @@ def create_filter(field_name, query_term, search_model):
         return create_range_filter(field, query_term)
     if hasattr(field, '_enum_range') and field._enum_range:
         return create_enum_range_filter(field, query_term)
+    if hasattr(field, '_enum_range_min_max') and field._enum_range_min_max:
+        return create_enum_range_min_max_filter(field, query_term)
     elif hasattr(field, '_enum'):
         return create_term_filter(field, query_term)
     elif hasattr(field, '_is_bool') and field._is_bool:
@@ -130,6 +132,30 @@ def create_enum_range_filter(field, query_term):
 
     kwargs = {field._name: range_params}
     return Range(**kwargs)
+
+
+def create_enum_range_min_max_filter(field, query_term):
+    """Creates an ElasticSearch combined enum range filter.
+
+    For example the fields `climbing_rating_min` and `climbing_rating_max` are
+    combined into a single search field. Searching for `crat=4c,6b` returns
+    the waypoints where the min/max climbing ratings match the given range.
+    """
+    query_terms = query_term.split(',')
+    map_enum = partial(map_enum_to_int, field._enum_mapper)
+    range_values = list(map(map_enum, query_terms))
+    range_values = [t for t in range_values if t is not None]
+
+    n = len(range_values)
+    if n != 2:
+        return None
+
+    kwargs_start = {field.field_min: {'gt': range_values[1]}}
+    kwargs_end = {field.field_max: {'lt': range_values[0]}}
+    return Bool(must_not=Bool(should=[
+        Range(**kwargs_start),
+        Range(**kwargs_end)
+    ]))
 
 
 def create_term_filter(field, query_term):

--- a/c2corg_api/tests/scripts/es/test_fill_index.py
+++ b/c2corg_api/tests/scripts/es/test_fill_index.py
@@ -43,7 +43,7 @@ class FillIndexTest(BaseTestCase):
         self.session.add(Route(
             document_id=71173,
             activities=['skitouring'], elevation_max=1500, elevation_min=700,
-            height_diff_up=800, height_diff_down=800, durations='1',
+            height_diff_up=800, height_diff_down=800, durations=['1'],
             locales=[
                 RouteLocale(
                     lang='en', title='Face N',
@@ -91,6 +91,7 @@ class FillIndexTest(BaseTestCase):
         self.assertEqual(route.title_en, 'Mont Blanc : Face N')
         self.assertEqual(route.title_fr, '')
         self.assertEqual(route.doc_type, 'r')
+        self.assertEqual(route.durations, [0])
 
         # merged document is ignored
         self.assertIsNone(SearchWaypoint.get(id=71174, ignore=404))

--- a/c2corg_api/tests/scripts/es/test_fill_index.py
+++ b/c2corg_api/tests/scripts/es/test_fill_index.py
@@ -16,6 +16,7 @@ class FillIndexTest(BaseTestCase):
         self.session.add(Waypoint(
             document_id=71171,
             waypoint_type='summit', elevation=2000, quality='medium',
+            access_time='15min',
             geometry=DocumentGeometry(
                 geom='SRID=3857;POINT(635956 5723604)'),
             locales=[
@@ -75,6 +76,7 @@ class FillIndexTest(BaseTestCase):
         self.assertEqual(waypoint1.summary_fr, 'Le Mont  Granier ')
         self.assertEqual(waypoint1.doc_type, 'w')
         self.assertEqual(waypoint1.quality, 2)
+        self.assertEqual(waypoint1.access_time, 3)
         self.assertAlmostEqual(waypoint1.geom[0], 5.71288994)
         self.assertAlmostEqual(waypoint1.geom[1], 45.64476395)
 

--- a/c2corg_api/tests/scripts/es/test_fill_index.py
+++ b/c2corg_api/tests/scripts/es/test_fill_index.py
@@ -15,7 +15,7 @@ class FillIndexTest(BaseTestCase):
         """
         self.session.add(Waypoint(
             document_id=71171,
-            waypoint_type='summit', elevation=2000,
+            waypoint_type='summit', elevation=2000, quality='medium',
             geometry=DocumentGeometry(
                 geom='SRID=3857;POINT(635956 5723604)'),
             locales=[
@@ -74,6 +74,7 @@ class FillIndexTest(BaseTestCase):
         self.assertEqual(waypoint1.title_fr, 'Mont Granier')
         self.assertEqual(waypoint1.summary_fr, 'Le Mont  Granier ')
         self.assertEqual(waypoint1.doc_type, 'w')
+        self.assertEqual(waypoint1.quality, 2)
         self.assertAlmostEqual(waypoint1.geom[0], 5.71288994)
         self.assertAlmostEqual(waypoint1.geom[1], 45.64476395)
 

--- a/c2corg_api/tests/search/test_mapping.py
+++ b/c2corg_api/tests/search/test_mapping.py
@@ -76,6 +76,24 @@ class MappingTest(BaseTestCase):
                 if hasattr(mapping_field, '_model_field'):
                     self.assertTrue(
                         mapping_field._model_field is getattr(model, field))
+                if hasattr(mapping_field, '_enum_range'):
+                    self.assertFalse(
+                        mapping_field._enum_range,
+                        'Field {0} should be listed as ENUM_RANGE_FIELDS'.
+                        format(field)
+                    )
+
+        enum_range_fields = search_model.ENUM_RANGE_FIELDS \
+            if hasattr(search_model, 'ENUM_RANGE_FIELDS') else []
+        for field in enum_range_fields:
+            self.assertTrue(hasattr(model, field))
+            self.assertIn(field, mapping_fields)
+            mapping_field = mapping_fields[field]
+
+            if isinstance(mapping_field, QueryableMixin):
+                if hasattr(mapping_field, '_model_field'):
+                    self.assertTrue(
+                        mapping_field._model_field is getattr(model, field))
 
         queryable_fields = search_model.queryable_fields
         self.assertIn('qa', queryable_fields)

--- a/c2corg_api/tests/search/test_search_filters.py
+++ b/c2corg_api/tests/search/test_search_filters.py
@@ -181,6 +181,33 @@ class AdvancedSearchTest(BaseTestCase):
             create_filter('qa', 'medium,invalid enum', SearchWaypoint),
             Range(quality={'gte': 2}))
 
+    def test_create_filter_enum_range_climbing_rating(self):
+        self.assertEqual(
+            create_filter(
+                'not a valid field', '4b,6c', SearchWaypoint),
+            None)
+        self.assertEqual(
+            create_filter('crat', '', SearchWaypoint),
+            None)
+        self.assertEqual(
+            create_filter('crat', 'invalid term', SearchWaypoint),
+            None)
+        self.assertEqual(
+            create_filter('crat', '4b', SearchWaypoint),
+            None)
+        self.assertEqual(
+            create_filter('crat', '4b,invalid term', SearchWaypoint),
+            None)
+        self.assertEqual(
+            create_filter('crat', 'invalid term,6c', SearchWaypoint),
+            None)
+        self.assertEqual(
+            create_filter('crat', '4b,6c', SearchWaypoint),
+            Bool(must_not=Bool(should=[
+                Range(climbing_rating_min={'gt': 17}),
+                Range(climbing_rating_max={'lt': 5})
+            ])))
+
     def test_create_filter_enum(self):
         self.assertEqual(
             create_filter('wtyp', '', SearchWaypoint),

--- a/c2corg_api/tests/search/test_search_filters.py
+++ b/c2corg_api/tests/search/test_search_filters.py
@@ -5,7 +5,8 @@ from c2corg_api.search.search_filters import create_filter, build_query, \
 from c2corg_api.search.mappings.outing_mapping import SearchOuting
 from c2corg_api.search.mappings.waypoint_mapping import SearchWaypoint
 from c2corg_api.tests import BaseTestCase
-from elasticsearch_dsl.query import Range, Term, Terms, Bool, GeoBoundingBox
+from elasticsearch_dsl.query import Range, Term, Terms, Bool, GeoBoundingBox, \
+    Missing
 
 
 class AdvancedSearchTest(BaseTestCase):
@@ -206,7 +207,11 @@ class AdvancedSearchTest(BaseTestCase):
             create_filter('crat', '4b,6c', SearchWaypoint),
             Bool(must_not=Bool(should=[
                 Range(climbing_rating_min={'gt': 17}),
-                Range(climbing_rating_max={'lt': 5})
+                Range(climbing_rating_max={'lt': 5}),
+                Bool(must=[
+                    Missing(field='climbing_rating_min'),
+                    Missing(field='climbing_rating_max')
+                ])
             ])))
 
     def test_create_filter_integer_range(self):
@@ -233,7 +238,11 @@ class AdvancedSearchTest(BaseTestCase):
             create_filter('ele', '1200,2400', SearchRoute),
             Bool(must_not=Bool(should=[
                 Range(elevation_min={'gt': 2400}),
-                Range(elevation_max={'lt': 1200})
+                Range(elevation_max={'lt': 1200}),
+                Bool(must=[
+                    Missing(field='elevation_min'),
+                    Missing(field='elevation_max')
+                ])
             ])))
 
     def test_create_filter_enum(self):

--- a/c2corg_api/tests/search/test_search_filters.py
+++ b/c2corg_api/tests/search/test_search_filters.py
@@ -151,6 +151,36 @@ class AdvancedSearchTest(BaseTestCase):
             create_filter('walt', '1500,NaN', SearchWaypoint),
             Range(elevation={'gte': 1500}))
 
+    def test_create_filter_enum_range(self):
+        self.assertEqual(
+            create_filter(
+                'not a valid field', 'medium,excellent', SearchWaypoint),
+            None)
+        self.assertEqual(
+            create_filter('qa', '', SearchWaypoint),
+            None)
+        self.assertEqual(
+            create_filter('qa', 'not a, valid enum', SearchWaypoint),
+            None)
+        self.assertEqual(
+            create_filter('qa', 'medium,excellent', SearchWaypoint),
+            Range(quality={'gte': 2, 'lte': 4}))
+        self.assertEqual(
+            create_filter('qa', 'medium,', SearchWaypoint),
+            Range(quality={'gte': 2}))
+        self.assertEqual(
+            create_filter('qa', 'medium', SearchWaypoint),
+            Range(quality={'gte': 2}))
+        self.assertEqual(
+            create_filter('qa', ',excellent', SearchWaypoint),
+            Range(quality={'lte': 4}))
+        self.assertEqual(
+            create_filter('qa', 'invalid enum,excellent', SearchWaypoint),
+            Range(quality={'lte': 4}))
+        self.assertEqual(
+            create_filter('qa', 'medium,invalid enum', SearchWaypoint),
+            Range(quality={'gte': 2}))
+
     def test_create_filter_enum(self):
         self.assertEqual(
             create_filter('wtyp', '', SearchWaypoint),

--- a/c2corg_api/tests/search/test_search_filters.py
+++ b/c2corg_api/tests/search/test_search_filters.py
@@ -1,4 +1,5 @@
 from c2corg_api.search import create_search, get_text_query
+from c2corg_api.search.mappings.route_mapping import SearchRoute
 from c2corg_api.search.search_filters import create_filter, build_query, \
     create_bbox_filter
 from c2corg_api.search.mappings.outing_mapping import SearchOuting
@@ -181,7 +182,7 @@ class AdvancedSearchTest(BaseTestCase):
             create_filter('qa', 'medium,invalid enum', SearchWaypoint),
             Range(quality={'gte': 2}))
 
-    def test_create_filter_enum_range_climbing_rating(self):
+    def test_create_filter_enum_range_min_max(self):
         self.assertEqual(
             create_filter(
                 'not a valid field', '4b,6c', SearchWaypoint),
@@ -206,6 +207,33 @@ class AdvancedSearchTest(BaseTestCase):
             Bool(must_not=Bool(should=[
                 Range(climbing_rating_min={'gt': 17}),
                 Range(climbing_rating_max={'lt': 5})
+            ])))
+
+    def test_create_filter_integer_range(self):
+        self.assertEqual(
+            create_filter(
+                'not a valid field', '1200,2400', SearchRoute),
+            None)
+        self.assertEqual(
+            create_filter('ele', '', SearchRoute),
+            None)
+        self.assertEqual(
+            create_filter('ele', 'invalid term', SearchRoute),
+            None)
+        self.assertEqual(
+            create_filter('ele', '1200', SearchRoute),
+            None)
+        self.assertEqual(
+            create_filter('ele', '1200,invalid term', SearchRoute),
+            None)
+        self.assertEqual(
+            create_filter('ele', 'invalid term,2400', SearchRoute),
+            None)
+        self.assertEqual(
+            create_filter('ele', '1200,2400', SearchRoute),
+            Bool(must_not=Bool(should=[
+                Range(elevation_min={'gt': 2400}),
+                Range(elevation_max={'lt': 1200})
             ])))
 
     def test_create_filter_enum(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ git+https://github.com/tsauerwein/cornice.git@nested-none
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@c381113c288b9739af46fc6650aa31d8db309093
+git+https://github.com/c2corg/v6_common.git@e681460
 
 # Discourse API client
 git+https://github.com/c2corg/pydiscourse.git@65e398343bbbc74fdb71cca4637c9f808e5adfb2


### PR DESCRIPTION
Closes https://github.com/c2corg/v6_api/issues/313

Now it is possible to do searches like `routes?trat=2.1,5.2` (for all routes with a ski rating between 2.1 and 5.2) or `routes?ele=1400,1600` (for all routes with that elevation range).