### PR TITLE
Fix issue 468 - problem when creating a new article (and waypoint)

### DIFF
--- a/c2corg_api/models/cache_version.py
+++ b/c2corg_api/models/cache_version.py
@@ -357,6 +357,9 @@ def update_cache_version_for_map(topo_map):
 def update_cache_version_associations(
         added_associations, removed_associations, ignore_document_id=None):
     changed_associations = added_associations + removed_associations
+    if not changed_associations:
+        return
+
     documents_to_update = set()
     waypoints_to_update = set()
     routes_to_update = set()
@@ -372,7 +375,7 @@ def update_cache_version_associations(
                 association['child_type'] == OUTING_TYPE:
             routes_to_update.add(association['parent_id'])
 
-    if ignore_document_id is not None and len(documents_to_update):
+    if ignore_document_id is not None:
         documents_to_update.remove(ignore_document_id)
 
     if documents_to_update:

--- a/c2corg_api/models/cache_version.py
+++ b/c2corg_api/models/cache_version.py
@@ -372,7 +372,7 @@ def update_cache_version_associations(
                 association['child_type'] == OUTING_TYPE:
             routes_to_update.add(association['parent_id'])
 
-    if ignore_document_id is not None:
+    if ignore_document_id is not None and len(documents_to_update):
         documents_to_update.remove(ignore_document_id)
 
     if documents_to_update:

--- a/c2corg_api/tests/views/test_article.py
+++ b/c2corg_api/tests/views/test_article.py
@@ -174,6 +174,35 @@ class TestArticleRest(BaseDocumentTestRest):
     def test_post_missing_content_type(self):
         self.post_missing_content_type({})
 
+    def test_post_empty_assoc_in_new_c_document(self):
+        body = {
+            'document_id': 0,
+            'type': '',
+            'quality': 'excellent',
+            'activities': ['hiking', 'skitouring'],
+            'categories': ['mountain_environment'],
+            'article_type': 'collab',
+            'associations': {
+                 'waypoints': [],
+                 'waypoint_children': [],
+                 'routes': [],
+                 'all_routes': {'total': 0, 'documents': []},
+                 'users': [],
+                 'recent_outings': {'total': 0, 'documents': []},
+                 'articles': [],
+                 'images': [],
+                 'areas': []
+            },
+            'locales': [{
+                'lang': 'en',
+                'title': 'new testing article',
+                'description': 'some description',
+                'summary': 'some summary'
+            }]
+        }
+
+        body, doc = self.post_success(body, user='moderator')
+
     def test_post_success(self):
         body = {
             'document_id': 123456,

--- a/c2corg_api/tests/views/test_article.py
+++ b/c2corg_api/tests/views/test_article.py
@@ -354,7 +354,8 @@ class TestArticleRest(BaseDocumentTestRest):
                     ],
                     'articles': [
                         {'document_id': self.article2.document_id}
-                    ]
+                    ],
+                    'images': []
                 },
                 'geometry': {
                     'geom':

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -485,8 +485,8 @@ class TestWaypointRest(BaseDocumentTestRest):
             },
             'waypoint_type': 'summit',
             'elevation': 3779,
-            'locales': [
-                {'id': 3456, 'version': 4567,
+            'locales': [{
+                'id': 3456, 'version': 4567,
                 'lang': 'en', 'title': 'Mont Pourri',
                 'access': 'y'}
             ],

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -473,6 +473,38 @@ class TestWaypointRest(BaseDocumentTestRest):
             '"swimming-pool" is not one of'))
         self.assertEqual(errors[0].get('name'), 'waypoint_type')
 
+    def test_post_empty_assoc_in_new_w_document(self):
+        body = {
+            'document_id': 0,
+            'version': 2345,
+            'geometry': {
+                'document_id': 5678, 'version': 6789,
+                'geom': '{"type": "Point", "coordinates": [635956, 5723604]}',
+                'geom_detail':
+                    '{"type": "Point", "coordinates": [635956, 5723604]}'
+            },
+            'waypoint_type': 'summit',
+            'elevation': 3779,
+            'locales': [
+                {'id': 3456, 'version': 4567,
+                'lang': 'en', 'title': 'Mont Pourri',
+                'access': 'y'}
+            ],
+            'associations': {
+                 'waypoints': [],
+                 'waypoint_children': [],
+                 'routes': [],
+                 'all_routes': {'total': 0, 'documents': []},
+                 'users': [],
+                 'recent_outings': {'total': 0, 'documents': []},
+                 'articles': [],
+                 'images': [],
+                 'areas': []
+            }
+        }
+
+        body, doc = self.post_success(body, user='moderator')
+
     def test_post_success(self):
         body = {
             'document_id': 1234,
@@ -485,10 +517,10 @@ class TestWaypointRest(BaseDocumentTestRest):
             },
             'waypoint_type': 'summit',
             'elevation': 3779,
-            'locales': [
-                {'id': 3456, 'version': 4567,
-                 'lang': 'en', 'title': 'Mont Pourri',
-                 'access': 'y'}
+            'locales': [{
+                'id': 3456, 'version': 4567,
+                'lang': 'en', 'title': 'Mont Pourri',
+                'access': 'y'}
             ],
             'associations': {
                 'waypoint_children': [


### PR DESCRIPTION
Can it be this simple (one line fix)? Test for WP/Article works now. On UI I do not experience any problem now.

When we are creating new document without any previous associations, we have no `documents_to_update` and we can't remove any ignored documents when it has nothing archived yet that can be ignored.

Close https://github.com/c2corg/v6_api/issues/468