### PR TITLE
Update cache keys when areas or maps change

### DIFF
--- a/c2corg_api/models/__init__.py
+++ b/c2corg_api/models/__init__.py
@@ -30,6 +30,7 @@ from c2corg_api.models import association  # noqa
 from c2corg_api.models import topo_map  # noqa
 from c2corg_api.models import area  # noqa
 from c2corg_api.models import area_association  # noqa
+from c2corg_api.models import topo_map_association  # noqa
 from c2corg_api.models import user_profile  # noqa
 from c2corg_api.models import outing  # noqa
 from c2corg_api.models import es_sync  # noqa

--- a/c2corg_api/models/area_association.py
+++ b/c2corg_api/models/area_association.py
@@ -1,5 +1,6 @@
 from c2corg_api.models import Base, schema, DBSession
 from c2corg_api.models.area import Area, AREA_TYPE
+from c2corg_api.models.cache_version import update_cache_version_for_area
 from c2corg_api.models.document import Document, DocumentGeometry, \
     DocumentLocale
 from c2corg_api.views import set_best_locale
@@ -89,6 +90,9 @@ def update_area(area, reset=False):
         AreaAssociation.__table__.insert().from_select(
             [AreaAssociation.document_id, AreaAssociation.area_id],
             intersecting_documents))
+
+    # update cache key for now associated docs
+    update_cache_version_for_area(area)
 
 
 def update_areas_for_document(document, reset=False):

--- a/c2corg_api/models/topo_map.py
+++ b/c2corg_api/models/topo_map.py
@@ -1,6 +1,5 @@
 from c2corg_api.models.enums import map_editor, map_scale
 from c2corg_api.models.schema_utils import restrict_schema, get_update_schema
-from c2corg_api.views import set_best_locale
 from c2corg_common.fields_topo_map import fields_topo_map
 from sqlalchemy import (
     Column,
@@ -11,15 +10,12 @@ from sqlalchemy import (
 
 from colanderalchemy import SQLAlchemySchemaNode
 
-from c2corg_api.models import schema, DBSession, Base
+from c2corg_api.models import schema, Base
 from c2corg_api.models.utils import copy_attributes
 from c2corg_api.models.document import (
     ArchiveDocument, Document, geometry_schema_overrides,
-    schema_document_locale, schema_attributes, DocumentGeometry,
-    DocumentLocale)
-from sqlalchemy.orm import load_only, joinedload
+    schema_document_locale, schema_attributes)
 from c2corg_common import document_types
-from sqlalchemy.sql.expression import or_, select
 
 MAP_TYPE = document_types.MAP_TYPE
 
@@ -97,42 +93,3 @@ schema_topo_map = SQLAlchemySchemaNode(
 schema_update_topo_map = get_update_schema(schema_topo_map)
 schema_listing_topo_map = restrict_schema(
     schema_topo_map, fields_topo_map.get('listing'))
-
-
-# TODO cache on document_id and lang (empty the cache if the document geometry
-# has changed or any maps was updated/created)
-def get_maps(document, lang):
-    """Load and return maps that intersect with the document geometry.
-    """
-    if document.geometry is None:
-        return []
-
-    document_geom = select([DocumentGeometry.geom]). \
-        where(DocumentGeometry.document_id == document.document_id)
-    document_geom_detail = select([DocumentGeometry.geom_detail]). \
-        where(DocumentGeometry.document_id == document.document_id)
-    topo_maps = DBSession. \
-        query(TopoMap). \
-        filter(TopoMap.redirects_to.is_(None)). \
-        join(
-            DocumentGeometry,
-            TopoMap.document_id == DocumentGeometry.document_id). \
-        options(load_only(
-            TopoMap.document_id, TopoMap.editor, TopoMap.code,
-            TopoMap.version, TopoMap.protected)). \
-        options(joinedload(TopoMap.locales).load_only(
-            DocumentLocale.lang, DocumentLocale.title,
-            DocumentLocale.version)). \
-        filter(
-            or_(
-                DocumentGeometry.geom_detail.ST_Intersects(
-                    document_geom.label('t1')),
-                DocumentGeometry.geom_detail.ST_Intersects(
-                    document_geom_detail.label('t2'))
-            )). \
-        all()
-
-    if lang is not None:
-        set_best_locale(topo_maps, lang)
-
-    return topo_maps

--- a/c2corg_api/models/topo_map_association.py
+++ b/c2corg_api/models/topo_map_association.py
@@ -1,4 +1,5 @@
 from c2corg_api.models import Base, schema, DBSession
+from c2corg_api.models.cache_version import update_cache_version_for_map
 from c2corg_api.models.document import Document, DocumentGeometry, \
     DocumentLocale
 from c2corg_api.models.topo_map import TopoMap, MAP_TYPE
@@ -91,8 +92,7 @@ def update_map(topo_map, reset=False):
             intersecting_documents))
 
     # update cache key for now associated docs
