### PR TITLE
Views for sitemaps

### DIFF
--- a/c2corg_api/caching.py
+++ b/c2corg_api/caching.py
@@ -24,13 +24,15 @@ cache_document_listing = create_region('listing')
 cache_document_history = create_region('history')
 cache_document_version = create_region('version')
 cache_document_info = create_region('info')
+cache_sitemap = create_region('sitemap')
 
 caches = [
     cache_document_detail,
     cache_document_listing,
     cache_document_history,
     cache_document_version,
-    cache_document_info
+    cache_document_info,
+    cache_sitemap
 ]
 
 

--- a/c2corg_api/tests/models/test_cache_version.py
+++ b/c2corg_api/tests/models/test_cache_version.py
@@ -31,6 +31,8 @@ class TestCacheVersion(BaseTestCase):
         cache_version = self.session.query(CacheVersion).get(
             waypoint.document_id)
         self.assertIsNotNone(cache_version)
+        self.assertIsNotNone(cache_version.version)
+        self.assertIsNotNone(cache_version.last_updated)
 
     def test_update_cache_version_single_wp(self):
         waypoint = Waypoint(waypoint_type='summit')
@@ -40,11 +42,15 @@ class TestCacheVersion(BaseTestCase):
 
         cache_version = self.session.query(CacheVersion).get(
             waypoint.document_id)
+        cache_version.last_updated = datetime.datetime(2016, 1, 1, 12, 1, 0)
+        self.session.flush()
         current_version = cache_version.version
+        current_last_updated = cache_version.last_updated
 
         update_cache_version(waypoint)
         self.session.refresh(cache_version)
         self.assertEqual(cache_version.version, current_version + 1)
+        self.assertNotEqual(cache_version.last_updated, current_last_updated)
 
         cache_version_untouched = self.session.query(CacheVersion).get(
             waypoint_unrelated.document_id)

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -278,7 +278,7 @@ class BaseDocumentTestRest(BaseTestRest):
         return body, locale
 
     def get_info_404(self):
-        self.app.get(self._prefix + '/-9999/en/info', status=404)
+        self.app.get(self._prefix + '/9999999/en/info', status=404)
 
     def get_lang(self, reference, user=None):
         headers = {} if not user else \
@@ -317,8 +317,10 @@ class BaseDocumentTestRest(BaseTestRest):
         headers = {} if not user else \
             self.add_authorization_header(username=user)
 
-        self.app.get(self._prefix + '/-9999', headers=headers, status=404)
-        self.app.get(self._prefix + '/-9999?l=es', headers=headers, status=404)
+        self.app.get(
+            self._prefix + '/9999999', headers=headers, status=404)
+        self.app.get(
+            self._prefix + '/9999999?l=es', headers=headers, status=404)
 
     def post_error(self, request_body, user='contributor'):
         response = self.app_post_json(self._prefix, request_body,
@@ -534,11 +536,12 @@ class BaseDocumentTestRest(BaseTestRest):
 
     def put_wrong_document_id(self, request_body, user='contributor'):
         response = self.app_put_json(
-            self._prefix + '/-9999', request_body, status=403)
+            self._prefix + '/9999999', request_body, status=403)
 
         headers = self.add_authorization_header(username=user)
         response = self.app_put_json(
-            self._prefix + '/-9999', request_body, headers=headers, status=404)
+            self._prefix + '/9999999', request_body, headers=headers,
+            status=404)
 
         body = response.json
         self.assertEqual(body['status'], 'error')

