### PR TITLE
Do not expose login user name

### DIFF
--- a/c2corg_api/models/user.py
+++ b/c2corg_api/models/user.py
@@ -1,7 +1,6 @@
 import bcrypt
 from c2corg_api.models.utils import ArrayOfEnum
 from c2corg_common.attributes import default_langs
-from c2corg_api.models.schema_utils import restrict_schema
 from c2corg_api.models.user_profile import UserProfile
 from sqlalchemy import (
     Boolean,
@@ -173,7 +172,3 @@ schema_create_user = SQLAlchemySchemaNode(
             'validator': colander.OneOf(default_langs)
         }
     })
-
-schema_association_user = restrict_schema(schema_user, [
-    'id', 'username', 'name'
-])

--- a/c2corg_api/models/user_profile.py
+++ b/c2corg_api/models/user_profile.py
@@ -40,7 +40,6 @@ class UserProfile(_UserProfileMixin, Document):
         'inherit_condition': Document.document_id == document_id
     }
 
-    username = association_proxy('user', 'username')
     name = association_proxy('user', 'name')
     forum_username = association_proxy('user', 'forum_username')
 

--- a/c2corg_api/search/mappings/user_mapping.py
+++ b/c2corg_api/search/mappings/user_mapping.py
@@ -17,9 +17,8 @@ class SearchUser(SearchDocument):
             return search_document
 
         for locale in document.locales:
-            search_document['title_' + locale.lang] = '{0} {1} {2}'.format(
-                document.username or '', document.name or '',
-                document.forum_username or '')
+            search_document['title_' + locale.lang] = '{0} {1}'.format(
+                document.name or '', document.forum_username or '')
 
         return search_document
 

--- a/c2corg_api/tests/scripts/es/test_sync.py
+++ b/c2corg_api/tests/scripts/es/test_sync.py
@@ -104,10 +104,10 @@ class SyncTest(BaseTestCase):
         self.assertEqual(doc['_op_type'], 'index')
         self.assertEqual(doc['_id'], document_id)
         self.assertEqual(
-            doc['title_en'], 'contributor Contributor contributor')
+            doc['title_en'], 'Contributor contributor')
         self.assertEqual(doc['description_en'], 'Me')
         self.assertEqual(
-            doc['title_fr'], 'contributor Contributor contributor')
+            doc['title_fr'], 'Contributor contributor')
         self.assertEqual(doc['description_fr'], 'Moi')
 
     @patch('c2corg_api.scripts.es.sync.ElasticBatch')

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -42,7 +42,7 @@ class TestOutingRest(BaseDocumentTestRest):
         doc4 = body['documents'][3]
         self.assertIn('author', doc4)
         author = doc4['author']
-        self.assertEqual(author['username'], 'contributor')
+        self.assertNotIn('username', author)
         self.assertEqual(author['name'], 'Contributor')
         self.assertEqual(author['user_id'], self.global_userids['contributor'])
 
@@ -975,7 +975,8 @@ class TestOutingRest(BaseDocumentTestRest):
             self.assertEqual(len(versions), 1)
             self.assertEqual(getattr(self, 'locale_' + lang).title, title)
             for r in versions:
-                self.assertEqual(r['username'], username)
+                self.assertEqual(r['name'], 'Contributor')
+                self.assertNotIn('username', r)
                 self.assertEqual(r['user_id'], user_id)
                 self.assertIn('written_at', r)
                 self.assertIn('version_id', r)

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -760,7 +760,8 @@ class TestRouteRest(BaseDocumentTestRest):
             self.assertEqual(len(versions), 1)
             self.assertEqual(getattr(self, 'locale_' + lang).title, title)
             for r in versions:
-                self.assertEqual(r['username'], username)
+                self.assertEqual(r['name'], 'Contributor')
+                self.assertNotIn('username', r)
                 self.assertEqual(r['user_id'], user_id)
                 self.assertIn('written_at', r)
                 self.assertIn('version_id', r)

--- a/c2corg_api/tests/views/test_user.py
+++ b/c2corg_api/tests/views/test_user.py
@@ -219,7 +219,7 @@ class TestUserRest(BaseUserTestRest):
         self.assertIsNotNone(search_doc)
 
         self.assertIsNotNone(search_doc['doc_type'])
-        self.assertEqual(search_doc['title_fr'], 'test Max Mustermann testf')
+        self.assertEqual(search_doc['title_fr'], 'Max Mustermann testf')
 
     def test_register_discourse_down(self):
         self.set_discourse_down()

