### PR TITLE
Update feed on changes

### DIFF
--- a/c2corg_api/models/feed.py
+++ b/c2corg_api/models/feed.py
@@ -13,11 +13,12 @@ from c2corg_api.models.route import ROUTE_TYPE
 from c2corg_api.models.user import User
 from c2corg_api.models.user_profile import USERPROFILE_TYPE
 from c2corg_api.models.utils import ArrayOfEnum
+from c2corg_api.views.validation import association_keys
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql.base import ARRAY
 from sqlalchemy.orm import relationship, column_property
 from sqlalchemy.sql.elements import literal_column
-from sqlalchemy.sql.expression import select
+from sqlalchemy.sql.expression import select, text
 from sqlalchemy.sql.functions import func
 from sqlalchemy.sql.schema import Column, ForeignKey, PrimaryKeyConstraint, \
     CheckConstraint, Index
@@ -173,6 +174,20 @@ class DocumentChange(Base):
         Base.__table_args__
     )
 
+    def copy(self):
+        copy = DocumentChange()
+        copy.document_id = self.document_id
+        copy.document_type = self.document_type
+        copy.change_type = self.change_type
+        copy.activities = self.activities
+        copy.area_ids = self.area_ids
+        if copy.document_type == OUTING_TYPE:
+            copy.user_ids = self.user_ids
+        else:
+            copy.user_ids = []
+        return copy
+
+
 # For performance reasons, areas and users are referenced in simple integer
 # arrays in 'feed_document_changes', no PK-FK relations are set up. To prevent
 # inconsistencies, triggers are used.
@@ -257,7 +272,7 @@ def update_feed_document_create(document, user_id):
     """Creates a new entry in the feed table when creating a new document.
     """
     if document.redirects_to or \
-            document.type in [IMAGE_TYPE, USERPROFILE_TYPE, AREA_TYPE]:
+            document.type in NO_FEED_DOCUMENT_TYPES:
         return
 
     # make sure all updates are written to the database, so that areas and
@@ -327,11 +342,7 @@ def update_feed_document_update(document, user_id, update_types):
 
 
 def update_participants_of_outing(outing_id, user_id):
-    existing_change = DBSession. \
-        query(DocumentChange). \
-        filter(DocumentChange.document_id == outing_id). \
-        filter(DocumentChange.change_type.in_(['created', 'updated'])). \
-        first()
+    existing_change = get_existing_change(outing_id)
 
     if not existing_change:
         log.warn('no feed change for document {}'.format(outing_id))
@@ -354,6 +365,29 @@ def update_participants_of_outing(outing_id, user_id):
 
     DBSession.flush()
 
+    # now also update the participants of other feed entries of the outing:
+    # set `user_ids` to the union of the participant ids and the `user_id` of
+    # the entry
+    participants_and_editor = text(
+        'ARRAY(SELECT DISTINCT UNNEST(array_cat('
+        '   ARRAY[guidebook.feed_document_changes.user_id], :participants)) '
+        'ORDER BY 1)')
+    DBSession.execute(
+        DocumentChange.__table__.update().
+        where(DocumentChange.document_id == outing_id).
+        where(DocumentChange.change_id != existing_change.change_id).
+        values(user_ids=participants_and_editor),
+        {'participants': participant_ids}
+    )
+
+
+def get_existing_change(document_id):
+    return DBSession. \
+        query(DocumentChange). \
+        filter(DocumentChange.document_id == document_id). \
+        filter(DocumentChange.change_type.in_(['created', 'updated'])). \
+        first()
+
 
 def update_feed_association_update(
         _parent_document_id, parent_document_type,
@@ -365,6 +399,53 @@ def update_feed_association_update(
             child_document_type == OUTING_TYPE):
         return
     update_participants_of_outing(child_document_id, user_id)
+
+
+def update_feed_images_upload(images, images_in, user_id):
+    """When uploading a set of images, create a feed entry for the document
+     the images are linked to.
+    """
+    if not images or not images_in:
+        return
+    assert len(images) == len(images_in)
+
+    # get the document that the images were uploaded to
+    document_id, document_type = get_linked_document(images_in)
+    if not document_id or not document_type:
+        return
+
+    image1_id, image2_id, image3_id, more_images = get_images(
+        images, images_in, document_id, document_type)
+
+    if not image1_id:
+        return
+
+    # load the feed entry for the images
+    change = get_existing_change(document_id)
+    if not change:
+        log.warn('no feed change for document {}'.format(document_id))
+        return
+
+    if change.user_id == user_id:
+        # if the same user, only update time and change_type.
+        # this avoids that multiple entries are shown in the feed for the same
+        # document.
+        change.change_type = 'updated'
+        change.time = func.now()
+    else:
+        # if different user: copy the feed entry
+        change = change.copy()
+        change.change_type = 'added_photos'
+        change.user_id = user_id
+        change.user_ids = list(set(change.user_ids).union([user_id]))
+
+    change.image1_id = image1_id
+    change.image2_id = image2_id
+    change.image3_id = image3_id
+    change.more_images = more_images
+
+    DBSession.add(change)
+    DBSession.flush()
 
 
 def _get_participants_of_outing(outing_id):
@@ -413,3 +494,86 @@ def update_activities_of_changes(document):
         where(DocumentChange.document_id == document.document_id).
         values(activities=document.activities)
     )
