### PR TITLE
Set env encoding in dockerfile

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -2,6 +2,13 @@ FROM docker.io/debian:jessie
 
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN apt-get update && apt-get install -y locales
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen en_US.UTF-8 && \
+    dpkg-reconfigure locales && \
+    /usr/sbin/update-locale LANG=en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
 RUN echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/50no-install-recommends
 RUN echo 'APT::Install-Suggests "0";' > /etc/apt/apt.conf.d/50no-install-suggests
 


### PR DESCRIPTION
This is needed to read email templates with utf-8 characters.