--- a/c2corg_api/tests/views/test_area.py
+++ b/c2corg_api/tests/views/test_area.py
@@ -170,7 +170,7 @@ class TestAreaRest(BaseDocumentTestRest):
     def test_put_wrong_document_id(self):
         body = {
             'document': {
-                'document_id': '-9999',
+                'document_id': '9999999',
                 'version': self.area1.version,
                 'area_type': 'range',
                 'locales': [

--- a/c2corg_api/tests/views/test_article.py
+++ b/c2corg_api/tests/views/test_article.py
@@ -268,7 +268,7 @@ class TestArticleRest(BaseDocumentTestRest):
     def test_put_wrong_document_id(self):
         body = {
             'document': {
-                'document_id': '-9999',
+                'document_id': '9999999',
                 'version': self.article1.version,
                 'categories': ['site_info'],
                 'activities': ['hiking'],

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -362,7 +362,7 @@ class TestImageRest(BaseTestImage):
     def test_put_wrong_document_id(self):
         body = {
             'document': {
-                'document_id': '-9999',
+                'document_id': '9999999',
                 'version': self.image.version,
                 'filename': 'put_wrong_document_id.jpg',
                 'activities': ['paragliding'],

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -493,7 +493,7 @@ class TestOutingRest(BaseDocumentTestRest):
     def test_put_wrong_document_id(self):
         body = {
             'document': {
-                'document_id': '-9999',
+                'document_id': '9999999',
                 'version': self.outing.version,
                 'activities': ['skitouring'],
                 'date_start': '2016-01-01',

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -420,7 +420,7 @@ class TestRouteRest(BaseDocumentTestRest):
     def test_put_wrong_document_id(self):
         body = {
             'document': {
-                'document_id': '-9999',
+                'document_id': '9999999',
                 'version': self.route.version,
                 'activities': ['hiking'],
                 'elevation_min': 700,

--- a/c2corg_api/tests/views/test_sitemap.py
+++ b/c2corg_api/tests/views/test_sitemap.py
@@ -1,0 +1,83 @@
+from c2corg_api.models.route import RouteLocale, Route
+from c2corg_api.models.waypoint import WaypointLocale, Waypoint
+
+from c2corg_api.tests.views import BaseTestRest
+
+
+class TestSitemapRest(BaseTestRest):
+    def setUp(self):  # noqa
+        super(TestSitemapRest, self).setUp()
+        self._prefix = '/sitemaps'
+
+        self.waypoint1 = Waypoint(
+            waypoint_type='summit', elevation=2000,
+            locales=[
+                WaypointLocale(
+                    lang='fr', title='Dent de Crolles')
+            ])
+        self.session.add(self.waypoint1)
+        self.waypoint2 = Waypoint(
+            waypoint_type='summit', elevation=4985,
+            locales=[
+                WaypointLocale(
+                    lang='en', title='Mont Blanc'),
+                WaypointLocale(
+                    lang='fr', title='Mont Blanc')
+            ])
+        self.session.add(self.waypoint2)
+        self.route = Route(
+            activities=['skitouring'], elevation_max=1500, elevation_min=700,
+            locales=[
+                RouteLocale(
+                    lang='fr', title='Mont Blanc du ciel',
+                    title_prefix='Mont Blanc'
+                )
+            ])
+        self.session.add(self.route)
+        self.session.flush()
+
+    def test_get(self):
+        response = self.app.get(self._prefix, status=200)
+        body = response.json
+
+        sitemaps = body['sitemaps']
+        self.assertIn('/sitemaps/w/0', sitemaps)
+        self.assertIn('/sitemaps/r/0', sitemaps)
+
+    def test_get_sitemap_invalid_doc_type(self):
+        response = self.app.get(self._prefix + '/z/0', status=400)
+        errors = response.json['errors']
+        self.assertError(errors, 'doc_type', 'invalid doc_type')
+
+    def test_get_sitemap_invalid_page(self):
+        response = self.app.get(self._prefix + '/a/-123', status=400)
+        errors = response.json['errors']
+        self.assertError(errors, 'i', 'invalid i')
+
+    def test_get_waypoint_sitemap(self):
+        response = self.app.get(self._prefix + '/w/0', status=200)
+        body = response.json
+
+        pages = body['pages']
+        self.assertEqual(len(pages), 3)
+        page1 = pages[0]
+        self.assertEqual(self.waypoint1.document_id, page1['document_id'])
+        self.assertIn('title', page1)
+        self.assertIn('lang', page1)
+        self.assertIn('lastmod', page1)
+
+    def test_get_waypoint_sitemap_no_pages(self):
+        self.app.get(self._prefix + '/w/1', status=404)
+
+    def test_get_route_sitemap(self):
+        response = self.app.get(self._prefix + '/r/0', status=200)
+        body = response.json
+
+        pages = body['pages']
+        self.assertEqual(len(pages), 1)
+        page1 = pages[0]
+        self.assertEqual(self.route.document_id, page1['document_id'])
+        self.assertIn('title', page1)
+        self.assertIn('title_prefix', page1)
+        self.assertIn('lang', page1)
+        self.assertIn('lastmod', page1)

--- a/c2corg_api/tests/views/test_sitemap.py
+++ b/c2corg_api/tests/views/test_sitemap.py
@@ -41,8 +41,12 @@ class TestSitemapRest(BaseTestRest):
         body = response.json
 
         sitemaps = body['sitemaps']
-        self.assertIn('/sitemaps/w/0', sitemaps)
-        self.assertIn('/sitemaps/r/0', sitemaps)
+        self.assertIsNotNone(
+            next(filter(lambda s: s['url'] == '/sitemaps/w/0', sitemaps), None)
+        )
+        self.assertIsNotNone(
+            next(filter(lambda s: s['url'] == '/sitemaps/r/0', sitemaps), None)
+        )
 
     def test_get_sitemap_invalid_doc_type(self):
         response = self.app.get(self._prefix + '/z/0', status=400)

--- a/c2corg_api/tests/views/test_topo_map.py
+++ b/c2corg_api/tests/views/test_topo_map.py
@@ -165,7 +165,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
     def test_put_wrong_document_id(self):
         body = {
             'document': {
-                'document_id': '-9999',
+                'document_id': '9999999',
                 'version': self.map1.version,
                 'editor': 'IGN',
                 'scale': '25000',

--- a/c2corg_api/tests/views/test_user_follow.py
+++ b/c2corg_api/tests/views/test_user_follow.py
@@ -169,7 +169,7 @@ class TestUserFollowingUserRest(BaseFollowTest):
     def test_following_wrong_user_id(self):
         headers = self.add_authorization_header(username='contributor')
         response = self.app.get(
-            self._prefix + '/-1',
+            self._prefix + '/9999999999',
             status=200, headers=headers)
         body = response.json
 

--- a/c2corg_api/tests/views/test_user_profile.py
+++ b/c2corg_api/tests/views/test_user_profile.py
@@ -158,7 +158,7 @@ class TestUserProfileRest(BaseDocumentTestRest):
     def test_put_wrong_document_id(self):
         body = {
             'document': {
-                'document_id': '-9999',
+                'document_id': '9999999',
                 'version': self.profile1.version,
                 'categories': ['mountain_guide'],
                 'locales': [

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -594,7 +594,7 @@ class TestWaypointRest(BaseDocumentTestRest):
     def test_put_wrong_document_id(self):
         body = {
             'document': {
-                'document_id': '-9999',
+                'document_id': '9999999',
                 'version': self.waypoint.version,
                 'waypoint_type': 'summit',
                 'elevation': 1234,

--- a/c2corg_api/views/sitemap.py
+++ b/c2corg_api/views/sitemap.py
@@ -1,0 +1,148 @@
+import logging
+
+from c2corg_api import DBSession
+from c2corg_api.models.cache_version import CacheVersion
+from c2corg_api.models.document import Document, DocumentLocale
+from c2corg_api.models.route import ROUTE_TYPE, RouteLocale
+from c2corg_api.models.user_profile import USERPROFILE_TYPE
+from c2corg_api.views import cors_policy
+from c2corg_api.views.validation import create_int_validator, \
+    validate_document_type
+from cornice.resource import resource, view
+from pyramid.httpexceptions import HTTPNotFound
+from sqlalchemy.sql.functions import func
+from math import ceil
+
+log = logging.getLogger(__name__)
+
+# Search engines accept not more than 50000 urls per sitemap,
+# see http://www.sitemaps.org/protocol.html
+PAGES_PER_SITEMAP = 50000
+
+
+validate_page = create_int_validator('i')
+
+
+@resource(
+    collection_path='/sitemaps', path='/sitemaps/{doc_type}/{i}',
+    cors_policy=cors_policy)
+class SitemapRest(object):
+
+    def __init__(self, request):
+        self.request = request
+
+    @view()
+    def collection_get(self):
+        """ Returns the information needed to generate a sitemap index file.
+        See: http://www.sitemaps.org/protocol.html
+
+        The response consists of a list of URLs to request the information
+        needed to generate the sitemap linked from the sitemap index.
+
+        E.g.
+
+            {
+                "sitemaps": [
+                    "/sitemaps/w/0",
+                    "/sitemaps/a/0",
+                    "/sitemaps/i/0",
+                    "/sitemaps/i/1",
+                    "/sitemaps/i/2",
+                    "/sitemaps/i/3",
+                    "/sitemaps/i/4",
+                    "/sitemaps/i/5",
+                    ...
+                ]
+            }
+        """
+        document_locales_per_type = DBSession. \
+            query(Document.type, func.count().label('count')). \
+            join(
+                DocumentLocale,
+                Document.document_id == DocumentLocale.document_id). \
+            filter(Document.type != USERPROFILE_TYPE). \
+            group_by(Document.type). \
+            all()
+
+        sitemaps = []
+        for doc_type, count in document_locales_per_type:
+            num_sitemaps = ceil(count / PAGES_PER_SITEMAP)
+            sitemaps_for_type = [
+                '/sitemaps/{}/{}'.format(doc_type, i)
+                for i in range(0, num_sitemaps)
+            ]
+            sitemaps.extend(sitemaps_for_type)
+
+        return {
+            'sitemaps': sitemaps
+        }
+
+    @view(validators=[validate_page, validate_document_type])
+    def get(self):
+        """ Returns the information needed to generate a sitemap for a given
+        type and sitemap page number.
+        """
+        doc_type = self.request.validated['doc_type']
+        i = self.request.validated['i']
+
+        fields = [
+            Document.document_id, DocumentLocale.lang, DocumentLocale.title,
+            CacheVersion.last_updated
+        ]
+
+        # include `title_prefix` for routes
+        is_route = doc_type == ROUTE_TYPE
+        if is_route:
+            fields.append(RouteLocale.title_prefix)
+
+        base_query = DBSession. \
+            query(*fields). \
+            select_from(Document). \
+            join(DocumentLocale,
+                 Document.document_id == DocumentLocale.document_id)
+
+        if is_route:
+            # joining on `RouteLocale.__table_` instead of `RouteLocale` to
+            # avoid that SQLAlchemy create an additional join on DocumentLocale
+            base_query = base_query. \
+                join(RouteLocale.__table__,
+                     DocumentLocale.id == RouteLocale.id)
+
+        base_query = base_query. \
+            join(CacheVersion,
+                 Document.document_id == CacheVersion.document_id). \
+            filter(Document.redirects_to.is_(None)). \
+            filter(Document.type == doc_type). \
+            order_by(Document.document_id, DocumentLocale.lang). \
+            limit(PAGES_PER_SITEMAP). \
+            offset(PAGES_PER_SITEMAP * i)
+
+        document_locales = base_query.all()
+
+        if not document_locales:
+            raise HTTPNotFound()
+
+        return {
+            'pages': [
+                self._format_page(locale, is_route)
+                for locale in document_locales
+            ]
+        }
+
+    def _format_page(self, document_locale, is_route):
+        if not is_route:
+            doc_id, lang, title, last_updated = document_locale
+        else:
+            doc_id, lang, title, last_updated, title_prefix = document_locale
+
+        page = {
+            'document_id': doc_id,
+            'lang': lang,
+            'title': title,
+            'lastmod': last_updated.isoformat()
+        }
+
+        if is_route:
+            page['title_prefix'] = title_prefix
+
+        return page

--- a/c2corg_api/views/sitemap.py
+++ b/c2corg_api/views/sitemap.py
@@ -20,8 +20,10 @@ from c2corg_api import caching
 log = logging.getLogger(__name__)
 
 # Search engines accept not more than 50000 urls per sitemap,
+# and the sitemap files may not exceed 10 MB. With 50000 urls the sitemaps
+# are not bigger than 9MB, but to be safe we are using 45000 urls per sitemap.
 # see http://www.sitemaps.org/protocol.html
-PAGES_PER_SITEMAP = 50000
+PAGES_PER_SITEMAP = 45000
 
 
 validate_page = create_int_validator('i')

--- a/c2corg_api/views/sitemap.py
+++ b/c2corg_api/views/sitemap.py
@@ -105,7 +105,11 @@ def _get_sitemap_index():
     for doc_type, count in document_locales_per_type:
         num_sitemaps = ceil(count / PAGES_PER_SITEMAP)
         sitemaps_for_type = [
-            '/sitemaps/{}/{}'.format(doc_type, i)
+            {
+                'url': '/sitemaps/{}/{}'.format(doc_type, i),
+                'doc_type': doc_type,
+                'i': i
+            }
             for i in range(0, num_sitemaps)
             ]
         sitemaps.extend(sitemaps_for_type)

--- a/c2corg_api/views/validation.py
+++ b/c2corg_api/views/validation.py
@@ -21,7 +21,10 @@ from dateutil import parser as datetime_parser
 def create_int_validator(field):
     def validator(request, **kwargs):
         try:
-            request.validated[field] = int(request.matchdict[field])
+            val = int(request.matchdict[field])
+            if val < 0:
+                raise ValueError
+            request.validated[field] = val
         except ValueError:
             request.errors.add('querystring', field, 'invalid ' + field)
     return validator

--- a/c2corg_api/views/validation.py
+++ b/c2corg_api/views/validation.py
@@ -9,6 +9,7 @@ from c2corg_api.models.user_profile import USERPROFILE_TYPE
 from c2corg_api.models.waypoint import WAYPOINT_TYPE
 from c2corg_common.associations import valid_associations
 from c2corg_common.attributes import default_langs
+from c2corg_common import document_types
 from colander import null
 from cornice.errors import Errors
 from webob.descriptors import parse_int_safe
@@ -49,6 +50,18 @@ def validate_lang(request, **kwargs):
     """
     lang = request.matchdict['lang']
     validate_lang_(lang, request)
+
+
+def validate_document_type(request, **kwargs):
+    """Checks if the document type given in the url as match-parameter
+    is correct (".../{doc_type}").
+    """
+    doc_type = request.matchdict['doc_type']
+    if doc_type is not None:
+        if doc_type in document_types.ALL:
+            request.validated['doc_type'] = doc_type
+            return
+    request.errors.add('querystring', 'doc_type', 'invalid doc_type')
 
 
 def validate_lang_param(request, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ git+https://github.com/tsauerwein/cornice.git@nested-none-2.1.0-c2corg
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@3d57114
+git+https://github.com/c2corg/v6_common.git@b705a82
 
 # Discourse API client
 git+https://github.com/c2corg/pydiscourse.git@65e398343bbbc74fdb71cca4637c9f808e5adfb2


### PR DESCRIPTION
This PR adds web-services that are consumed by the UI server-side to generate sitemaps for SEO:

* `/sitemaps` returns a list of URLs to request sitemap information for a document type (paginated). The web-service is used by the UI to generate a [sitemap index](http://www.sitemaps.org/protocol.html#index).
For example:
```
{
	"sitemaps": [{
				"url": "/sitemaps/w/0",
				"i": 0,
				"doc_type": "w"
			}, {
				"url": "/sitemaps/i/0",
				"i": 0,
				"doc_type": "i"
			}, {
				"url": "/sitemaps/i/1",
				"i": 1,
				"doc_type": "i"
			},
```

* `/sitemaps/{doc_type}/{i}` returns the information needed to generate a sitemap for a document type.
For example: `/sitemaps/w/0`
```
{
	"pages": [{
		"lastmod": "2016-10-28T11:07:39.540612",
		"document_id": 37191,
		"title": "Patraflon",
		"lang": "fr"
	}, {
		"lastmod": "2016-10-28T11:07:39.540612",
		"document_id": 37192,
		"title": "Pointe de Tosse",
		"lang": "fr"
	}, 
```

The sitemaps are cached for 1 day.

Closes https://github.com/c2corg/v6_api/issues/205