### PR TITLE
Use forum_username and name instead of username in discourse payload

### DIFF
--- a/c2corg_api/security/discourse_client.py
+++ b/c2corg_api/security/discourse_client.py
@@ -111,8 +111,8 @@ class APIDiscourseClient(object):
             'nonce': nonce,
             'email': user.email,
             'external_id': user.id,
-            'username': user.username,
-            'name': user.username,
+            'username': user.forum_username,
+            'name': user.name,
         }
 
         key = self.sso_key.encode('utf-8')


### PR DESCRIPTION
Relate https://github.com/c2corg/v6_forum/issues/48

Actually, login to Topoguide overwrite discourse username and name to topoguide login name.
Here I fix this problem.