### PR TITLE
Manage climbing_outdoor_type during migration

### DIFF
--- a/c2corg_api/scripts/migration/documents/routes.py
+++ b/c2corg_api/scripts/migration/documents/routes.py
@@ -81,9 +81,9 @@ class MigrateRoutes(MigrateDocuments):
             activities = ['skitouring']
 
         climbing_outdoor_type = None
-        if 'rock_climbing' in activities and not ('hiking' in activities) :
+        if 'rock_climbing' in activities and 'hiking' not in activities:
             climbing_outdoor_type = 'multi'
-        
+
         orientations = self.convert_type(
             document_in.facing, MigrateRoutes.orientation_types)
         if orientations is not None:

--- a/c2corg_api/scripts/migration/documents/routes.py
+++ b/c2corg_api/scripts/migration/documents/routes.py
@@ -80,6 +80,10 @@ class MigrateRoutes(MigrateDocuments):
             # (in v6 activities are required)
             activities = ['skitouring']
 
+        climbing_outdoor_type = None
+        if 'rock_climbing' in activities and not ('hiking' in activities) :
+            climbing_outdoor_type = 'multi'
+        
         orientations = self.convert_type(
             document_in.facing, MigrateRoutes.orientation_types)
         if orientations is not None:
@@ -113,6 +117,7 @@ class MigrateRoutes(MigrateDocuments):
             redirects_to=document_in.redirects_to,
             # elevation=document_in.elevation,  # used for difficulties_height
             activities=activities,
+            climbing_outdoor_type=climbing_outdoor_type,
             orientations=orientations,
             height_diff_up=document_in.height_diff_up,
             height_diff_down=document_in.height_diff_down,


### PR DESCRIPTION
See https://github.com/c2corg/v6_api/issues/474 : 
During migration, all routes whose "activities" field has "rock_climbing" AND has not "hiking", the field "climbing_outdoor_type" must be set to "multi".

I change the route migration script to manage the climbing_outdoor_type value about the activities.
This is just a proposal, I didn't tested the script.