-    # TODO
-    # update_cache_version_for_map(topo_map)
+    update_cache_version_for_map(topo_map)
 
 
 def update_maps_for_document(document, reset=False):
@@ -115,7 +115,7 @@ def update_maps_for_document(document, reset=False):
         where(DocumentGeometry.document_id == document.document_id)
     document_geom_detail = select([DocumentGeometry.geom_detail]). \
         where(DocumentGeometry.document_id == document.document_id)
-    intersecting_areas = DBSession. \
+    intersecting_maps = DBSession. \
         query(
             DocumentGeometry.document_id,  # id of a map
             literal_column(str(document.document_id))). \
@@ -134,7 +134,7 @@ def update_maps_for_document(document, reset=False):
     DBSession.execute(
         TopoMapAssociation.__table__.insert().from_select(
             [TopoMapAssociation.topo_map_id, TopoMapAssociation.document_id],
-            intersecting_areas))
+            intersecting_maps))
 
 
 def get_maps(document, lang):

--- a/c2corg_api/models/topo_map_association.py
+++ b/c2corg_api/models/topo_map_association.py
@@ -1,0 +1,163 @@
+from c2corg_api.models import Base, schema, DBSession
+from c2corg_api.models.document import Document, DocumentGeometry, \
+    DocumentLocale
+from c2corg_api.models.topo_map import TopoMap, MAP_TYPE
+from c2corg_api.views import set_best_locale
+from sqlalchemy import (
+    Column,
+    Integer,
+    ForeignKey
+    )
+from sqlalchemy.orm import relationship, load_only, joinedload
+from sqlalchemy.schema import PrimaryKeyConstraint
+from sqlalchemy.sql.elements import literal_column
+from sqlalchemy.sql.expression import and_, or_, select
+
+
+class TopoMapAssociation(Base):
+    """Associations between documents and maps.
+
+    Used to cache which documents are within the area of a map. The entries in
+    this table are created automatically when a maps is changed/added, when a
+    document is added or a document geometry changes.
+    """
+    __tablename__ = 'map_associations'
+
+    document_id = Column(
+        Integer, ForeignKey(schema + '.documents.document_id'),
+        nullable=False)
+    document = relationship(
+        Document, primaryjoin=document_id == Document.document_id
+    )
+
+    topo_map_id = Column(
+        Integer, ForeignKey(schema + '.maps.document_id'),
+        nullable=False)
+    topo_map = relationship(
+        TopoMap, primaryjoin=topo_map_id == TopoMap.document_id)
+
+    __table_args__ = (
+        PrimaryKeyConstraint(document_id, topo_map_id),
+        Base.__table_args__
+    )
+
+
+Document._maps = relationship(
+    TopoMap,
+    secondary=TopoMapAssociation.__table__,
+    viewonly=True, cascade='expunge'
+)
+
+
+def update_map(topo_map, reset=False):
+    """Create associations for the given map with all intersecting documents.
+
+    If `reset` is True, all possible existing associations to this map are
+    dropped before creating new associations.
+    """
+    if reset:
+        DBSession.execute(
+            TopoMapAssociation.__table__.delete().where(
+                TopoMapAssociation.topo_map_id == topo_map.document_id)
+        )
+
+    if topo_map.redirects_to:
+        # ignore forwarded maps
+        return
+
+    map_geom = select([DocumentGeometry.geom_detail]). \
+        where(DocumentGeometry.document_id == topo_map.document_id)
+    intersecting_documents = DBSession. \
+        query(
+            DocumentGeometry.document_id,  # id of a document
+            literal_column(str(topo_map.document_id))). \
+        join(
+            Document,
+            and_(
+                Document.document_id == DocumentGeometry.document_id,
+                Document.type != MAP_TYPE)). \
+        filter(Document.redirects_to.is_(None)). \
+        filter(
+            or_(
+                DocumentGeometry.geom.ST_Intersects(
+                    map_geom.label('t1')),
+                DocumentGeometry.geom_detail.ST_Intersects(
+                    map_geom.label('t2'))
+            ))
+
+    DBSession.execute(
+        TopoMapAssociation.__table__.insert().from_select(
+            [TopoMapAssociation.document_id, TopoMapAssociation.topo_map_id],
+            intersecting_documents))
+
+    # update cache key for now associated docs
+    # TODO
+    # update_cache_version_for_map(topo_map)
+
+
+def update_maps_for_document(document, reset=False):
+    """Create associations for the given documents with all intersecting maps.
+
+    If `reset` is True, all possible existing associations to this document are
+    dropped before creating new associations.
+    """
+    if reset:
+        DBSession.execute(
+            TopoMapAssociation.__table__.delete().where(
+                TopoMapAssociation.document_id == document.document_id)
+        )
+
+    if document.redirects_to:
+        # ignore forwarded maps
+        return
+
+    document_geom = select([DocumentGeometry.geom]). \
+        where(DocumentGeometry.document_id == document.document_id)
+    document_geom_detail = select([DocumentGeometry.geom_detail]). \
+        where(DocumentGeometry.document_id == document.document_id)
+    intersecting_areas = DBSession. \
+        query(
+            DocumentGeometry.document_id,  # id of a map
+            literal_column(str(document.document_id))). \
+        join(
+            TopoMap,
+            TopoMap.document_id == DocumentGeometry.document_id). \
+        filter(TopoMap.redirects_to.is_(None)). \
+        filter(
+            or_(
+                DocumentGeometry.geom_detail.ST_Intersects(
+                    document_geom.label('t1')),
+                DocumentGeometry.geom_detail.ST_Intersects(
+                    document_geom_detail.label('t2'))
+            ))
+
+    DBSession.execute(
+        TopoMapAssociation.__table__.insert().from_select(
+            [TopoMapAssociation.topo_map_id, TopoMapAssociation.document_id],
+            intersecting_areas))
+
+
+def get_maps(document, lang):
+    """Load and return areas linked with the given document.
+    """
+    maps = DBSession. \
+        query(TopoMap). \
+        filter(TopoMap.redirects_to.is_(None)). \
+        join(
+            TopoMapAssociation,
+            TopoMap.document_id == TopoMapAssociation.topo_map_id). \
+        options(load_only(
+            TopoMap.document_id, TopoMap.version, TopoMap.protected,
+            TopoMap.editor, TopoMap.scale, TopoMap.code)). \
+        options(joinedload(TopoMap.locales).load_only(
+            DocumentLocale.lang, DocumentLocale.title,
+            DocumentLocale.version)). \
+        filter(
+            TopoMapAssociation.document_id == document.document_id
+        ). \
+        all()
+
+    if lang is not None:
+        set_best_locale(maps, lang)
+
+    return maps

