### PR TITLE
Allow to create images without title

### DIFF
--- a/c2corg_api/models/image.py
+++ b/c2corg_api/models/image.py
@@ -20,7 +20,8 @@ from c2corg_api.models import schema, enums, Base
 from c2corg_api.models.utils import copy_attributes, ArrayOfEnum
 from c2corg_api.models.document import (
     ArchiveDocument, Document, geometry_schema_overrides,
-    schema_document_locale, schema_attributes)
+    schema_attributes, DocumentLocale,
+    schema_locale_attributes)
 from c2corg_common import document_types
 
 IMAGE_TYPE = document_types.IMAGE_TYPE
@@ -114,6 +115,19 @@ class ArchiveImage(_ImageMixin, ArchiveDocument):
 
     __table_args__ = Base.__table_args__
 
+# special schema for image locales: images can be created without title
+schema_image_locale = SQLAlchemySchemaNode(
+    DocumentLocale,
+    # whitelisted attributes
+    includes=schema_locale_attributes,
+    overrides={
+        'version': {
+            'missing': None
+        },
+        'title': {
+            'missing': ''
+        }
+    })
 
 schema_image = SQLAlchemySchemaNode(
     Image,
@@ -127,7 +141,7 @@ schema_image = SQLAlchemySchemaNode(
             'missing': None
         },
         'locales': {
-            'children': [schema_document_locale]
+            'children': [schema_image_locale]
         },
         'geometry': geometry_schema_overrides
     })

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -254,18 +254,17 @@ class TestImageRest(BaseTestImage):
         self.assertEqual(locale.get('lang'), 'en')
 
     def test_post_missing_title(self):
-        body_post = {
-            'filename': 'post_missing_title.jpg',
-            'activities': ['paragliding'],
-            'image_type': 'collaborative',
-            'height': 1500,
-            'locales': [
-                {'lang': 'en'}
-            ]
-        }
-        body = self.post_missing_title(body_post)
-        errors = body.get('errors')
-        self.assertEqual(len(errors), 2)
+        request_body = self._post_success_document()
+        del request_body['locales'][0]['title']
+
+        body, doc = self.post_success(request_body)
+        self.assertEqual(doc.locales[0].title, '')
+
+    def test_post_missing_title_none(self):
+        request_body = self._post_success_document()
+        request_body['locales'][0]['title'] = None
+
+        self.post_success(request_body)
 
     @patch('c2corg_api.views.image.requests.post',
            return_value=Mock(status_code=200))
@@ -434,7 +433,7 @@ class TestImageRest(BaseTestImage):
                 'image_type': 'personal',
                 'height': 2000,
                 'locales': [
-                    {'lang': 'en', 'title': 'Mont Blanc from the air',
+                    {'lang': 'en',
                      'description': 'A nice picture',
                      'version': self.image4.get_locale('en').version}
                 ]
@@ -691,8 +690,12 @@ class TestImageListRest(BaseTestImage):
     def test_post_multiple(self, post_mock):
         body = {
             'images': [
-                self._post_success_document({'filename': 'post_image1.jpg'}),
-                self._post_success_document({'filename': 'post_image2.jpg'})]
+                self._post_success_document({
+                    'filename': 'post_image2.jpg',
+                    'locales': [{'lang': 'en'}]
+                }),
+                self._post_success_document({'filename': 'post_image1.jpg'})
+            ]
         }
         body, doc = self.post_success(body)
         self._validate_post_success(body, doc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ git+https://github.com/tsauerwein/cornice.git@nested-none
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@234086
+git+https://github.com/c2corg/v6_common.git@af97c18
 
 # Discourse API client
 git+https://github.com/c2corg/pydiscourse.git@65e398343bbbc74fdb71cca4637c9f808e5adfb2


### PR DESCRIPTION
The `title` field can be omitted (e.g. `"locales":[{"lang":"fr"}]`) or set to `null` (e.g. `"locales":[{"lang":"fr", "title": null}]`).

Closes https://github.com/c2corg/v6_api/issues/399