### PR TITLE
Remove unique contraint on image filename

### DIFF
--- a/c2corg_api/models/image.py
+++ b/c2corg_api/models/image.py
@@ -10,7 +10,6 @@ from sqlalchemy import (
     SmallInteger,
     String
     )
-from sqlalchemy.ext.declarative import declared_attr
 
 from colander import MappingSchema, SchemaNode, Sequence
 from colanderalchemy import SQLAlchemySchemaNode
@@ -44,11 +43,7 @@ class _ImageMixin(object):
 
     file_size = Column(Integer)
 
-    @declared_attr
-    def filename(self):
-        return Column(String(30),
-                      nullable=False,
-                      unique=(self.__name__ == 'Image'))
+    filename = Column(String(30), nullable=False)
 
     date_time = Column(DateTime)
 


### PR DESCRIPTION
Relate #363

I need this in master to automate the migration process.
This could be reverted when filenames will be unique in V5 database.