### PR TITLE
Add web-services for feed preferences and user following

### DIFF
--- a/c2corg_api/models/area_association.py
+++ b/c2corg_api/models/area_association.py
@@ -147,7 +147,8 @@ def get_areas(document, lang):
             AreaAssociation,
             Area.document_id == AreaAssociation.area_id). \
         options(load_only(
-            Area.document_id, Area.area_type, Area.version, Area.protected)). \
+            Area.document_id, Area.area_type, Area.version, Area.protected,
+            Area.type)). \
         options(joinedload(Area.locales).load_only(
             DocumentLocale.lang, DocumentLocale.title,
             DocumentLocale.version)). \

--- a/c2corg_api/models/feed.py
+++ b/c2corg_api/models/feed.py
@@ -48,6 +48,7 @@ User.has_area_filter = column_property(
     correlate_except(FilterArea),
     deferred=True
 )
+User.feed_filter_areas = relationship('Area', secondary=FilterArea.__table__)
 
 
 class FollowedUser(Base):

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -171,6 +171,7 @@ class BaseTestCase(unittest.TestCase):
         registry = self.app.app.registry
         self.mailer = get_mailer(registry)
         self.email_service = EmailService(self.mailer, settings)
+        EmailService.instance = None
 
         self.config = testing.setUp()
 

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -61,6 +61,12 @@ class BaseTestRest(BaseTestCase):
                 return
         self.fail('no error ({0}, {1})'.format(name, description))
 
+    def get_error(self, errors, name):  # noqa
+        for error in errors:
+            if name == error.get('name'):
+                return error
+        self.fail('no error for {0}'.format(name))
+
     def post_json_with_token(self, url, token, body={}, status=200):
         headers = self.add_authorization_header(token=token)
         r = self.app_post_json(url, body, headers=headers, status=status)

--- a/c2corg_api/tests/views/test_user_account.py
+++ b/c2corg_api/tests/views/test_user_account.py
@@ -1,0 +1,116 @@
+from c2corg_api.models.user import User
+from c2corg_api.models.user_profile import USERPROFILE_TYPE
+from c2corg_api.search import search_documents, elasticsearch_config
+from c2corg_api.tests.views.test_user import BaseUserTestRest
+
+
+class TestUserAccountRest(BaseUserTestRest):
+
+    def test_read_account_info(self):
+        url = '/users/account'
+        body = self.get_json_with_contributor(url, status=200)
+        self.assertBodyEqual(body, 'name', 'Contributor')
+        self.assertBodyEqual(body, 'email', 'contributor@camptocamp.org')
+        self.assertBodyEqual(body, 'forum_username', 'contributor')
+
+    def _update_account_field_discourse_up(self, field, value):
+        url = '/users/account'
+        currentpassword = self.global_passwords['contributor']
+
+        data = {
+            'currentpassword': currentpassword
+        }
+        data[field] = value
+        self.post_json_with_contributor(url, data, status=200)
+
+        self.assertEqual(1, int(self.discourse_client.sso_sync.called_count))
+
+    def _update_account_field_discourse_down(self, field, value):
+        self.set_discourse_down()
+
+        url = '/users/account'
+        currentpassword = self.global_passwords['contributor']
+
+        data = {
+            'currentpassword': currentpassword
+        }
+        data[field] = value
+        self.post_json_with_contributor(url, data, status=500)
+
+        self.assertEqual(1, int(self.discourse_client.sso_sync.called_count))
+
+    def test_update_account_email_discourse_up(self):
+        email_count = self.get_email_box_length()
+
+        new_email = 'superemail@localhost.localhost'
+        self._update_account_field_discourse_up('email', new_email)
+
+        user_id = self.global_userids['contributor']
+        user = self.session.query(User).get(user_id)
+        self.assertEqual(user.email_to_validate, new_email)
+        self.assertNotEqual(user.email, new_email)
+
+        email_count_after = self.get_email_box_length()
+        self.assertEqual(email_count_after, email_count + 1)
+
+        # Simulate confirmation email validation
+        nonce = self.extract_nonce('validate_change_email')
+        url_api_validation = '/users/validate_change_email/%s' % nonce
+        self.app_post_json(url_api_validation, {}, status=200)
+
+        self.session.expunge(user)
+        user = self.session.query(User).get(user_id)
+        self.assertEqual(user.email, new_email)
+        self.assertIsNone(user.validation_nonce)
+
+    def test_update_account_email_discourse_down(self):
+        new_email = 'superemail@localhost.localhost'
+        self._update_account_field_discourse_down('email', new_email)
+
+    def test_update_account_name_discourse_up(self):
+        self._update_account_field_discourse_up('name', 'changed')
+
+        user_id = self.global_userids['contributor']
+        user = self.session.query(User).get(user_id)
+        self.assertEqual(user.name, 'changed')
+
+        # check that the search index is updated with the new name
+        self.sync_es()
+        search_doc = search_documents[USERPROFILE_TYPE].get(
+            id=user_id,
+            index=elasticsearch_config['index'])
+
+        # and check that the cache version of the user profile was updated
+        self.check_cache_version(user_id, 2)
+
+        self.assertIsNotNone(search_doc['doc_type'])
+        self.assertEqual(
+            search_doc['title_en'], 'contributor changed contributor')
+
+    def test_update_account_name_discourse_down(self):
+        self._update_account_field_discourse_down('name', 'changed')
+
+    def test_update_account_forum_username_discourse_up(self):
+        self._update_account_field_discourse_up('forum_username', 'changed')
+
+        user_id = self.global_userids['contributor']
+        user = self.session.query(User).get(user_id)
+        self.assertEqual(user.forum_username, 'changed')
+
+    def test_update_account_forum_username_discourse_down(self):
+        self._update_account_field_discourse_down('forum_username', 'changed')
+
+    def test_update_preferred_lang(self):
+        user_id = self.global_userids['contributor']
+        user = self.session.query(User).get(user_id)
+        self.assertEqual(user.lang, 'fr')
+
+        request_body = {
+            'lang': 'en'
+        }
+        url = self._prefix + '/update_preferred_language'
+        self.post_json_with_contributor(url, request_body, status=200)
+
+        self.session.expunge(user)
+        user = self.session.query(User).get(user_id)
+        self.assertEqual(user.lang, 'en')

