### PR TITLE
Handle broken database connections

### DIFF
--- a/c2corg_api/jobs/__init__.py
+++ b/c2corg_api/jobs/__init__.py
@@ -17,22 +17,24 @@ def configure_scheduler_from_config(settings):
     scheduler = BackgroundScheduler()
     scheduler.start()
 
+    # run `purge_account` job at 0:00
     scheduler.add_job(
         purge_account,
         id='purge_account',
         name='Purge accounts which where not activated',
         trigger='cron',
-        minute=0,
-        hour=0
+        hour=0,
+        minute=0
     )
 
+    # run `purge_token` job at 0:30
     scheduler.add_job(
         purge_token,
         id='purge_token',
         name='Purge expired tokens',
         trigger='cron',
-        minute=30,
-        hour=0
+        hour=0,
+        minute=30
     )
 
     scheduler.add_listener(exception_listener, EVENT_JOB_ERROR)

--- a/c2corg_api/search/__init__.py
+++ b/c2corg_api/search/__init__.py
@@ -40,7 +40,7 @@ def client_from_config(settings):
     return Elasticsearch([{
         'host': settings['elasticsearch.host'],
         'port': int(settings['elasticsearch.port'])
-    }])
+    }], maxsize=int(settings['elasticsearch.pool']))
 
 
 def configure_es_from_config(settings):

--- a/common.ini.in
+++ b/common.ini.in
@@ -10,6 +10,10 @@ pyramid.default_locale_name = en
 
 version = {version}
 
+# size of the connection pool for the database. note that this number is
+# per application instance.
+sqlalchemy.pool_size=20
+
 elasticsearch.host = {elasticsearch_host}
 elasticsearch.port = {elasticsearch_port}
 elasticsearch.index = {elasticsearch_index}

--- a/common.ini.in
+++ b/common.ini.in
@@ -17,6 +17,7 @@ sqlalchemy.pool_size=20
 elasticsearch.host = {elasticsearch_host}
 elasticsearch.port = {elasticsearch_port}
 elasticsearch.index = {elasticsearch_index}
+elasticsearch.pool = 50
 
 # Redis is used as queue to notify the syncer script of changed documents
 # and also as cache


### PR DESCRIPTION
Validate connections in the database connection pool before using them. Otherwise errors might be raised when a broken connection after restarting the database is used.

I also tested the syncer/background-job scripts. Both continue to run if Postgres/Redis/ElasticSearch is restarted.

Closes https://github.com/c2corg/v6_api/issues/344