### PR TITLE
Improve search

### DIFF
--- a/c2corg_api/search/search.py
+++ b/c2corg_api/search/search.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import joinedload
 
 from c2corg_api.models import DBSession
 from c2corg_api.search import create_search, get_text_query, \
-    elasticsearch_config
+    elasticsearch_config, get_text_query_on_title
 from c2corg_api.views import to_json_dict, set_best_locale
 
 
@@ -22,7 +22,7 @@ def search_for_types(search_types, search_term, limit, lang):
     else:
         # search in ElasticSearch
         results_for_type = do_multi_search_for_types(
-            search_types, search_term, limit)
+            search_types, search_term, limit, lang)
 
     # load the documents using the document ids returned from the search
     results = {}
@@ -49,7 +49,7 @@ def search_for_types(search_types, search_term, limit, lang):
     return results
 
 
-def do_multi_search_for_types(search_types, search_term, limit):
+def do_multi_search_for_types(search_types, search_term, limit, lang):
     """ Executes a multi-search for all document types in a single request
     and returns a list of tuples (document_ids, total) containing the results
     for each type.
@@ -59,7 +59,7 @@ def do_multi_search_for_types(search_types, search_term, limit):
     for search_type in search_types:
         (_, document_type, _, _, _, _) = search_type
         search = create_search(document_type).\
-            query(get_text_query(search_term)).\
+            query(get_text_query_on_title(search_term, lang)).\
             fields([]).\
             extra(from_=0, size=limit)
         multi_search = multi_search.add(search)

--- a/c2corg_api/search/search.py
+++ b/c2corg_api/search/search.py
@@ -3,8 +3,8 @@ from elasticsearch_dsl.search import MultiSearch
 from sqlalchemy.orm import joinedload
 
 from c2corg_api.models import DBSession
-from c2corg_api.search import create_search, get_text_query, \
-    elasticsearch_config, get_text_query_on_title
+from c2corg_api.search import create_search, elasticsearch_config, \
+    get_text_query_on_title
 from c2corg_api.views import to_json_dict, set_best_locale
 
 

--- a/c2corg_api/search/search_filters.py
+++ b/c2corg_api/search/search_filters.py
@@ -21,7 +21,8 @@ def build_query(url_params, meta_params, doc_type):
 
     search = create_search(doc_type)
     if search_term:
-        search = search.query(get_text_query(search_term))
+        search = search.query(
+            get_text_query(search_term, meta_params.get('lang')))
 
     search_model = search_documents[doc_type]
     for param in url_params:

--- a/c2corg_api/tests/search/test_search_filters.py
+++ b/c2corg_api/tests/search/test_search_filters.py
@@ -101,9 +101,12 @@ class AdvancedSearchTest(BaseTestCase):
             bool2 = q2['query']['bool']
             if 'must' in bool1 or 'must' in bool2:
                 self.assertEqual(bool1['must'], bool2['must'])
-            filters1 = bool1['filter']
-            filters2 = bool2['filter']
-            self.assertFiltersEqual(filters1, filters2)
+            if 'should' in bool1 or 'should' in bool2:
+                self.assertEqual(bool1['should'], bool2['should'])
+            if 'filter' in bool1 or 'filter' in bool2:
+                filters1 = bool1['filter']
+                filters2 = bool2['filter']
+                self.assertFiltersEqual(filters1, filters2)
         else:
             self.assertEqual(q1['query'], q2['query'])
 


### PR DESCRIPTION
- Only search on the title for the simple search.
- Use an analyzer that is more adapted to place or user names.
- Boost the fields for the given language.
- Fixes a problem with elision filters (e.g. "l'article" -> "article").

All the problems mentioned in https://github.com/c2corg/v6_api/issues/206 are fixed with these improvements.

Related to https://github.com/c2corg/v6_api/issues/206
Related to https://github.com/c2corg/v6_ui/issues/493
Related to https://github.com/c2corg/v6_ui/issues/351