--- a/c2corg_api/tests/views/test_user_follow.py
+++ b/c2corg_api/tests/views/test_user_follow.py
@@ -1,0 +1,204 @@
+from c2corg_api.models.feed import FollowedUser
+from c2corg_api.models.user import User
+from c2corg_api.tests.views import BaseTestRest
+from c2corg_api.views.user_follow import get_follower_relation
+
+
+class BaseFollowTest(BaseTestRest):
+
+    def setUp(self):  # noqa
+        super(BaseFollowTest, self).setUp()
+
+        self.contributor = self.session.query(User).get(
+            self.global_userids['contributor'])
+        self.contributor2 = self.session.query(User).get(
+            self.global_userids['contributor2'])
+        self.moderator = self.session.query(User).get(
+            self.global_userids['moderator'])
+
+        self.session.add(FollowedUser(
+            followed_user_id=self.contributor2.id,
+            follower_user_id=self.contributor.id))
+
+        self.session.flush()
+
+    def is_following(self, followed_user_id, follower_user_id):
+        return get_follower_relation(
+            followed_user_id, follower_user_id) is not None
+
+
+class TestUserFollowRest(BaseFollowTest):
+
+    def setUp(self):  # noqa
+        super(TestUserFollowRest, self).setUp()
+        self._prefix = '/users/follow'
+
+    def test_follow_unauthenticated(self):
+        self.app_post_json(self._prefix, {}, status=403)
+
+    def test_follow(self):
+        request_body = {
+            'user_id': self.moderator.id
+        }
+
+        headers = self.add_authorization_header(username='contributor')
+        self.app_post_json(
+            self._prefix, request_body, status=200, headers=headers)
+
+        self.assertTrue(
+            self.is_following(self.moderator.id, self.contributor.id))
+
+    def test_follow_already_followed_user(self):
+        """ Test that following an already followed user does not raise an
+        error.
+        """
+        request_body = {
+            'user_id': self.contributor2.id
+        }
+
+        headers = self.add_authorization_header(username='contributor')
+        self.app_post_json(
+            self._prefix, request_body, status=200, headers=headers)
+
+        self.assertTrue(
+            self.is_following(self.contributor2.id, self.contributor.id))
+
+    def test_follow_invalid_user_id(self):
+        request_body = {
+            'user_id': -1
+        }
+
+        headers = self.add_authorization_header(username='contributor')
+        response = self.app_post_json(
+            self._prefix, request_body, status=400, headers=headers)
+
+        body = response.json
+        self.assertEqual(body.get('status'), 'error')
+        errors = body.get('errors')
+        self.assertIsNotNone(self.get_error(errors, 'user_id'))
+
+
+class TestUserUnfollowRest(BaseFollowTest):
+
+    def setUp(self):  # noqa
+        super(TestUserUnfollowRest, self).setUp()
+        self._prefix = '/users/unfollow'
+
+    def test_follow_unauthenticated(self):
+        self.app_post_json(self._prefix, {}, status=403)
+
+    def test_unfollow(self):
+        request_body = {
+            'user_id': self.contributor2.id
+        }
+
+        headers = self.add_authorization_header(username='contributor')
+        self.app_post_json(
+            self._prefix, request_body, status=200, headers=headers)
+
+        self.assertFalse(
+            self.is_following(self.moderator.id, self.contributor.id))
+
+    def test_unfollow_not_followed_user(self):
+        """ Test that unfollowing a not followed user does not raise an error.
+        """
+        request_body = {
+            'user_id': self.moderator.id
+        }
+
+        headers = self.add_authorization_header(username='contributor')
+        self.app_post_json(
+            self._prefix, request_body, status=200, headers=headers)
+
+        self.assertFalse(
+            self.is_following(self.moderator.id, self.contributor.id))
+
+    def test_follow_invalid_user_id(self):
+        request_body = {
+            'user_id': -1
+        }
+
+        headers = self.add_authorization_header(username='contributor')
+        response = self.app_post_json(
+            self._prefix, request_body, status=400, headers=headers)
+
+        body = response.json
+        self.assertEqual(body.get('status'), 'error')
+        errors = body.get('errors')
+        self.assertIsNotNone(self.get_error(errors, 'user_id'))
+
+
+class TestUserFollowingUserRest(BaseFollowTest):
+
+    def setUp(self):  # noqa
+        super(TestUserFollowingUserRest, self).setUp()
+        self._prefix = '/users/following-user'
+
+    def test_follow_unauthenticated(self):
+        self.app.get(self._prefix + '/123', status=403)
+
+    def test_following(self):
+        headers = self.add_authorization_header(username='contributor')
+        response = self.app.get(
+            self._prefix + '/{}'.format(self.contributor2.id),
+            status=200, headers=headers)
+        body = response.json
+
+        self.assertTrue(body['is_following'])
+
+    def test_following_not(self):
+        headers = self.add_authorization_header(username='contributor')
+        response = self.app.get(
+            self._prefix + '/{}'.format(self.moderator.id),
+            status=200, headers=headers)
+        body = response.json
+
+        self.assertFalse(body['is_following'])
+
+    def test_following_invalid_user_id(self):
+        headers = self.add_authorization_header(username='contributor')
+        response = self.app.get(
+            self._prefix + '/invalid-user-id',
+            status=400, headers=headers)
+
+        body = response.json
+        self.assertEqual(body.get('status'), 'error')
+        errors = body.get('errors')
+        self.assertIsNotNone(self.get_error(errors, 'id'))
+
+    def test_following_wrong_user_id(self):
+        headers = self.add_authorization_header(username='contributor')
+        response = self.app.get(
+            self._prefix + '/-1',
+            status=200, headers=headers)
+        body = response.json
+
+        self.assertFalse(body['is_following'])
+
+
+class TestUserFollowingRest(BaseFollowTest):
+
+    def setUp(self):  # noqa
+        super(TestUserFollowingRest, self).setUp()
+        self._prefix = '/users/following'
+
+    def test_follow_unauthenticated(self):
+        self.app.get(self._prefix, status=403)
+
+    def test_following(self):
+        headers = self.add_authorization_header(username='contributor')
+        response = self.app.get(self._prefix, status=200, headers=headers)
+        body = response.json
+
+        following_users = body['following']
+        self.assertEqual(1, len(following_users))
+        self.assertEqual(
+            self.contributor2.id, following_users[0]['document_id'])
+
+    def test_following_empty(self):
+        headers = self.add_authorization_header(username='contributor2')
+        response = self.app.get(self._prefix, status=200, headers=headers)
+        body = response.json
+
+        following_users = body['following']
+        self.assertEqual(0, len(following_users))