--- a/c2corg_api/scripts/migration/map_associations.py
+++ b/c2corg_api/scripts/migration/map_associations.py
@@ -1,0 +1,41 @@
+import transaction
+import zope
+
+from c2corg_api.scripts.migration.migrate_base import MigrateBase
+
+
+class MigrateMapAssociations(MigrateBase):
+    """Initialize associations between maps and documents.
+    """
+
+    def migrate(self):
+        self.start('map associations')
+
+        with transaction.manager:
+            self.session_target.execute(SQL_CREATE_MAP_ASSOCIATIONS)
+            zope.sqlalchemy.mark_changed(self.session_target)
+
+        # run vacuum on the table (must be outside a transaction)
+        engine = self.session_target.bind
+        conn = engine.connect()
+        old_lvl = conn.connection.isolation_level
+        conn.connection.set_isolation_level(0)
+        conn.execute('vacuum analyze guidebook.map_associations;')
+        conn.connection.set_isolation_level(old_lvl)
+        conn.close()
+
+        self.stop()
+
+
+SQL_CREATE_MAP_ASSOCIATIONS = """
+insert into guidebook.map_associations (document_id, topo_map_id) (
+  select d.document_id, a.document_id as map_document_id
+  from (select g.document_id, g.geom, g.geom_detail from
+    guidebook.documents_geometries g join guidebook.documents d
+    on g.document_id = d.document_id and d.type <> 'm') d
+  join (select ga.document_id, ga.geom_detail from
+    guidebook.maps a join guidebook.documents_geometries ga
+    on ga.document_id = a.document_id) a
+  on ST_Intersects(d.geom, a.geom_detail) or
+     ST_Intersects(d.geom_detail, a.geom_detail));
+"""

