### PR TITLE
Add migrating of V5 waterfall type - change migrating of V5 glacier

### DIFF
--- a/c2corg_api/scripts/migration/documents/waypoints/summit.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/summit.py
@@ -76,11 +76,12 @@ class MigrateSummits(MigrateWaypoints):
         '4':   'climbing_outdoor',  # was 'cliff'
         '6':   'locality',          # was 'valley'
         '3':   'lake',
-        '7':   'misc',              # was 'glacier'
+        '7':   'locality',          # was 'glacier'
         '8':   'bisse',
         '9':   'waterpoint',        # was 'source'
         '10':  'canyon',
         '11':  'cave',              # was': 'hole'
+        '12':  'waterfall',         # was': 'cascade'
         '100': 'hut',
         '5':   'virtual',           # was 'raid'
         '99':  'misc'               # was 'other'


### PR DESCRIPTION
In V5, I added a new type for the "summits" : "cascade".
Then, on V5 we are be able to change the V5 cliff summits to V5 cascade summits.
In the V6, the corresponding WP will have the good type, because the V5 cliff type doesn't exist in V6 (it will be migrated to climbing_outdoor, which is incompatible to manage ice fall routes).
In the migration, we need to migrate V5 cascade summit type to V6 cascade WP type. It is the purpose of this pull request.

More over, I changed the migrating of V5 glacier summit type, to locality instead of misc, because a glacier is similar to a valley, but colder :-)