--- a/c2corg_api/tests/views/test_user_preferences.py
+++ b/c2corg_api/tests/views/test_user_preferences.py
@@ -1,0 +1,124 @@
+from c2corg_api.models.area import Area
+from c2corg_api.models.document import DocumentLocale
+from c2corg_api.models.feed import FilterArea
+from c2corg_api.models.user import User
+from c2corg_api.tests.views import BaseTestRest
+
+
+class TestUserPreferencesRest(BaseTestRest):
+
+    def setUp(self):  # noqa
+        super(TestUserPreferencesRest, self).setUp()
+        self._prefix = '/users/feed-preferences'
+
+        self.area1 = Area(
+            area_type='range',
+            locales=[
+                DocumentLocale(lang='fr', title='France'),
+                DocumentLocale(lang='de', title='Frankreich')
+            ]
+        )
+        self.area2 = Area(
+            area_type='range',
+            locales=[
+                DocumentLocale(lang='fr', title='Suisse')
+            ]
+        )
+
+        self.session.add_all([self.area1, self.area2])
+        self.session.flush()
+
+        self.contributor = self.session.query(User).get(
+            self.global_userids['contributor'])
+        self.contributor.feed_filter_areas.append(self.area1)
+        self.contributor.feed_filter_activities = ['hiking']
+        self.session.flush()
+
+    def test_get_preferences_unauthenticated(self):
+        self.app.get(self._prefix, status=403)
+
+    def test_get_preferences(self):
+        headers = self.add_authorization_header(username='contributor')
+        response = self.app.get(self._prefix, status=200, headers=headers)
+        body = response.json
+
+        self.assertEqual(['hiking'], body['activities'])
+        self.assertEqual(False, body['followed_only'])
+        areas = body['areas']
+        self.assertEqual(1, len(areas))
+        self.assertEqual(self.area1.document_id, areas[0]['document_id'])
+        locale = areas[0]['locales'][0]
+        self.assertEqual('fr', locale['lang'])
+
+    def test_get_preferences_lang(self):
+        """ Get the preferences with parameter `lang`.
+        """
+        headers = self.add_authorization_header(username='contributor')
+        response = self.app.get(
+            self._prefix + '?pl=de', status=200, headers=headers)
+        body = response.json
+
+        areas = body['areas']
+        locale = areas[0]['locales'][0]
+        self.assertEqual('de', locale['lang'])
+
+    def test_post_preferences_unauthenticated(self):
+        self.app_post_json(self._prefix, {}, status=403)
+
+    def test_post_preferences_invalid(self):
+        request_body = {
+            # missing 'followed_only'
+            # wrong activity
+            'activities': ['hiking', 'soccer'],
+            # wrong area entry
+            'areas': [{
+                'id': self.area2.document_id
+            }]
+        }
+
+        headers = self.add_authorization_header(username='contributor')
+        response = self.app_post_json(
+            self._prefix, request_body, status=400, headers=headers)
+
+        body = response.json
+        self.assertEqual(body.get('status'), 'error')
+        errors = body.get('errors')
+
+        self.assertIsNotNone(self.get_error(errors, 'activities.1'))
+        self.assertCorniceRequired(
+            self.get_error(errors, 'areas.0.document_id'),
+            'areas.0.document_id')
+        self.assertCorniceMissing(
+            self.get_error(errors, 'followed_only'), 'followed_only')
+
+    def test_post_preferences(self):
+        request_body = {
+            'followed_only': True,
+            'activities': ['hiking', 'skitouring'],
+            'areas': [{
+                'document_id': self.area2.document_id
+            }]
+        }
+
+        headers = self.add_authorization_header(username='contributor')
+        self.app_post_json(
+            self._prefix, request_body, status=200, headers=headers)
+
+        self.session.refresh(self.contributor)
+        self.assertTrue(self.contributor.feed_followed_only)
+        self.assertEquals(
+            ['hiking', 'skitouring'],
+            self.contributor.feed_filter_activities)
+
+        self.assertIsNone(
+            self.session.query(FilterArea).
+            filter(
+                FilterArea.user_id == self.contributor.id,
+                FilterArea.area_id == self.area1.document_id
+            ).first())
+        self.assertIsNotNone(
+            self.session.query(FilterArea).
+            filter(
+                FilterArea.user_id == self.contributor.id,
+                FilterArea.area_id == self.area2.document_id
+            ).first())