--- a/c2corg_api/scripts/migration/migrate.py
+++ b/c2corg_api/scripts/migration/migrate.py
@@ -11,6 +11,8 @@ from c2corg_api.scripts.migration.documents.user_profiles import \
     MigrateUserProfiles
 from c2corg_api.scripts.migration.documents.outings import MigrateOutings
 from c2corg_api.scripts.migration.documents.images import MigrateImages
+from c2corg_api.scripts.migration.map_associations import \
+    MigrateMapAssociations
 from c2corg_api.scripts.migration.set_default_geometries import \
     SetDefaultGeometries
 from sqlalchemy import engine_from_config
@@ -78,6 +80,7 @@ def main(argv=sys.argv):
     MigrateAssociations(connection_source, session, batch_size).migrate()
     SetDefaultGeometries(connection_source, session, batch_size).migrate()
     MigrateAreaAssociations(connection_source, session, batch_size).migrate()
+    MigrateMapAssociations(connection_source, session, batch_size).migrate()
     UpdateSequences(connection_source, session, batch_size).migrate()
 
 if __name__ == "__main__":

--- a/c2corg_api/tests/models/test_cache_version.py
+++ b/c2corg_api/tests/models/test_cache_version.py
@@ -1,8 +1,11 @@
 import datetime
 
+from c2corg_api.models.area import Area
+from c2corg_api.models.area_association import AreaAssociation
 from c2corg_api.models.association import Association
 from c2corg_api.models.cache_version import CacheVersion, \
-    update_cache_version, update_cache_version_associations
+    update_cache_version, update_cache_version_associations, \
+    update_cache_version_for_area
 from c2corg_api.models.outing import Outing, OUTING_TYPE
 from c2corg_api.models.route import Route, ROUTE_TYPE
 from c2corg_api.models.user import User
@@ -341,3 +344,28 @@ class TestCacheVersion(BaseTestCase):
         self.assertEqual(cache_version_route.version, 2)
         self.assertEqual(cache_version_outing.version, 2)
         self.assertEqual(cache_version_untouched.version, 1)
+
+    def test_update_cache_version_for_area(self):
+        waypoint = Waypoint(waypoint_type='summit')
+        waypoint_unrelated = Waypoint(waypoint_type='summit')
+        area = Area()
+        self.session.add_all([waypoint, waypoint_unrelated, area])
+        self.session.flush()
+
+        self.session.add(AreaAssociation(
+            document_id=waypoint.document_id, area_id=area.document_id))
+        self.session.flush()
+
+        update_cache_version_for_area(area)
+
+        cache_version_waypoint = self.session.query(CacheVersion).get(
+            waypoint.document_id)
+        cache_version_untouched = self.session.query(CacheVersion).get(
+            waypoint_unrelated.document_id)
+        cache_version_area = self.session.query(CacheVersion).get(
+            area.document_id)
+
+        self.assertEqual(cache_version_waypoint.version, 2)
+        self.assertEqual(cache_version_untouched.version, 1)
+        # the cache key of the area is also not updated!
+        self.assertEqual(cache_version_area.version, 1)

--- a/c2corg_api/tests/models/test_cache_version.py
+++ b/c2corg_api/tests/models/test_cache_version.py
@@ -5,9 +5,11 @@ from c2corg_api.models.area_association import AreaAssociation
 from c2corg_api.models.association import Association
 from c2corg_api.models.cache_version import CacheVersion, \
     update_cache_version, update_cache_version_associations, \
-    update_cache_version_for_area
+    update_cache_version_for_area, update_cache_version_for_map
 from c2corg_api.models.outing import Outing, OUTING_TYPE
 from c2corg_api.models.route import Route, ROUTE_TYPE
+from c2corg_api.models.topo_map import TopoMap
+from c2corg_api.models.topo_map_association import TopoMapAssociation
 from c2corg_api.models.user import User
 from c2corg_api.models.user_profile import UserProfile
 from c2corg_api.models.waypoint import Waypoint, WAYPOINT_TYPE, WaypointLocale
@@ -369,3 +371,29 @@ class TestCacheVersion(BaseTestCase):
         self.assertEqual(cache_version_untouched.version, 1)
         # the cache key of the area is also not updated!
         self.assertEqual(cache_version_area.version, 1)
