### PR TITLE
Fix cornice branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ git+https://github.com/tsauerwein/ColanderAlchemy.git@c2corg
 
 # Cornice>1.2.1
 # needs: https://github.com/mozilla-services/cornice/pull/359
-git+https://github.com/tsauerwein/cornice.git@nested-none
+git+https://github.com/tsauerwein/cornice.git@nested-none-c2corg
 
 # c2corg_common project
 # for development use a local checkout


### PR DESCRIPTION
For Cornice we are currently still using an unmerged branch in my Cornice repository. I have a PR open with this branch. But today I rebased this branch with the latest version of Cornice, which unfortunately makes our tests fail.

So, I created a separate branch containing the fix on an old Cornice version.