### PR TITLE
Include quality/waypoint_type for climbing_indoor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ git+https://github.com/tsauerwein/cornice.git@nested-none
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@f0e7c9c093ccecbceae29717ad0b779c9f228ec8
+git+https://github.com/c2corg/v6_common.git@fab440a
 
 # Discourse API client
 git+https://github.com/c2corg/pydiscourse.git@65e398343bbbc74fdb71cca4637c9f808e5adfb2


### PR DESCRIPTION
Some fields were missing in the listing schema for `climbing_indoor`. See https://github.com/c2corg/v6_common/commit/fab440adf0b96bde7715e034235f50480fe26a01

Closes https://github.com/c2corg/v6_api/issues/404