+
+    def test_update_cache_version_for_map(self):
+        waypoint = Waypoint(waypoint_type='summit')
+        waypoint_unrelated = Waypoint(waypoint_type='summit')
+        topo_map = TopoMap()
+        self.session.add_all([waypoint, waypoint_unrelated, topo_map])
+        self.session.flush()
+
+        self.session.add(TopoMapAssociation(
+            document_id=waypoint.document_id,
+            topo_map_id=topo_map.document_id))
+        self.session.flush()
+
+        update_cache_version_for_map(topo_map)
+
+        cache_version_waypoint = self.session.query(CacheVersion).get(
+            waypoint.document_id)
+        cache_version_untouched = self.session.query(CacheVersion).get(
+            waypoint_unrelated.document_id)
+        cache_version_map = self.session.query(CacheVersion).get(
+            topo_map.document_id)
+
+        self.assertEqual(cache_version_waypoint.version, 2)
+        self.assertEqual(cache_version_untouched.version, 1)
+        # the cache key of the map is also not updated!
+        self.assertEqual(cache_version_map.version, 1)

--- a/c2corg_api/tests/models/test_map.py
+++ b/c2corg_api/tests/models/test_map.py
@@ -1,6 +1,5 @@
-from c2corg_api.models.document import DocumentLocale, DocumentGeometry
-from c2corg_api.models.topo_map import TopoMap, get_maps
-from c2corg_api.models.waypoint import Waypoint
+from c2corg_api.models.document import DocumentLocale
+from c2corg_api.models.topo_map import TopoMap
 
 from c2corg_api.tests import BaseTestCase
 
@@ -36,45 +35,3 @@ class TestMap(BaseTestCase):
         self.assertIsNone(locale_archive.id)
         self.assertEqual(locale_archive.lang, locale.lang)
         self.assertEqual(locale_archive.title, locale.title)
-
-    def test_get_maps(self):
-        map1 = TopoMap(
-            locales=[
-                DocumentLocale(lang='en', title='Passo del Maloja'),
-                DocumentLocale(lang='fr', title='Passo del Maloja')
-            ],
-            geometry=DocumentGeometry(geom_detail='SRID=3857;POLYGON((1060345.67641127 5869598.161661,1161884.8271513 5866294.47946546,1159243.3608776 5796747.98963817,1058506.68785187 5800000.03655724,1060345.67641127 5869598.161661))')  # noqa
-        )
-        map2 = TopoMap(
-            locales=[
-                DocumentLocale(lang='fr', title='Monte Disgrazia')
-            ],
-            geometry=DocumentGeometry(geom_detail='SRID=3857;POLYGON((1059422.5474971 5834730.45170096,1110000.12573506 5833238.36363707,1108884.30979916 5798519.62445622,1058506.68785187 5800000.03655724,1059422.5474971 5834730.45170096))')  # noqa
-        )
-        map3 = TopoMap(
-            locales=[
-                DocumentLocale(lang='fr', title='Sciora')
-            ],
-            geometry=DocumentGeometry(geom_detail='SRID=3857;POLYGON((1059422.5474971 5834730.45170096,1084713.47958582 5834021.11961652,1084204.54539729 5816641.60293193,1058963.71520182 5817348.14989301,1059422.5474971 5834730.45170096))')  # noqa
-        )
-        map4 = TopoMap(
-            locales=[
-                DocumentLocale(lang='fr', title='...')
-            ],
-            geometry=DocumentGeometry(geom_detail='SRID=3857;POLYGON((753678.422528324 6084684.82967302,857818.351438369 6084952.58494753,857577.289072432 6013614.93425228,754282.556732048 6013351.52692378,753678.422528324 6084684.82967302))')  # noqa
-        )
-        waypoint = Waypoint(
-            waypoint_type='summit',
-            geometry=DocumentGeometry(geom='SRID=3857;POINT(1069913.22199537 5830556.39234855)')  # noqa
-        )
-        self.session.add_all([waypoint, map1, map2, map3, map4])
-        self.session.flush()
-
-        maps = get_maps(waypoint, 'en')
-        self.assertEqual(
-            set([m.document_id for m in maps]),
-            set([map1.document_id, map2.document_id, map3.document_id]))
-
-        for m in maps:
-            # check that the "best" locale is set
-            self.assertEqual(len(m.locales), 1)