+
+
+def get_linked_document(images_in):
+    """Given a list of image inputs, return a linked document from the first
+    image.
+    """
+    assert images_in
+
+    image_in = images_in[0]
+    associations = image_in.get('associations')
+    if not associations:
+        return None, None
+
+    for doc_key, docs in associations.items():
+        doc_type = association_keys[doc_key]
+
+        if doc_type in NO_FEED_DOCUMENT_TYPES:
+            continue
+
+        if docs:
+            return docs[0]['document_id'], doc_type
+
+    return None, None
+
+
+def get_images(images, images_in, document_id, document_type):
+    """Returns the first 3 images that are associated to the given document.
+    """
+    image_count = len(images)
+
+    # get all the images linked to the document
+    image_ids = []
+    for i in range(0, image_count):
+        image_in = images_in[i]
+
+        if is_linked_to_doc(image_in, document_id, document_type):
+            image_ids.append(images[0].document_id)
+
+        if len(image_ids) > 3:
+            break
+
+    # then select the first 3 images
+    image1_id = None
+    image2_id = None
+    image3_id = None
+    more_images = False
+
+    if image_ids:
+        image1_id = image_ids.pop(0)
+
+    if image_ids:
+        image2_id = image_ids.pop(0)
+
+    if image_ids:
+        image3_id = image_ids.pop(0)
+
+    if image_ids:
+        more_images = True
+
+    return image1_id, image2_id, image3_id, more_images
+
+
+def is_linked_to_doc(image_in, document_id, document_type):
+    """Check if the given document is linked to the image.
+    """
+    associations = image_in.get('associations')
+    if not associations:
+        return False
+
+    for doc_key, docs in associations.items():
+        doc_type = association_keys[doc_key]
+
+        if doc_type != document_type:
+            continue
+
+        for doc in docs:
+            if doc['document_id'] == document_id:
+                return True
+
+    return False
+
+# the document types that have no entry in the feed
+NO_FEED_DOCUMENT_TYPES = [IMAGE_TYPE, USERPROFILE_TYPE, AREA_TYPE]

