### PR TITLE
Add missing articles to the document_configs

### DIFF
--- a/c2corg_api/views/document_schemas.py
+++ b/c2corg_api/views/document_schemas.py
@@ -215,5 +215,6 @@ document_configs = {
     IMAGE_TYPE: image_documents_config,
     AREA_TYPE: area_documents_config,
     MAP_TYPE: topo_map_documents_config,
+    ARTICLE_TYPE: article_documents_config,
     USERPROFILE_TYPE: user_profile_documents_config
 }


### PR DESCRIPTION
It caused `KeyError: 'c'` on the feed page before.

More info in the issue thread that should be closed after this merge

Close https://github.com/c2corg/v6_api/issues/437