--- a/c2corg_api/tests/models/test_topo_map_associations.py
+++ b/c2corg_api/tests/models/test_topo_map_associations.py
@@ -1,0 +1,177 @@
+from c2corg_api.models.document import DocumentGeometry
+from c2corg_api.models.topo_map import TopoMap
+from c2corg_api.models.topo_map_association import update_map, \
+    TopoMapAssociation, update_maps_for_document, get_maps
+from c2corg_api.models.waypoint import Waypoint
+
+from c2corg_api.tests import BaseTestCase
+
+
+class TestTopoMapAssociation(BaseTestCase):
+
+    def setUp(self):  # noqa
+        BaseTestCase.setUp(self)
+
+        self.map1 = TopoMap(
+            code='3232ET',
+            geometry=DocumentGeometry(
+                geom_detail='SRID=3857;POLYGON((668518.249382151 5728802.39591739,668518.249382151 5745465.66808356,689156.247019149 5745465.66808356,689156.247019149 5728802.39591739,668518.249382151 5728802.39591739))')  # noqa
+        )
+        self.session.add(self.map1)
+        self.session.flush()
+        self.map2 = TopoMap(
+            code='3233ET',
+            redirects_to=self.map1.document_id,
+            geometry=DocumentGeometry(
+                geom_detail='SRID=3857;POLYGON((668518.249382151 5728802.39591739,668518.249382151 5745465.66808356,689156.247019149 5745465.66808356,689156.247019149 5728802.39591739,668518.249382151 5728802.39591739))')  # noqa
+        )
+
+        # wp inside the area of the map
+        self.waypoint1 = Waypoint(
+            waypoint_type='summit',
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POINT(677461.381691516 5740879.44638645)')
+        )
+        # wp outside the area of the map
+        self.waypoint2 = Waypoint(
+            waypoint_type='summit',
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POINT(693666.031687976 5741108.7574713)')
+        )
+        # wp without geometry
+        self.waypoint3 = Waypoint(
+            waypoint_type='summit'
+        )
+        # wp with empty geometry
+        self.waypoint4 = Waypoint(
+            waypoint_type='summit',
+            geometry=DocumentGeometry()
+        )
+        self.session.add_all([
+            self.map2, self.waypoint1, self.waypoint2, self.waypoint3,
+            self.waypoint4])
+        self.session.flush()
+
+        # wp inside the area of the map, but with `redirects_to`
+        # (should be ignored)
+        self.waypoint5 = Waypoint(
+            waypoint_type='summit',
+            redirects_to=self.waypoint1.document_id,
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POINT(677461.381691516 5740879.44638645)')
+        )
+        self.session.add(self.waypoint5)
+
+    def test_update_map(self):
+        update_map(self.map1)
+
+        added_links = self.session.query(TopoMapAssociation). \
+            filter(TopoMapAssociation.topo_map_id == self.map1.document_id). \
+            all()
+        self.assertEqual(len(added_links), 1)
+        self.assertEqual(
+            added_links[0].document_id, self.waypoint1.document_id)
+
+    def test_update_map_reset_first(self):
+        # add an association with wp2, which should be removed after the update
+        self.session.add(TopoMapAssociation(
+            document_id=self.waypoint2.document_id,
+            topo_map_id=self.map1.document_id))
+        self.session.flush()
+
+        update_map(self.map1, reset=True)
+
+        updated_links = self.session.query(TopoMapAssociation). \
+            filter(TopoMapAssociation.topo_map_id == self.map1.document_id). \
+            all()
+        self.assertEqual(len(updated_links), 1)
+        self.assertEqual(
+            updated_links[0].document_id, self.waypoint1.document_id)
+
+    def test_update_map_reset_first_forwarded(self):
+        """Tests that maps with `redirects_to` are ignored.
+        """
+        # add an association with wp2, which should be removed after the update
+        self.session.add(TopoMapAssociation(
+            document_id=self.waypoint2.document_id,
+            topo_map_id=self.map2.document_id))
+        self.session.flush()
+
+        update_map(self.map2, reset=True)
+
+        updated_links = self.session.query(TopoMapAssociation). \
+            filter(TopoMapAssociation.topo_map_id == self.map2.document_id). \
+            all()
+        self.assertEqual(len(updated_links), 0)
+
+    def test_update_document(self):
+        # waypoint inside the area
+        update_maps_for_document(self.waypoint1)
+
+        added_links = self._get_links_for_document(self.waypoint1)
+        self.assertEqual(len(added_links), 1)
+        self.assertEqual(
+            added_links[0].topo_map_id, self.map1.document_id)
+
+        # wp outside the area of the map
+        update_maps_for_document(self.waypoint2)
+
+        added_links = self._get_links_for_document(self.waypoint2)
+        self.assertEqual(len(added_links), 0)
+
+        # wp without geometry
+        update_maps_for_document(self.waypoint3)
+
+        added_links = self._get_links_for_document(self.waypoint3)
+        self.assertEqual(len(added_links), 0)
+
+        # wp with empty geometry
+        update_maps_for_document(self.waypoint4)
+
+        added_links = self._get_links_for_document(self.waypoint4)
+        self.assertEqual(len(added_links), 0)
+
+    def test_update_document_forwarded(self):
+        # waypoint inside the area of the map but forwarded (should be ignored)
+        update_maps_for_document(self.waypoint5)
+
+        added_links = self._get_links_for_document(self.waypoint1)
+        self.assertEqual(len(added_links), 0)
+
+    def test_update_document_reset_first(self):
+        # add an association with wp2, which should be removed after the update
+        self.session.add(TopoMapAssociation(
+            document_id=self.waypoint2.document_id,
+            topo_map_id=self.map1.document_id))
+        self.session.flush()
+
+        update_maps_for_document(self.waypoint2, reset=True)
+
+        updated_links = self._get_links_for_document(self.waypoint2)
+        self.assertEqual(len(updated_links), 0)
+
+    def test_get_maps(self):
+        update_map(self.map1)
+        maps = get_maps(self.waypoint1, 'en')
+
+        self.assertEqual(len(maps), 1)
+        self.assertEqual(
+            maps[0].document_id, self.map1.document_id)
+
+    def test_get_maps_forwarded(self):
+        """Tests that forwarded maps are not included.
+        """
+        # add an association with wp1
+        self.session.add(TopoMapAssociation(
+            document_id=self.waypoint1.document_id,
+            topo_map_id=self.map2.document_id))
+        self.session.flush()
+        areas = get_maps(self.waypoint1, 'en')
+
+        self.assertEqual(len(areas), 0)
+
+    def _get_links_for_document(self, doc):
+        return self.session.query(TopoMapAssociation). \
+            filter(
+            TopoMapAssociation.document_id == doc.document_id). \
+            all()

