### PR TITLE
Add health web-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ Check the Discourse forum is up and available to the client API:
 "id" is a v6 user id. The script should return a 200OK.
 
 
+Health service
+--------------
+
+To get information about a running API instance, e.g. its version and the
+status of its components, the health service `/health` can be used:
+
+    GET http://localhost:6543/health
+
+
 Developer Tips
 --------------
 

--- a/c2corg_api/tests/views/test_health.py
+++ b/c2corg_api/tests/views/test_health.py
@@ -1,0 +1,9 @@
+from c2corg_api.tests.views import BaseTestRest
+
+
+class TestHealthRest(BaseTestRest):
+    def setUp(self):  # noqa
+        super(TestHealthRest, self).setUp()
+
+    def test_get(self):
+        self.app.get('/health', status=200)

--- a/c2corg_api/views/health.py
+++ b/c2corg_api/views/health.py
@@ -1,0 +1,84 @@
+import logging
+
+from c2corg_api.caching import cache_document_detail
+from c2corg_api.models import DBSession, es_sync
+from c2corg_api.search import elasticsearch_config
+from c2corg_api.views import cors_policy
+from cornice.resource import resource, view
+
+log = logging.getLogger(__name__)
+
+
+@resource(path='/health', cors_policy=cors_policy)
+class HealthRest(object):
+
+    def __init__(self, request):
+        self.request = request
+
+    @view()
+    def get(self):
+        """ Returns information about the version of the API and the status
+        of its components:
+
+            - Git revision
+            - PostgreSQL status
+            - Last run of the ES syncer script
+            - ES status
+            - Number of documents indexed in ES
+            - Redis status
+            - Number of keys in Redis
+
+        """
+        status = {
+            'version': self.request.registry.settings.get('cache_version')
+        }
+
+        self._add_database_status(status)
+        self._add_es_status(status)
+        self._add_redis_status(status)
+
+        return status
+
+    def _add_database_status(self, status):
+        last_es_syncer_run = None
+        success = False
+
+        try:
+            last_es_syncer_run, _ = es_sync.get_status(DBSession)
+            success = True
+        except:
+            log.exception('Getting last es syncer run failed')
+
+        status['pg'] = 'ok' if success else 'error'
+        status['last_es_syncer_run'] = last_es_syncer_run.isoformat() \
+            if last_es_syncer_run else ''
+
+    def _add_es_status(self, status):
+        es_docs = None
+        success = False
+
+        try:
+            client = elasticsearch_config['client']
+            index = elasticsearch_config['index']
+            stats = client.indices.stats(index, metric='docs')
+            es_docs = stats['indices'][index]['total']['docs']['count']
+            success = True
+        except:
+            log.exception('Getting indexed docs count failed')
+
+        status['es'] = 'ok' if success else 'error'
+        status['es_indexed_docs'] = es_docs
+
+    def _add_redis_status(self, status):
+        redis_keys = None
+        success = False
+
+        try:
+            client = cache_document_detail.backend.client
+            redis_keys = client.dbsize()
+            success = True
+        except:
+            log.exception('Getting redis keys failed')
+
+        status['redis'] = 'ok' if success else 'error'
+        status['redis_keys'] = redis_keys

--- a/common.ini.in
+++ b/common.ini.in
@@ -8,8 +8,6 @@ noauthorization = {noauthorization}
 
 pyramid.default_locale_name = en
 
-version = {version}
-
 # size of the connection pool for the database. note that this number is
 # per application instance.
 sqlalchemy.pool_size=20

--- a/development.ini.in
+++ b/development.ini.in
@@ -16,9 +16,6 @@ pyramid.includes =
     pyramid_debugtoolbar
     pyramid_tm
 
-# disable version in dev mode
-version =
-
 # in dev. mode, append the timestamp to the cache key, so that the cache is
 # invalidated when the debug server reloads
 cache_version_timestamp = True


### PR DESCRIPTION
Returns the Git revision and the status of components of the API. E.g.:

```
{
	"redis_keys": 13025,
	"redis": "ok",
	"es": "ok",
	"pg": "ok",
	"last_es_syncer_run": "2016-11-11T12:27:52.023859+01:00",
	"version": "15fbece",
	"es_indexed_docs": 0
}
```

closes https://github.com/c2corg/v6_api/issues/490