--- a/c2corg_api/tests/views/test_user_account.py
+++ b/c2corg_api/tests/views/test_user_account.py
@@ -86,7 +86,7 @@ class TestUserAccountRest(BaseUserTestRest):
 
         self.assertIsNotNone(search_doc['doc_type'])
         self.assertEqual(
-            search_doc['title_en'], 'contributor changed contributor')
+            search_doc['title_en'], 'changed contributor')
 
     def test_update_account_name_discourse_down(self):
         self._update_account_field_discourse_down('name', 'changed')

--- a/c2corg_api/tests/views/test_user_profile.py
+++ b/c2corg_api/tests/views/test_user_profile.py
@@ -33,7 +33,8 @@ class TestUserProfileRest(BaseDocumentTestRest):
         body = self.get_collection(user='contributor')
         doc = body['documents'][0]
         self.assertIn('areas', doc)
-        self.assertIn('username', doc)
+        self.assertIn('name', doc)
+        self.assertNotIn('username', doc)
         self.assertNotIn('geometry', doc)
 
     def test_get_collection_paginated(self):
@@ -77,7 +78,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
         body = response.json
 
         self.assertEqual(body.get('not_authorized'), True)
-        self.assertIn('username', body)
+        self.assertNotIn('username', body)
         self.assertIn('name', body)
         self.assertNotIn('locales', body)
         self.assertNotIn('geometry', body)
@@ -91,7 +92,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
         self.session.flush()
 
         body = self.get(self.profile1, check_title=False)
-        self.assertIn('username', body)
+        self.assertNotIn('username', body)
         self.assertIn('name', body)
         self.assertIn('locales', body)
         self.assertIn('geometry', body)
@@ -101,7 +102,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
         self._assert_geometry(body)
         self.assertIsNone(body['locales'][0].get('title'))
         self.assertNotIn('maps', body)
-        self.assertIn('username', body)
+        self.assertNotIn('username', body)
         self.assertIn('name', body)
 
     def test_get_unconfirmed_user(self):
@@ -337,7 +338,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
         self.assertEquals(profile.get_locale('es').description, 'Yo')
         search_doc = self._check_es_index()
         self.assertEqual(
-            search_doc['title_es'], 'contributor Contributor contributor')
+            search_doc['title_es'], 'Contributor contributor')
 
     def _check_es_index(self):
         sync_es(self.session)
@@ -346,9 +347,9 @@ class TestUserProfileRest(BaseDocumentTestRest):
             index=elasticsearch_config['index'])
         self.assertEqual(search_doc['doc_type'], self.profile1.type)
         self.assertEqual(
-            search_doc['title_en'], 'contributor Contributor contributor')
+            search_doc['title_en'], 'Contributor contributor')
         self.assertEqual(
-            search_doc['title_fr'], 'contributor Contributor contributor')
+            search_doc['title_fr'], 'Contributor contributor')
         return search_doc
 
     def _assert_geometry(self, body):

--- a/c2corg_api/tests/views/test_user_profile.py
+++ b/c2corg_api/tests/views/test_user_profile.py
@@ -104,6 +104,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
         self.assertNotIn('maps', body)
         self.assertNotIn('username', body)
         self.assertIn('name', body)
+        self.assertIn('forum_username', body)
 
     def test_get_unconfirmed_user(self):
         headers = self.add_authorization_header(username='contributor')

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -1109,8 +1109,8 @@ class TestWaypointRest(BaseDocumentTestRest):
             self.assertEqual(len(versions), 1)
             self.assertEqual(getattr(self, 'locale_' + lang).title, title)
             for r in versions:
-                self.assertEqual(r['username'], username)
-                self.assertIsNotNone(r['name'])
+                self.assertEqual(r['name'], 'Contributor')
+                self.assertNotIn('username', r)
                 self.assertEqual(r['user_id'], user_id)
                 self.assertIn('written_at', r)
                 self.assertIn('version_id', r)

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -98,7 +98,7 @@ def to_json_dict(obj, schema, with_special_locales_attrs=False):
     # it because it's not a real column)
     special_attributes = [
         'available_langs', 'associations', 'maps', 'areas', 'author',
-        'protected', 'type', 'name', 'username', 'creator'
+        'protected', 'type', 'name', 'creator'
     ]
     for attr in special_attributes:
         if hasattr(obj, attr):