--- a/c2corg_api/models/feed.py
+++ b/c2corg_api/models/feed.py
@@ -319,6 +319,7 @@ def update_feed_document_update(document, user_id, update_types):
     """
     if document.redirects_to:
         # TODO delete existing feed entry?
+        # see https://github.com/c2corg/v6_api/issues/386
         return
     if document.type in [IMAGE_TYPE, USERPROFILE_TYPE, AREA_TYPE]:
         return

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -106,6 +106,11 @@ class BaseTestRest(BaseTestCase):
         self.assertIsNotNone(cache_version)
         self.assertEqual(cache_version.version, version)
 
+    def get_feed_change(self, document_id):
+        return self.session.query(DocumentChange). \
+            filter(DocumentChange.document_id == document_id). \
+            first()
+
 
 class BaseDocumentTestRest(BaseTestRest):
 
@@ -975,11 +980,6 @@ class BaseDocumentTestRest(BaseTestRest):
                 search_doc['title_es'], document.get_locale('es').title)
 
         return (body, document)
-
-    def get_feed_change(self, document_id):
-        return self.session.query(DocumentChange). \
-            filter(DocumentChange.document_id == document_id). \
-            first()
 
 
 def get_locale(locales, lang):

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -106,10 +106,14 @@ class BaseTestRest(BaseTestCase):
         self.assertIsNotNone(cache_version)
         self.assertEqual(cache_version.version, version)
 
-    def get_feed_change(self, document_id):
-        return self.session.query(DocumentChange). \
-            filter(DocumentChange.document_id == document_id). \
-            first()
+    def get_feed_change(self, document_id, change_type=None):
+        q = self.session.query(DocumentChange). \
+            filter(DocumentChange.document_id == document_id)
+
+        if change_type:
+            q = q.filter(DocumentChange.change_type == change_type)
+
+        return q.first()
 
 
 class BaseDocumentTestRest(BaseTestRest):

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -4,6 +4,7 @@ import urllib.parse
 import urllib.error
 
 from c2corg_api.models.cache_version import CacheVersion
+from c2corg_api.models.feed import DocumentChange
 from c2corg_api.models.route import Route
 from c2corg_api.models.user import User
 from c2corg_api.models.user_profile import UserProfile
@@ -974,6 +975,11 @@ class BaseDocumentTestRest(BaseTestRest):
                 search_doc['title_es'], document.get_locale('es').title)
 
         return (body, document)
+
+    def get_feed_change(self, document_id):
+        return self.session.query(DocumentChange). \
+            filter(DocumentChange.document_id == document_id). \
+            first()
 
 
 def get_locale(locales, lang):

--- a/c2corg_api/tests/views/test_feed.py
+++ b/c2corg_api/tests/views/test_feed.py
@@ -175,6 +175,18 @@ class TestFeedRest(BaseFeedTestRest):
         document_ids = get_document_ids(body)
         self.assertEqual(0, len(document_ids))
 
+    def test_get_public_feed_redirected_document(self):
+        """ Test that redirected documents are ignored.
+        """
+        self.waypoint1.redirects_to = self.waypoint2.document_id
+        self.session.flush()
+
+        response = self.app.get(self._prefix, status=200)
+        body = response.json
+
+        feed = body['feed']
+        self.assertEqual(3, len(feed))
+
 
 class TestPersonalFeedRest(BaseFeedTestRest):
 

--- a/c2corg_api/tests/views/test_feed.py
+++ b/c2corg_api/tests/views/test_feed.py
@@ -381,22 +381,6 @@ class TestPersonalFeedRest(BaseFeedTestRest):
         feed = body['feed']
         self.assertEqual(0, len(feed))
 
-    def test_get_feed_filter_deactivated(self):
-        """ Get personal feed with filters deactivated (returns default feed).
-        """
-        # set an activity filter for the user
-        user = self.session.query(User).get(self.global_userids['contributor'])
-        user.feed_filter_activities = ['hiking']
-        self.session.flush()
-
-        headers = self.add_authorization_header(username='contributor')
-        response = self.app.get(
-            '/personal-feed?filter=0', status=200, headers=headers)
-        body = response.json
-
-        feed = body['feed']
-        self.assertEqual(4, len(feed))
-
 
 class TestProfileFeedRest(BaseFeedTestRest):
 

--- a/c2corg_api/tests/views/test_feed.py
+++ b/c2corg_api/tests/views/test_feed.py
@@ -369,6 +369,22 @@ class TestPersonalFeedRest(BaseFeedTestRest):
         feed = body['feed']
         self.assertEqual(0, len(feed))
 
+    def test_get_feed_filter_deactivated(self):
+        """ Get personal feed with filters deactivated (returns default feed).
+        """
+        # set an activity filter for the user
+        user = self.session.query(User).get(self.global_userids['contributor'])
+        user.feed_filter_activities = ['hiking']
+        self.session.flush()
+
+        headers = self.add_authorization_header(username='contributor')
+        response = self.app.get(
+            '/personal-feed?filter=0', status=200, headers=headers)
+        body = response.json
+
+        feed = body['feed']
+        self.assertEqual(4, len(feed))
+
 
 class TestProfileFeedRest(BaseFeedTestRest):
 

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -401,7 +401,10 @@ class TestOutingRest(BaseDocumentTestRest):
                  'weather': 'sunny'}
             ],
             'associations': {
-                'users': [{'document_id': self.global_userids['contributor']}],
+                'users': [
+                    {'document_id': self.global_userids['contributor']},
+                    {'document_id': self.global_userids['contributor2']}
+                ],
                 'routes': [{'document_id': self.route.document_id}],
                 # images are ignored
                 'images': [{'document_id': self.route.document_id}]
@@ -443,6 +446,10 @@ class TestOutingRest(BaseDocumentTestRest):
             (self.global_userids['contributor'], doc.document_id))
         self.assertIsNotNone(association_user)
 
+        association_user2 = self.session.query(Association).get(
+            (self.global_userids['contributor2'], doc.document_id))
+        self.assertIsNotNone(association_user2)
+
         association_user_log = self.session.query(AssociationLog). \
             filter(AssociationLog.parent_document_id ==
                    self.global_userids['contributor']). \
@@ -450,6 +457,16 @@ class TestOutingRest(BaseDocumentTestRest):
                    doc.document_id). \
             first()
         self.assertIsNotNone(association_user_log)
+
+        # check that a change is created in the feed
+        feed_change = self.get_feed_change(doc.document_id)
+        self.assertIsNotNone(feed_change)
+        self.assertEqual(feed_change.activities, ['skitouring'])
+        self.assertEqual(
+            feed_change.user_ids,
+            [self.global_userids['contributor'],
+             self.global_userids['contributor2']])
+        self.assertEqual(feed_change.area_ids, [])
 
     def test_post_set_default_geom_from_route(self):
         body = {

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -9,6 +9,7 @@ from c2corg_api.models.article import Article
 from c2corg_api.models.association import Association
 from c2corg_api.models.cache_version import get_cache_key, CacheVersion
 from c2corg_api.models.document_history import DocumentVersion
+from c2corg_api.models.feed import update_feed_document_create
 from c2corg_api.models.outing import Outing, OutingLocale
 from c2corg_api.models.topo_map import TopoMap
 from c2corg_api.models.topo_map_association import TopoMapAssociation
@@ -736,6 +737,15 @@ class TestWaypointRest(BaseDocumentTestRest):
             (waypoint.document_id, self.article1.document_id))
         self.assertIsNotNone(association_a)
 
+        # check that the feed change is updated
+        feed_change = self.get_feed_change(waypoint.document_id)
+        self.assertIsNotNone(feed_change)
+        self.assertEqual(
+            feed_change.user_ids, [self.global_userids['contributor']])
+        self.assertEqual(
+            feed_change.area_ids, [self.area1.document_id]
+        )
+
     def test_put_success_figures_and_lang_only(self):
         body_put = {
             'message': 'Update',
@@ -1212,6 +1222,7 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.waypoint_version = self.session.query(DocumentVersion). \
             filter(DocumentVersion.document_id == self.waypoint.document_id). \
             filter(DocumentVersion.lang == 'en').first()
+        update_feed_document_create(self.waypoint, user_id)
 
         self.waypoint2 = Waypoint(
             waypoint_type='climbing_outdoor', elevation=2,

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -552,6 +552,15 @@ class TestWaypointRest(BaseDocumentTestRest):
         self.check_cache_version(
             self.waypoint2.document_id, waypoint2_cache_key + 1)
 
+        # check that a change is created in the feed
+        feed_change = self.get_feed_change(doc.document_id)
+        self.assertIsNotNone(feed_change)
+        self.assertEqual(
+            feed_change.user_ids, [self.global_userids['contributor']])
+        self.assertEqual(
+            feed_change.area_ids, [self.area1.document_id]
+        )
+
     def test_put_wrong_document_id(self):
         body = {
             'document': {

--- a/c2corg_api/views/association.py
+++ b/c2corg_api/views/association.py
@@ -1,6 +1,7 @@
 from c2corg_api.models import DBSession
 from c2corg_api.models.cache_version import update_cache_version_associations
 from c2corg_api.models.document import Document
+from c2corg_api.models.feed import update_feed_association_update
 from c2corg_api.models.route import Route
 from c2corg_api.scripts.es import sync
 from c2corg_api.search.notify_sync import notify_es_syncer
@@ -78,6 +79,10 @@ class AssociationRest(object):
               'child_type': association.child_document_type}], [])
 
         notify_es_syncer_if_needed(association, self.request)
+        update_feed_association_update(
+            association.parent_document_id, association.parent_document_type,
+            association.child_document_id, association.child_document_type,
+            self.request.authenticated_userid)
 
         return {}
 
@@ -115,6 +120,10 @@ class AssociationRest(object):
               'child_type': association.child_document_type}])
 
         notify_es_syncer_if_needed(association, self.request)
+        update_feed_association_update(
+            association.parent_document_id, association.parent_document_type,
+            association.child_document_id, association.child_document_type,
+            self.request.authenticated_userid)
 
         return {}
 

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -13,7 +13,8 @@ from c2corg_api.models.document import (
     UpdateType, DocumentLocale, ArchiveDocumentLocale, ArchiveDocument,
     ArchiveDocumentGeometry, set_available_langs, get_available_langs)
 from c2corg_api.models.document_history import HistoryMetaData, DocumentVersion
-from c2corg_api.models.feed import update_feed_document_create
+from c2corg_api.models.feed import update_feed_document_create, \
+    update_feed_document_update
 from c2corg_api.models.topo_map import schema_listing_topo_map, \
     MAP_TYPE
 from c2corg_api.models.topo_map_association import update_maps_for_document, \
@@ -271,6 +272,7 @@ class DocumentRest(object):
         if update_types or associations:
             # update search index
             notify_es_syncer(self.request.registry.queue_config)
+            update_feed_document_update(document, user_id, update_types)
         if associations and (removed_associations or added_associations):
             update_cache_version_associations(
                 added_associations, removed_associations)

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -13,6 +13,7 @@ from c2corg_api.models.document import (
     UpdateType, DocumentLocale, ArchiveDocumentLocale, ArchiveDocument,
     ArchiveDocumentGeometry, set_available_langs, get_available_langs)
 from c2corg_api.models.document_history import HistoryMetaData, DocumentVersion
+from c2corg_api.models.feed import update_feed_document_create
 from c2corg_api.models.topo_map import schema_listing_topo_map, \
     MAP_TYPE
 from c2corg_api.models.topo_map_association import update_maps_for_document, \
@@ -200,6 +201,8 @@ class DocumentRest(object):
                 document, document_in['associations'], user_id)
             update_cache_version_associations(
                 added_associations, [], document.document_id)
+
+        update_feed_document_create(document, user_id)
 
         notify_es_syncer(self.request.registry.queue_config)
         return document

--- a/c2corg_api/views/feed.py
+++ b/c2corg_api/views/feed.py
@@ -276,10 +276,17 @@ def load_feed(changes, lang):
     if not changes:
         return {'feed': []}
 
-    # TODO deal with redirected documents
-
     documents_to_load = get_documents_to_load(changes)
     documents = load_documents(documents_to_load, lang)
+
+    # only return changes for which the document/user could be loaded
+    changes = [
+        c for c in changes
+        if documents.get(c.user_id) and documents.get(c.document_id)
+    ]
+
+    if not changes:
+        return {'feed': []}
 
     last_change = changes[-1]
     pagination_token = '{},{}'.format(
@@ -292,16 +299,24 @@ def load_feed(changes, lang):
                 'time': c.time.isoformat(),
                 'user': documents[c.user_id],
                 'participants': [
-                    documents[user_id] for user_id in c.user_ids
-                    if user_id != c.user_id
+                    documents[user_id]
+                    for user_id in c.user_ids
+                    if user_id != c.user_id and documents.get(user_id)
                 ],
                 'change_type': c.change_type,
                 'document': documents[c.document_id],
-                'image1': documents[c.image1_id] if c.image1_id else None,
-                'image2': documents[c.image2_id] if c.image2_id else None,
-                'image3': documents[c.image3_id] if c.image3_id else None,
+                'image1':
+                    documents[c.image1_id]
+                    if c.image1_id and documents.get(c.image1_id) else None,
+                'image2':
+                    documents[c.image2_id]
+                    if c.image2_id and documents.get(c.image2_id) else None,
+                'image3':
+                    documents[c.image3_id]
+                    if c.image3_id and documents.get(c.image3_id) else None,
                 'more_images': c.more_images
-            } for c in changes
+            }
+            for c in changes
         ],
         'pagination_token': pagination_token
     }

--- a/c2corg_api/views/feed.py
+++ b/c2corg_api/views/feed.py
@@ -70,27 +70,15 @@ class PersonalFeedRest(object):
         """Get the personal homepage feed for the authenticated user.
 
         Request:
