### PR TITLE
Increase lock timeout for cache

### DIFF
--- a/c2corg_api/caching.py
+++ b/c2corg_api/caching.py
@@ -66,7 +66,7 @@ def configure_caches(settings):
             arguments={
                 'connection_pool': redis_pool,
                 'distributed_lock': True,
-                'lock_timeout': 5  # 5 seconds (dogpile lock)
+                'lock_timeout': 15  # 15 seconds (dogpile lock)
             },
             replace_existing_backend=True
         )


### PR DESCRIPTION
dogpile.cache uses a lock to avoid the dogpile effect. Currently, there is a timeout of 5 seconds for this lock. This means if the cache value (e.g. the rendered response) is not created in 5 seconds, there might be an error. To accommodate for our slow demo server, I increased the timeout to 15 seconds.

Closes https://github.com/c2corg/v6_api/issues/368

I will do the same for the UI.