@@ -190,7 +190,6 @@ def set_creator(documents, field_name):
     t = DBSession.query(
         ArchiveDocument.document_id.label('document_id'),
         User.id.label('user_id'),
-        User.username.label('username'),
         User.name.label('name'),
         over(
             func.rank(), partition_by=ArchiveDocument.document_id,
@@ -208,15 +207,14 @@ def set_creator(documents, field_name):
         filter(ArchiveDocument.document_id.in_(document_ids)). \
         subquery('t')
     query = DBSession.query(
-            t.c.document_id, t.c.user_id, t.c.username, t.c.name). \
+            t.c.document_id, t.c.user_id, t.c.name). \
         filter(t.c.rank == 1)
 
     author_for_documents = {
         document_id: {
-            'username': username,
             'name': name,
             'user_id': user_id
-        } for document_id, user_id, username, name in query
+        } for document_id, user_id, name in query
     }
 
     for document in documents:

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -98,7 +98,7 @@ def to_json_dict(obj, schema, with_special_locales_attrs=False):
     # it because it's not a real column)
     special_attributes = [
         'available_langs', 'associations', 'maps', 'areas', 'author',
-        'protected', 'type', 'name', 'creator'
+        'protected', 'type', 'name', 'forum_username', 'creator'
     ]
     for attr in special_attributes:
         if hasattr(obj, attr):

--- a/c2corg_api/views/document_listings.py
+++ b/c2corg_api/views/document_listings.py
@@ -150,9 +150,10 @@ def _load_documents(document_ids, clazz, base_query):
 
 def add_load_for_profiles(document_query, clazz):
     if clazz == UserProfile:
-        # for profiles load name together from the associated user
+        # for profiles load names together from the associated user
         document_query = add_profile_filter(document_query, clazz). \
-            options(contains_eager('user').load_only(User.id, User.name))
+            options(contains_eager('user').load_only(
+                User.id, User.name, User.forum_username))
     return document_query
 
 

--- a/c2corg_api/views/document_listings.py
+++ b/c2corg_api/views/document_listings.py
@@ -150,9 +150,9 @@ def _load_documents(document_ids, clazz, base_query):
 
 def add_load_for_profiles(document_query, clazz):
     if clazz == UserProfile:
-        # for profiles load username/name together from the associated user
+        # for profiles load name together from the associated user
         document_query = add_profile_filter(document_query, clazz). \
-            options(contains_eager('user'))
+            options(contains_eager('user').load_only(User.id, User.name))
     return document_query
 
 

--- a/c2corg_api/views/document_version.py
+++ b/c2corg_api/views/document_version.py
@@ -2,6 +2,7 @@ from c2corg_api.caching import cache_document_version
 from c2corg_api.models import DBSession
 from c2corg_api.models.cache_version import get_cache_key
 from c2corg_api.models.document_history import DocumentVersion
+from c2corg_api.models.user import User
 from c2corg_api.views import to_json_dict, to_seconds, etag_cache
 from pyramid.httpexceptions import HTTPNotFound
 from sqlalchemy.orm import joinedload
@@ -43,7 +44,8 @@ class DocumentVersionRest(object):
             self, document_id, lang, version_id, clazz, locale_clazz, schema,
             adapt_schema):
         version = DBSession.query(DocumentVersion) \
-            .options(joinedload('history_metadata').joinedload('user')) \
+            .options(joinedload('history_metadata').joinedload('user').
+                     load_only(User.id, User.name)) \
             .options(joinedload(
                 DocumentVersion.document_archive.of_type(clazz))) \
             .options(joinedload(
@@ -80,7 +82,6 @@ def serialize_version(version):
     return {
         'version_id': version.id,
         'user_id': version.history_metadata.user_id,
-        'username': version.history_metadata.user.username,
         'name': version.history_metadata.user.name,
         'comment': version.history_metadata.comment,
         'written_at': to_seconds(version.history_metadata.written_at)

--- a/c2corg_api/views/user.py
+++ b/c2corg_api/views/user.py
@@ -362,6 +362,7 @@ def token_to_response(user, token, request):
     return {
         'token': token.value,
         'username': user.username,
+        'name': user.name,
         'forum_username': user.forum_username,
         'expire': int(expire_time.total_seconds()),
         'roles': roles,

--- a/c2corg_api/views/user_profile.py
+++ b/c2corg_api/views/user_profile.py
@@ -33,7 +33,7 @@ class UserProfileRest(DocumentRest):
             filter(User.id == requested_user_id). \
             filter(User.email_validated). \
             options(load_only(
-                User.id, User.is_profile_public, User.name, User.username)). \
+                User.id, User.is_profile_public, User.name)). \
             first()
 
         if not requested_user:
@@ -48,8 +48,7 @@ class UserProfileRest(DocumentRest):
             return {
                 'not_authorized': True,
                 'document_id': requested_user.id,
-                'name': requested_user.name,
-                'username': requested_user.username
+                'name': requested_user.name
             }
 
     @restricted_json_view(


### PR DESCRIPTION
It looks like `username` is still used on the UI side, I will take a look. We can wait with merging this PR after the beta release.

Closes https://github.com/c2corg/v6_api/issues/436
Closes https://github.com/c2corg/v6_api/issues/420