### PR TITLE
Update c2corg_common

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ git+https://github.com/tsauerwein/cornice.git@nested-none-c2corg
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@a154635
+git+https://github.com/c2corg/v6_common.git@3d57114
 
 # Discourse API client
 git+https://github.com/c2corg/pydiscourse.git@65e398343bbbc74fdb71cca4637c9f808e5adfb2


### PR DESCRIPTION
To make sure https://github.com/c2corg/v6_common/pull/39 is taken into account.