### PR TITLE
Update bcrypt to 3.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ GeoAlchemy2==0.2.6
 Shapely==1.5.13
 pyproj==1.9.5.1
 pyramid-jwtauth==0.1.3
-bcrypt==2.0.0
+bcrypt==3.1.1
 elasticsearch==2.3.0
 elasticsearch_dsl==2.0.0
 pyramid_mailer==0.14.1


### PR DESCRIPTION
To avoid the following warning:

> .../c2corg/v6_api/.build/venv/lib/python3.5/site-packages/bcrypt/__init__.py:46: UserWarning: implicit cast to 'char *' from a different pointer type: will be forbidden in the future (check that the types are as you expect; use an explicit ffi.cast() if they are correct)
>   b"$" + prefix + b"$", rounds, salt, len(salt), output, len(output),