### PR TITLE
Add config for the demo@c2corg instance

### DIFF
--- a/config/demo
+++ b/config/demo
@@ -1,0 +1,20 @@
+include Makefile
+
+host = api.demov6.camptocamp.org
+
+export instanceid = api
+export base_url = /
+export db_name = c2corg_demo
+export tests_db_name = c2corg_demo_tests
+export elasticsearch_index = c2corg_demo
+export tests_elasticsearch_index = c2corg_demo_tests
+
+export image_backend_url = http://images.demov6.camptocamp.org
+export discourse_url = http://forum.demov6.camptocamp.org
+
+# FIXME
+export discourse_sso_secret = d836444a9e4084d5b224a60c208dce14
+export discourse_api_key = 4647c0d98e8beb793da099ff103b9793d8d4f94fff7cdd52d58391c6fa025845
+export image_backend_secret_key = test
+export recaptcha_secret_key = 6LdWkR4TAAAAALcZLh54HFlAWFHiMQhZR5jR4p3F
+


### PR DESCRIPTION
See also https://github.com/c2corg/v6_ui/pull/624

The "secret" settings are the same than in https://github.com/c2corg/v6_api/blob/demo-config/config/default#L69-L75 and should probably be changed. Maybe also set using a more private way :P 