-            `GET` `/personal-feed[?pl=...][&limit=...][&token=...][&filter=...]`  # noqa
+            `GET` `/personal-feed[?pl=...][&limit=...][&token=...]`
 
-        Parameters:
-
-            `filter=(0|1)` (optional)
-            If `filter` is set to `0`, the filter preferences of the user will
-            be ignored and the default/public feed is returned.
-
-            For the other parameters see above for '/feed'.
+        Parameters: See above for '/feed'.
 
         """
         user_id = self.request.authenticated_userid
         lang, token_id, token_time, limit = get_params(self.request)
-
-        if self.request.GET.get('filter') == '0':
-            # return default feed if filters are disabled
-            changes = get_changes_of_feed(token_id, token_time, limit)
-        else:
-            changes = get_changes_of_personal_feed(
-                user_id, token_id, token_time, limit)
-
+        changes = get_changes_of_personal_feed(
+            user_id, token_id, token_time, limit)
         return load_feed(changes, lang)
 
 

--- a/c2corg_api/views/feed.py
+++ b/c2corg_api/views/feed.py
@@ -70,15 +70,27 @@ class PersonalFeedRest(object):
         """Get the personal homepage feed for the authenticated user.
 
         Request:
-            `GET` `/personal-feed[?pl=...][&limit=...][&token=...]`
+            `GET` `/personal-feed[?pl=...][&limit=...][&token=...][&filter=...]`  # noqa
 
-        Parameters: See above for '/feed'.
+        Parameters:
+
+            `filter=(0|1)` (optional)
+            If `filter` is set to `0`, the filter preferences of the user will
+            be ignored and the default/public feed is returned.
+
+            For the other parameters see above for '/feed'.
 
         """
         user_id = self.request.authenticated_userid
         lang, token_id, token_time, limit = get_params(self.request)
-        changes = get_changes_of_personal_feed(
-            user_id, token_id, token_time, limit)
+
+        if self.request.GET.get('filter') == '0':
+            # return default feed if filters are disabled
+            changes = get_changes_of_feed(token_id, token_time, limit)
+        else:
+            changes = get_changes_of_personal_feed(
+                user_id, token_id, token_time, limit)
+
         return load_feed(changes, lang)
 
 


### PR DESCRIPTION
The feed is updated...

* When a new document is created (no user or image).
* When a new user is associated to an outing.
* When a group of images is uploaded.

Related to https://github.com/c2corg/v6_api/issues/403