--- a/c2corg_api/tests/views/test_area.py
+++ b/c2corg_api/tests/views/test_area.py
@@ -144,7 +144,9 @@ class TestAreaRest(BaseDocumentTestRest):
             all()
         self.assertEqual(len(links), 2)
         self.assertEqual(links[0].document_id, self.waypoint1.document_id)
+        self.check_cache_version(self.waypoint1.document_id, 2)
         self.assertEqual(links[1].document_id, self.route.document_id)
+        self.check_cache_version(self.route.document_id, 2)
 
     def test_put_wrong_document_id(self):
         body = {
@@ -307,7 +309,11 @@ class TestAreaRest(BaseDocumentTestRest):
             all()
         self.assertEqual(len(links), 2)
         self.assertEqual(links[0].document_id, self.waypoint1.document_id)
+        self.check_cache_version(self.waypoint1.document_id, 2)
         self.assertEqual(links[1].document_id, self.route.document_id)
+        self.check_cache_version(self.route.document_id, 2)
+        # waypoint 2 is no longer associated, the cache key was incremented
+        self.check_cache_version(self.waypoint2.document_id, 2)
 
     def test_put_success_figures_only(self):
         body = {

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -7,6 +7,7 @@ from c2corg_api.models.association import Association, AssociationLog
 from c2corg_api.models.document_history import DocumentVersion
 from c2corg_api.models.outing import Outing, OutingLocale
 from c2corg_api.models.topo_map import TopoMap
+from c2corg_api.models.topo_map_association import TopoMapAssociation
 from c2corg_api.models.waypoint import Waypoint, WaypointLocale
 from c2corg_api.tests.search import reset_search_index
 from c2corg_api.views.route import check_title_prefix
@@ -853,15 +854,6 @@ class TestRouteRest(BaseDocumentTestRest):
             gear='paraglider'))
         self.session.add(self.route4)
 