--- a/c2corg_api/tests/views/test_user_preferences.py
+++ b/c2corg_api/tests/views/test_user_preferences.py
@@ -5,11 +5,11 @@ from c2corg_api.models.user import User
 from c2corg_api.tests.views import BaseTestRest
 
 
-class TestUserPreferencesRest(BaseTestRest):
+class TestUserFilterPreferencesRest(BaseTestRest):
 
     def setUp(self):  # noqa
-        super(TestUserPreferencesRest, self).setUp()
-        self._prefix = '/users/feed-preferences'
+        super(TestUserFilterPreferencesRest, self).setUp()
+        self._prefix = '/users/preferences'
 
         self.area1 = Area(
             area_type='range',

--- a/c2corg_api/views/user.py
+++ b/c2corg_api/views/user.py
@@ -86,22 +86,6 @@ def validate_unique_attribute(attrname, request):
             request.errors.add('body', attrname, 'already used ' + attrname)
 
 
-@resource(path='/users/{id}', cors_policy=cors_policy)
-class UserRest(object):
-    def __init__(self, request):
-        self.request = request
-
-    @restricted_view(validators=validate_id)
-    def get(self):
-        id = self.request.validated['id']
-        user = DBSession. \
-            query(User). \
-            filter(User.id == id). \
-            first()
-
-        return to_json_dict(user, schema_user)
-
-
 def validate_captcha(request):
     """Validate the recaptcha sent by UI.
     """

--- a/c2corg_api/views/user.py
+++ b/c2corg_api/views/user.py
@@ -1,42 +1,30 @@
-from c2corg_api.models.cache_version import update_cache_version
-from c2corg_api.search.notify_sync import notify_es_syncer
-from c2corg_common.attributes import default_langs
-from pyramid.settings import asbool
+import datetime
+import logging
 
+import colander
+import requests
+from c2corg_api.emails.email_service import get_email_service
+from c2corg_api.models import DBSession
 from c2corg_api.models.document import DocumentLocale
-from c2corg_api.models.user_profile import UserProfile
-from c2corg_api.views.document import DocumentRest
-from functools import partial
-from pyramid.httpexceptions import HTTPInternalServerError
-
-from cornice.resource import resource
-
 from c2corg_api.models.user import (
         User, schema_user, schema_create_user, Purpose)
-
-from c2corg_api.views import (
-        cors_policy, json_view, restricted_view, restricted_json_view,
-        to_json_dict)
-from c2corg_api.views.validation import (
-        validate_id, validate_required_json_string)
-
-from c2corg_api.models import DBSession
-
+from c2corg_api.models.user_profile import UserProfile
+from c2corg_api.search.notify_sync import notify_es_syncer
+from c2corg_api.security.discourse_client import get_discourse_client
 from c2corg_api.security.roles import (
     try_login, log_validated_user_i_know_what_i_do,
     remove_token, extract_token, renew_token)
-
-from c2corg_api.security.discourse_client import get_discourse_client
-
-from c2corg_api.emails.email_service import get_email_service
-
+from c2corg_api.views import (
+        cors_policy, json_view, restricted_view, restricted_json_view,
+        to_json_dict)
+from c2corg_api.views.document import DocumentRest
+from c2corg_api.views.validation import validate_required_json_string
+from cornice.resource import resource
+from functools import partial
+from pyramid.httpexceptions import HTTPInternalServerError
+from pyramid.settings import asbool
 from sqlalchemy.sql.expression import and_
 
-import requests
-import colander
-import datetime
-
-import logging
 log = logging.getLogger(__name__)
 
 ENCODING = 'UTF-8'
@@ -325,161 +313,6 @@ class UserNonceValidationRest(object):
             request.errors.status = 403
             request.errors.add('body', 'user', 'Login failed')
             return None
-
-
-class UpdatePreferredLangSchema(colander.MappingSchema):
-    lang = colander.SchemaNode(
-            colander.String(),
-            validator=colander.OneOf(default_langs))
-
-
-@resource(path='/users/update_preferred_language', cors_policy=cors_policy)
-class UserPreferredLanguageRest(object):
-    schema = UpdatePreferredLangSchema()
-
-    def __init__(self, request):
-        self.request = request
-
-    @restricted_json_view(renderer='json', schema=schema)
-    def post(self):
-        request = self.request
-        userid = request.authenticated_userid
-        user = DBSession.query(User).get(userid)
-        user.lang = request.validated['lang']
-        return {}
-
-
-class UpdateAccountSchema(colander.MappingSchema):
-    email = colander.SchemaNode(
-            colander.String(),
-            missing=colander.drop,
-            validator=colander.All(
-                colander.Email(),
-                colander.Function(
-                    partial(is_unused_user_attribute, 'email'),
-                    'Already used email'
-                )
-            ))
-    name = colander.SchemaNode(
-            colander.String(),
-            missing=colander.drop,
-            validator=colander.Length(min=3))
-    forum_username = colander.SchemaNode(
-            colander.String(),
-            missing=colander.drop,
-            validator=colander.All(
-                colander.Length(min=3),
-                colander.Function(
-                    partial(is_unused_user_attribute, 'forum_username'),
-                    'Already used forum name'
-                )
-            ))
-    currentpassword = colander.SchemaNode(
-            colander.String(encoding=ENCODING),
-            validator=colander.Length(min=3))
-    newpassword = colander.SchemaNode(
-            colander.String(encoding=ENCODING),
-            missing=colander.drop,
-            validator=colander.Length(min=3))
-
-
-@resource(path='/users/account', cors_policy=cors_policy)
-class UserAccountRest(object):
-    updateschema = UpdateAccountSchema()
-
-    def __init__(self, request):
-        self.request = request
-
-    def get_user(self):
-        userid = self.request.authenticated_userid
-        return DBSession.query(User).get(userid)
-
-    @restricted_view(renderer='json', http_cache=0)
-    def get(self):
-        user = self.get_user()
-        return {
-            'email': user.email,
-            'name': user.name,
-            'forum_username': user.forum_username,
-            }
-
-    @restricted_json_view(renderer='json', schema=updateschema)
-    def post(self):
-        user = self.get_user()
-        request = self.request
-        validated = request.validated
-
-        result = {}
-
-        # Before all, check whether the user knows the current password
-        current_password = validated['currentpassword']
-        if not user.validate_password(current_password):
-            request.errors.add('body', 'currentpassword', 'Invalid password')
-            return
-
-        sync_sso = False
-
-        # update password if a new password is provided
-        if 'newpassword' in validated:
-            user.password = validated['newpassword']
-
-        # start email validation procedure if a new email is provided
-        email_link = None
-        if 'email' in validated and validated['email'] != user.email:
-            user.email_to_validate = validated['email']
-            user.update_validation_nonce(
-                    Purpose.change_email,
-                    VALIDATION_EXPIRE_DAYS)
-            email_service = get_email_service(self.request)
-            nonce = user.validation_nonce
-            settings = request.registry.settings
-            link = settings['mail.validate_change_email_url_template'].format(
-                '#', nonce)
-            email_link = link
-            result['email'] = validated['email']
-            result['sent_email'] = True
-            sync_sso = True
-
-        update_search_index = False
-        if 'name' in validated:
-            user.name = validated['name']
-            result['name'] = user.name
-            update_search_index = True
-            sync_sso = True
-
-        if 'forum_username' in validated:
-            user.forum_username = validated['forum_username']
-            result['forum_username'] = user.forum_username
-            update_search_index = True
-            sync_sso = True
-
-        # Synchronize everything except the new email (still stored
-        # in the email_to_validate attribute while validation is pending).
-        if sync_sso:
-            try:
-                client = get_discourse_client(request.registry.settings)
-                client.sync_sso(user)
-            except:
-                log.error('Error syncing with discourse', exc_info=True)
-                raise HTTPInternalServerError('Error with Discourse')
-
-        try:
-            DBSession.flush()
-        except:
-            log.warning('Error persisting user', exc_info=True)
-            raise HTTPInternalServerError('Error persisting user')
-
-        if email_link:
-            email_service.send_change_email_confirmation(user, link)
-
-        if update_search_index:
-            # when user name changes, the search index has to be updated
-            notify_es_syncer(self.request.registry.queue_config)
-
-            # also update the cache version of the user profile
-            update_cache_version(user.profile)
-
-        return result
 
 
 @resource(

--- a/c2corg_api/views/user_account.py
+++ b/c2corg_api/views/user_account.py
@@ -1,0 +1,173 @@
+import logging
+
+import colander
+from c2corg_api import DBSession
+from c2corg_api.emails.email_service import get_email_service
+from c2corg_api.models.cache_version import update_cache_version
+from c2corg_api.models.user import User, Purpose
+from c2corg_api.search.notify_sync import notify_es_syncer
+from c2corg_api.security.discourse_client import get_discourse_client
+from c2corg_api.views import cors_policy, restricted_json_view, restricted_view
+from c2corg_api.views.user import is_unused_user_attribute, ENCODING, \
+    VALIDATION_EXPIRE_DAYS
+from c2corg_common.attributes import default_langs
+from cornice.resource import resource
+from functools import partial
+from pyramid.httpexceptions import HTTPInternalServerError
+
+log = logging.getLogger(__name__)
+
+
+class UpdatePreferredLangSchema(colander.MappingSchema):
+    lang = colander.SchemaNode(
+            colander.String(),
+            validator=colander.OneOf(default_langs))
+
+
+@resource(path='/users/update_preferred_language', cors_policy=cors_policy)
+class UserPreferredLanguageRest(object):
+    schema = UpdatePreferredLangSchema()
+
+    def __init__(self, request):
+        self.request = request
+
+    @restricted_json_view(renderer='json', schema=schema)
+    def post(self):
+        request = self.request
+        userid = request.authenticated_userid
+        user = DBSession.query(User).get(userid)
+        user.lang = request.validated['lang']
+        return {}
+
+
+class UpdateAccountSchema(colander.MappingSchema):
+    email = colander.SchemaNode(
+            colander.String(),
+            missing=colander.drop,
+            validator=colander.All(
+                colander.Email(),
+                colander.Function(
+                    partial(is_unused_user_attribute, 'email'),
+                    'Already used email'
+                )
+            ))
+    name = colander.SchemaNode(
+            colander.String(),
+            missing=colander.drop,
+            validator=colander.Length(min=3))
+    forum_username = colander.SchemaNode(
+            colander.String(),
+            missing=colander.drop,
+            validator=colander.All(
+                colander.Length(min=3),
+                colander.Function(
+                    partial(is_unused_user_attribute, 'forum_username'),
+                    'Already used forum name'
+                )
+            ))
+    currentpassword = colander.SchemaNode(
+            colander.String(encoding=ENCODING),
+            validator=colander.Length(min=3))
+    newpassword = colander.SchemaNode(
+            colander.String(encoding=ENCODING),
+            missing=colander.drop,
+            validator=colander.Length(min=3))
+
+
+@resource(path='/users/account', cors_policy=cors_policy)
+class UserAccountRest(object):
+    updateschema = UpdateAccountSchema()
+
+    def __init__(self, request):
+        self.request = request
+
+    def get_user(self):
+        userid = self.request.authenticated_userid
+        return DBSession.query(User).get(userid)
+
+    @restricted_view(renderer='json', http_cache=0)
+    def get(self):
+        user = self.get_user()
+        return {
+            'email': user.email,
+            'name': user.name,
+            'forum_username': user.forum_username,
+            }
+
+    @restricted_json_view(renderer='json', schema=updateschema)
+    def post(self):
+        user = self.get_user()
+        request = self.request
+        validated = request.validated
+
+        result = {}
+
+        # Before all, check whether the user knows the current password
+        current_password = validated['currentpassword']
+        if not user.validate_password(current_password):
+            request.errors.add('body', 'currentpassword', 'Invalid password')
+            return
+
+        sync_sso = False
+
+        # update password if a new password is provided
+        if 'newpassword' in validated:
+            user.password = validated['newpassword']
+
+        # start email validation procedure if a new email is provided
+        email_link = None
+        if 'email' in validated and validated['email'] != user.email:
+            user.email_to_validate = validated['email']
+            user.update_validation_nonce(
+                    Purpose.change_email,
+                    VALIDATION_EXPIRE_DAYS)
+            email_service = get_email_service(self.request)
+            nonce = user.validation_nonce
+            settings = request.registry.settings
+            link = settings['mail.validate_change_email_url_template'].format(
+                '#', nonce)
+            email_link = link
+            result['email'] = validated['email']
+            result['sent_email'] = True
+            sync_sso = True
+
+        update_search_index = False
+        if 'name' in validated:
+            user.name = validated['name']
+            result['name'] = user.name
+            update_search_index = True
+            sync_sso = True
+
+        if 'forum_username' in validated:
+            user.forum_username = validated['forum_username']
+            result['forum_username'] = user.forum_username
+            update_search_index = True
+            sync_sso = True
+
+        # Synchronize everything except the new email (still stored
+        # in the email_to_validate attribute while validation is pending).
+        if sync_sso:
+            try:
+                client = get_discourse_client(request.registry.settings)
+                client.sync_sso(user)
+            except:
+                log.error('Error syncing with discourse', exc_info=True)
+                raise HTTPInternalServerError('Error with Discourse')
+
+        try:
+            DBSession.flush()
+        except:
+            log.warning('Error persisting user', exc_info=True)
+            raise HTTPInternalServerError('Error persisting user')
+
+        if email_link:
+            email_service.send_change_email_confirmation(user, link)
+
+        if update_search_index:
+            # when user name changes, the search index has to be updated
+            notify_es_syncer(self.request.registry.queue_config)
+
+            # also update the cache version of the user profile
+            update_cache_version(user.profile)
+
+        return result

--- a/c2corg_api/views/user_follow.py
+++ b/c2corg_api/views/user_follow.py
@@ -1,0 +1,174 @@
+import logging
+
+from c2corg_api import DBSession
+from c2corg_api.models.feed import FollowedUser
+from c2corg_api.models.user import User
+from c2corg_api.views import cors_policy, restricted_json_view
+from c2corg_api.views.document_listings import get_documents_for_ids
+from c2corg_api.views.document_schemas import user_profile_documents_config
+from c2corg_api.views.validation import validate_id, \
+    validate_preferred_lang_param
+from colander import MappingSchema, SchemaNode, Integer, required
+from cornice.resource import resource
+
+log = logging.getLogger(__name__)
+
+
+class FollowSchema(MappingSchema):
+    user_id = SchemaNode(Integer(), missing=required)
+
+
+def validate_user_id(request):
+    """ Check that the user exists.
+    """
+    user_id = request.validated['user_id']
+    user_exists_query = DBSession.query(User). \
+        filter(User.id == user_id). \
+        exists()
+    user_exists = DBSession.query(user_exists_query).scalar()
+
+    if not user_exists:
+        request.errors.add(
+            'body', 'user_id', 'user {0} does not exist'.format(user_id))
+
+
+def get_follower_relation(followed_user_id, follower_user_id):
+    return DBSession. \
+        query(FollowedUser). \
+        filter(FollowedUser.followed_user_id == followed_user_id). \
+        filter(FollowedUser.follower_user_id == follower_user_id). \
+        first()
+
+
+@resource(path='/users/follow', cors_policy=cors_policy)
+class UserFollowRest(object):
+
+    def __init__(self, request):
+        self.request = request
+
+    @restricted_json_view(schema=FollowSchema(), validators=[validate_user_id])
+    def post(self):
+        """ Follow the given user.
+        Creates a follower relation, so that the authenticated user is
+        following the given user.
+
+
+        Request:
+            `POST` `/users/follow`
+
+        Request body:
+            {'user_id': @user_id@}
+
+        """
+        followed_user_id = self.request.validated['user_id']
+        follower_user_id = self.request.authenticated_userid
+        follower_relation = get_follower_relation(
+            followed_user_id, follower_user_id)
+
+        if not follower_relation:
+            DBSession.add(FollowedUser(
+                followed_user_id=followed_user_id,
+                follower_user_id=follower_user_id))
+
+        return {}
+
+
+@resource(path='/users/unfollow', cors_policy=cors_policy)
+class UserUnfollowRest(object):
+
+    def __init__(self, request):
+        self.request = request
+
+    @restricted_json_view(schema=FollowSchema(), validators=[validate_user_id])
+    def post(self):
+        """ Unfollow the given user.
+
+        Request:
+            `POST` `/users/unfollow`
+
+        Request body:
+            {'user_id': @user_id@}
+
+        """
+        followed_user_id = self.request.validated['user_id']
+        follower_user_id = self.request.authenticated_userid
+        follower_relation = get_follower_relation(
+            followed_user_id, follower_user_id)
+
+        if follower_relation:
+            DBSession.delete(follower_relation)
+        else:
+            log.warn(
+                'tried to delete not existing follower relation '
+                '({0}, {1})'.format(followed_user_id, follower_user_id))
+
+        return {}
+
+
+@resource(path='/users/following-user/{id}', cors_policy=cors_policy)
+class UserFollowingUserRest(object):
+
+    def __init__(self, request):
+        self.request = request
+
+    @restricted_json_view(validators=[validate_id])
+    def get(self):
+        """ Check if the authenticated user follows the given user.
+
+        Request:
+            `GET` `users/following-user/{user_id}`
+
+        Example response:
+
+            {'is_following': true}
+
+        """
+        followed_user_id = self.request.validated['id']
+        follower_user_id = self.request.authenticated_userid
+        follower_relation = get_follower_relation(
+            followed_user_id, follower_user_id)
+
+        return {
+            'is_following': follower_relation is not None
+        }
+
+
+@resource(path='/users/following', cors_policy=cors_policy)
+class UserFollowingRest(object):
+
+    def __init__(self, request):
+        self.request = request
+
+    @restricted_json_view(validators=[validate_preferred_lang_param])
+    def get(self):
+        """ Get the users that the authenticated user is following.
+
+        Request:
+            `GET` `/users/following`
+
+        Example response:
+
+            {
+                'following': [
+                    {
+                        'document_id': 123,
+                        ...
+                    }
+                ]
+            }
+        """
+        follower_user_id = self.request.authenticated_userid
+
+        followed_user_ids = DBSession. \
+            query(FollowedUser.followed_user_id). \
+            filter(FollowedUser.follower_user_id == follower_user_id). \
+            all()
+        followed_user_ids = [user_id for (user_id, ) in followed_user_ids]
+
+        followed_users = get_documents_for_ids(
+            followed_user_ids, None, user_profile_documents_config). \
+            get('documents')
+
+        return {
+            'following': followed_users
+        }

--- a/c2corg_api/views/user_preferences.py
+++ b/c2corg_api/views/user_preferences.py
@@ -12,7 +12,7 @@ from colander import MappingSchema, SchemaNode, String, Boolean, Sequence, \
 from sqlalchemy.orm import joinedload, load_only
 
 
-class FeedPreferencesSchema(MappingSchema):
+class FilterPreferencesSchema(MappingSchema):
     activities = SchemaNode(
         Sequence(),
         SchemaNode(String(), validator=OneOf(activities)),
@@ -22,8 +22,8 @@ class FeedPreferencesSchema(MappingSchema):
     followed_only = SchemaNode(Boolean(), missing=required)
 
 
-@resource(path='/users/feed-preferences', cors_policy=cors_policy)
-class UserFeedPreferencesRest(object):
+@resource(path='/users/preferences', cors_policy=cors_policy)
+class UserFilterPreferencesRest(object):
 
     def __init__(self, request):
         self.request = request
@@ -52,7 +52,7 @@ class UserFeedPreferencesRest(object):
         """Get the filter preferences of the authenticated user.
 
         Request:
-            `GET` `/users/feed-preferences[?pl=...]`
+            `GET` `/users/preferences[?pl=...]`
 
         Parameters:
 
@@ -78,7 +78,7 @@ class UserFeedPreferencesRest(object):
             ]
         }
 
-    @restricted_json_view(schema=FeedPreferencesSchema())
+    @restricted_json_view(schema=FilterPreferencesSchema())
     def post(self):
         user = self.get_user(with_area_locales=False)
 

--- a/c2corg_api/views/user_preferences.py
+++ b/c2corg_api/views/user_preferences.py
@@ -1,0 +1,105 @@
+from c2corg_api import DBSession
+from c2corg_api.models.area import schema_listing_area, Area
+from c2corg_api.models.schema_utils import SchemaAssociationDoc
+from c2corg_api.models.user import User
+from c2corg_api.views import cors_policy, restricted_json_view, \
+    restricted_view, to_json_dict, set_best_locale
+from c2corg_api.views.validation import validate_preferred_lang_param
+from c2corg_common.attributes import activities
+from cornice.resource import resource
+from colander import MappingSchema, SchemaNode, String, Boolean, Sequence, \
+    OneOf, required
+from sqlalchemy.orm import joinedload, load_only
+
+
+class FeedPreferencesSchema(MappingSchema):
+    activities = SchemaNode(
+        Sequence(),
+        SchemaNode(String(), validator=OneOf(activities)),
+        missing=required)
+    areas = SchemaNode(
+        Sequence(), SchemaAssociationDoc(), missing=required)
+    followed_only = SchemaNode(Boolean(), missing=required)
+
+
+@resource(path='/users/feed-preferences', cors_policy=cors_policy)
+class UserFeedPreferencesRest(object):
+
+    def __init__(self, request):
+        self.request = request
+
+    def get_user(self, with_area_locales=True):
+        user_id = self.request.authenticated_userid
+
+        area_joinedload = \
+            joinedload(User.feed_filter_areas). \
+            load_only(
+                Area.document_id, Area.area_type, Area.version,
+                Area.protected, Area.type)
+
+        if with_area_locales:
+            area_joinedload = area_joinedload. \
+                joinedload('locales'). \
+                load_only('lang', 'title', 'version')
+
+        return DBSession. \
+            query(User). \
+            options(area_joinedload). \
+            get(user_id)
+
+    @restricted_view(validators=[validate_preferred_lang_param])
+    def get(self):
+        """Get the filter preferences of the authenticated user.
+
+        Request:
+            `GET` `/users/feed-preferences[?pl=...]`
+
+        Parameters:
+
+            `pl=...` (optional)
+            When set only the given locale will be included (if available).
+            Otherwise the default locale of the user will be used.
+        """
+        user = self.get_user()
+
+        lang = self.request.validated.get('lang')
+        if not lang:
+            lang = user.lang
+
+        areas = user.feed_filter_areas
+        if lang is not None:
+            set_best_locale(areas, lang)
+
+        return {
+            'followed_only': user.feed_followed_only,
+            'activities': user.feed_filter_activities,
+            'areas': [
+                to_json_dict(a, schema_listing_area) for a in areas
+            ]
+        }
+
+    @restricted_json_view(schema=FeedPreferencesSchema())
+    def post(self):
+        user = self.get_user(with_area_locales=False)
+
+        validated = self.request.validated
+        user.feed_followed_only = validated['followed_only']
+        user.feed_filter_activities = validated['activities']
+
+        # update filter areas: get all areas given in the request and
+        # then set on `user.feed_filter_areas`
+        area_ids = [
+            a['document_id'] for a in validated['areas']
+        ]
+        areas = []
+        if area_ids:
+            areas = DBSession. \
+                query(Area). \
+                filter(Area.document_id.in_(area_ids)). \
+                options(
+                    load_only(Area.document_id, Area.version, Area.type)). \
+                all()
+
+        user.feed_filter_areas = areas
+
+        return {}


### PR DESCRIPTION
Adds the following web-services:

- GET `/users/feed-preferences`: Get the preferences for the feed.
- POST `/users/feed-preferences`: Set the preferences for the feed.
- POST `/users/follow`: Follow a user given in the request body.
- POST `/users/unfollow`: Unfollow a user given in the request body.
- GET `/users/following/{user_id}`: Return if the authenticated user is following the given user.
- GET `/users/following`: Return a list with all users that the authenticated user is following.

Closes https://github.com/c2corg/v6_api/issues/401
Closes https://github.com/c2corg/v6_api/issues/402
Related to https://github.com/c2corg/v6_api/issues/403