### PR TITLE
Use pserve instead Gunicorn for development server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ template: $(TEMPLATE_FILES)
 .PHONY: serve
 serve: install development.ini
 	echo "#\n# Also remember to start the ElasticSearch syncer script with:\n# make -f ... run-syncer\n#"
-	.build/venv/bin/gunicorn --paste development.ini --reload
+	.build/venv/bin/pserve development.ini --reload
 
 .PHONY: run-syncer
 run-syncer: install development.ini


### PR DESCRIPTION
Gunicorn is hanging too often, I now also had the problem with the UI dev server.

Closes https://github.com/c2corg/v6_api/issues/353