-        # add a map
-        self.session.add(TopoMap(
-            code='3232ET', editor='IGN', scale='25000',
-            locales=[
-                DocumentLocale(lang='fr', title='Belley')
-            ],
-            geometry=DocumentGeometry(geom_detail='SRID=3857;POLYGON((635900 5723600, 635900 5723700, 636000 5723700, 636000 5723600, 635900 5723600))')  # noqa
-        ))
-
         # add some associations
         self.waypoint = Waypoint(
             waypoint_type='summit', elevation=4,
@@ -892,6 +884,19 @@ class TestRouteRest(BaseDocumentTestRest):
         self.session.add(Association.create(
             parent_document=self.waypoint,
             child_document=self.route))
+
+        # add a map
+        topo_map = TopoMap(
+            code='3232ET', editor='IGN', scale='25000',
+            locales=[
+                DocumentLocale(lang='fr', title='Belley')
+            ],
+            geometry=DocumentGeometry(geom_detail='SRID=3857;POLYGON((635900 5723600, 635900 5723700, 636000 5723700, 636000 5723600, 635900 5723600))')  # noqa
+        )
+        self.session.add(topo_map)
+        self.session.flush()
+        self.session.add(TopoMapAssociation(
+            document=self.route, topo_map=topo_map))
 
         self.outing1 = Outing(
             activities=['skitouring'], date_start=datetime.date(2016, 1, 1),

--- a/c2corg_api/views/area.py
+++ b/c2corg_api/views/area.py
@@ -1,6 +1,7 @@
 from c2corg_api.models.area import schema_area, Area, schema_update_area, \
     schema_listing_area, AREA_TYPE
 from c2corg_api.models.area_association import update_area
+from c2corg_api.models.cache_version import update_cache_version_for_area
 from c2corg_api.models.document import UpdateType
 from c2corg_common.fields_area import fields_area
 from cornice.resource import resource, view
@@ -59,5 +60,9 @@ def update_associations(area, update_types, user_id):
     """Update the links between this area and documents when the geometry
     has changed.
     """
+    if update_types:
+        # update cache key for currently associated docs
+        update_cache_version_for_area(area)
+
     if UpdateType.GEOM in update_types:
         update_area(area, reset=True)

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -6,6 +6,8 @@ from c2corg_api.models.cache_version import update_cache_version, \
     get_cache_keys
 from c2corg_api.models.image import schema_association_image
 from c2corg_api.models.outing import Outing
+from c2corg_api.models.topo_map_association import update_maps_for_document, \
+    get_maps
 from c2corg_api.models.user import User, schema_association_user
 from functools import partial
 
@@ -20,7 +22,8 @@ from c2corg_api.models.document import (
     ArchiveDocumentGeometry, set_available_langs, get_available_langs)
 from c2corg_api.models.document_history import HistoryMetaData, DocumentVersion
 from c2corg_api.models.route import schema_association_route
-from c2corg_api.models.topo_map import get_maps, schema_listing_topo_map
+from c2corg_api.models.topo_map import schema_listing_topo_map, \
+    MAP_TYPE
 from c2corg_api.models.user_profile import UserProfile
 from c2corg_api.models.waypoint import schema_association_waypoint
 from c2corg_api.search import advanced_search
@@ -322,6 +325,9 @@ class DocumentRest(object):
         if document.type != AREA_TYPE:
             update_areas_for_document(document, reset=False)
 
+        if document.type != MAP_TYPE:
+            update_maps_for_document(document, reset=False)
+
         if after_add:
             after_add(document, user_id=user_id)
 
@@ -378,6 +384,9 @@ class DocumentRest(object):
 
             if document.type != AREA_TYPE and UpdateType.GEOM in update_types:
                 update_areas_for_document(document, reset=True)
+
+            if document.type != MAP_TYPE and UpdateType.GEOM in update_types:
+                update_maps_for_document(document, reset=True)
 
             if after_update:
                 after_update(document, update_types, user_id=user_id)

--- a/c2corg_api/views/topo_map.py
+++ b/c2corg_api/views/topo_map.py
@@ -1,3 +1,4 @@
+from c2corg_api.models.cache_version import update_cache_version_for_map
 from c2corg_api.models.document import UpdateType
 from c2corg_api.models.topo_map import (
     TopoMap, schema_topo_map, schema_update_topo_map, schema_listing_topo_map,
@@ -57,9 +58,7 @@ def update_associations(topo_map, update_types, user_id):
     """
     if update_types:
         # update cache key for currently associated docs
-        # TODO
-        # update_cache_version_for_map(topo_map)
-        pass
+        update_cache_version_for_map(topo_map)
 
     if UpdateType.GEOM in update_types:
         update_map(topo_map, reset=True)


### PR DESCRIPTION
When a map or area changes, the cache keys of associated documents have to be updated.

Associations between maps and documents are now also stored in a table (same as for areas), because maps do not change that often.

Closes https://github.com/c2corg/v6_api/issues/362

The migration script has to be run again, because changes to the database were made.