### PR TITLE
Support 3D and 4D geometries

### DIFF
--- a/c2corg_api/models/utils.py
+++ b/c2corg_api/models/utils.py
@@ -103,7 +103,9 @@ def _force_2d(geojson_track):
             [_force_2d_coords(coords) for coords in polygon]
             for polygon in geojson_track['coordinates']
         ]
-    raise Exception('Unexpected geometry type')
+    else:
+        raise Exception('Unexpected geometry type')
+    return geojson_track
 
 
 def _force_2d_coords(coords):

--- a/c2corg_api/models/utils.py
+++ b/c2corg_api/models/utils.py
@@ -1,6 +1,7 @@
 import geoalchemy2
 from geoalchemy2 import WKBElement
-from shapely.geometry import LineString, MultiLineString
+from geomet import wkb
+from shapely.geometry import LineString, MultiLineString, shape
 from sqlalchemy.dialects import postgresql
 import sqlalchemy as sa
 from sqlalchemy.sql.expression import and_
@@ -64,16 +65,49 @@ def get_mid_point(wkb_track):
     """Get the point in the middle of a track. If the track is a
     MultiLineString the point in the middle of the first line is taken.
     """
-    assert(isinstance(wkb_track, geoalchemy2.WKBElement))
-    track = geoalchemy2.shape.to_shape(wkb_track)
+    track = wkb_to_shape(wkb_track)
+
     if isinstance(track, LineString):
-        return geoalchemy2.shape.from_shape(
-            track.interpolate(0.5, True), srid=3857)
+        mid_point = track.interpolate(0.5, True)
     elif isinstance(track, MultiLineString) and track.geoms:
-        return geoalchemy2.shape.from_shape(
-            track.geoms[0].interpolate(0.5, True), srid=3857)
+        mid_point = track.geoms[0].interpolate(0.5, True)
     else:
         return None
+
+    return geoalchemy2.shape.from_shape(mid_point, srid=3857)
+
+
+def wkb_to_shape(wkb_element):
+    """ Create a 2D Shapely shape from a WKB value. 3D and 4D geometries
+     are turned into 2D geometries.
+    """
+    assert(isinstance(wkb_element, geoalchemy2.WKBElement))
+    geometry = wkb.loads(bytes(wkb_element.data))
+    return shape(_force_2d(geometry))
+
+
+def _force_2d(geojson_track):
+    if geojson_track['type'].lower() == 'point':
+        coords = geojson_track['coordinates']
+        geojson_track['coordinates'] = [coords[0], coords[1]]
+    elif geojson_track['type'].lower() == 'linestring':
+        geojson_track['coordinates'] = \
+            _force_2d_coords(geojson_track['coordinates'])
+    elif geojson_track['type'].lower() in ('multilinestring', 'polygon'):
+        geojson_track['coordinates'] = [
+            _force_2d_coords(coords)
+            for coords in geojson_track['coordinates']
+        ]
+    elif geojson_track['type'].lower() == 'multipolygon':
+        geojson_track['coordinates'] = [
+            [_force_2d_coords(coords) for coords in polygon]
+            for polygon in geojson_track['coordinates']
+        ]
+    raise Exception('Unexpected geometry type')
+
+
+def _force_2d_coords(coords):
+    return [[coord[0], coord[1]] for coord in coords]
 
 
 def windowed_query(q, column, windowsize):

--- a/c2corg_api/scripts/migration/documents/outings.py
+++ b/c2corg_api/scripts/migration/documents/outings.py
@@ -40,7 +40,7 @@ class MigrateOutings(MigrateDocuments):
             'select '
             '   oa.id, oa.document_archive_id, oa.is_latest_version, '
             '   oa.elevation, oa.is_protected, oa.redirects_to, '
-            '   ST_Force2D(ST_SetSRID(oa.geom, 3857)) geom, '
+            '   ST_SetSRID(oa.geom, 3857) geom, '
             '   oa.date, oa.activities, oa.height_diff_up, '
             '   oa.height_diff_down, oa.outing_length, oa.min_elevation, '
             '   oa.max_elevation, oa.partial_trip, '

--- a/c2corg_api/scripts/migration/documents/routes.py
+++ b/c2corg_api/scripts/migration/documents/routes.py
@@ -35,7 +35,7 @@ class MigrateRoutes(MigrateDocuments):
             'select '
             '   ra.id, ra.document_archive_id, ra.is_latest_version, '
             '   ra.elevation, ra.is_protected, ra.redirects_to, '
-            '   ST_Force2D(ST_SetSRID(ra.geom, 3857)) geom, '
+            '   ST_SetSRID(ra.geom, 3857) geom, '
             '   ra.activities, ra.facing, ra.height_diff_up, '
             '   ra.height_diff_down, ra.route_type, ra.route_length, '
             '   ra.min_elevation, ra.max_elevation, ra.duration, ra.slope, '

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -136,7 +136,17 @@ def teardown_package():
         initializees.drop_index()
 
 
-class BaseTestCase(unittest.TestCase):
+class AssertionsMixin(object):
+
+    def assertCoodinateEquals(self, coord1, coord2):  # noqa
+        self.assertEqual(len(coord1), len(coord2), 'not the same dimension')
+        for i in range(0, len(coord1)):
+            self.assertAlmostEquals(
+                coord1[i], coord2[i],
+                msg='{} does not almost equal {}'.format(coord1[i], coord2[i]))
+
+
+class BaseTestCase(unittest.TestCase, AssertionsMixin):
     """The idea for unit tests is, that the database tables
     are created only once per test run and every test case uses a
     transaction which is rolled back at the end. This avoids that

--- a/c2corg_api/tests/models/test_utils.py
+++ b/c2corg_api/tests/models/test_utils.py
@@ -1,11 +1,14 @@
 import unittest
 
+from c2corg_api.ext.colander_ext import wkbelement_from_geojson
+from c2corg_api.models.utils import wkb_to_shape
+from c2corg_api.tests import AssertionsMixin
 from c2corg_common.fields_waypoint import fields_waypoint
 from c2corg_api.models.schema_utils import restrict_schema
 from c2corg_api.models.waypoint import schema_waypoint
 
 
-class TestUtils(unittest.TestCase):
+class TestUtils(unittest.TestCase, AssertionsMixin):
 
     def test_restrict_schema(self):
         fields = fields_waypoint.get('summit').get('fields')
@@ -26,6 +29,65 @@ class TestUtils(unittest.TestCase):
         self.assertHasField(locale_node, 'lang')
         self.assertHasField(locale_node, 'title')
         self.assertHasNotField(locale_node, 'access_period')
+
+    def test_wkb_to_shape_point(self):
+        wkb = wkbelement_from_geojson(
+            '{"type": "Point", "coordinates": [1.0, 2.0, 3.0, 4.0]}', 3857)
+        point = wkb_to_shape(wkb)
+        self.assertFalse(point.has_z)
+        self.assertAlmostEquals(point.x, 1.0)
+        self.assertAlmostEquals(point.y, 2.0)
+
+    def test_wkb_to_shape_linestring(self):
+        wkb = wkbelement_from_geojson(
+            '{"type": "LineString", "coordinates": ' +
+            '[[635956, 5723604, 1200], [635966, 5723644, 1210]]}', 3857)
+        line = wkb_to_shape(wkb)
+        self.assertFalse(line.has_z)
+
+        self.assertEqual(len(line.coords), 2)
+        self.assertEqual(len(line.coords[0]), 2)
+        self.assertCoodinateEquals(
+            line.coords[0], [635956.0, 5723604.0])
+        self.assertCoodinateEquals(
+            line.coords[1], [635966.0, 5723644.0])
+
+    def test_wkb_to_shape_multilinestring(self):
+        wkb = wkbelement_from_geojson(
+            '{"type": "MultiLineString", "coordinates": ' +
+            '[[[635956, 5723604, 1200], [635966, 5723644, 1210]]]}', 3857)
+        line = wkb_to_shape(wkb)
+        self.assertFalse(line.has_z)
+
+        self.assertEqual(len(line.geoms), 1)
+        self.assertEqual(len(line.geoms[0].coords), 2)
+        self.assertEqual(len(line.geoms[0].coords[0]), 2)
+        self.assertCoodinateEquals(
+            line.geoms[0].coords[0], [635956.0, 5723604.0])
+        self.assertCoodinateEquals(
+            line.geoms[0].coords[1], [635966.0, 5723644.0])
+
+    def test_wkb_to_shape_polygon(self):
+        wkb = wkbelement_from_geojson(
+            '{"type": "Polygon", "coordinates": ' +
+            '[[[100.0, 0.0, 1200], [101.0, 0.0, 1200], [101.0, 1.0, 1200], '
+            '[100.0, 1.0, 1200], [100.0, 0.0, 1200]]]}', 3857)
+        polygon = wkb_to_shape(wkb)
+        self.assertFalse(polygon.has_z)
+
+        self.assertEqual(len(polygon.exterior.coords), 5)
+        self.assertEqual(len(polygon.exterior.coords[0]), 2)
+
+    def test_wkb_to_shape_multipolygon(self):
+        wkb = wkbelement_from_geojson(
+            '{"type": "MultiPolygon", "coordinates": ' +
+            '[[[[100.0, 0.0, 1200], [101.0, 0.0, 1200], [101.0, 1.0, 1200], '
+            '[100.0, 1.0, 1200], [100.0, 0.0, 1200]]]]}', 3857)
+        multi_polygon = wkb_to_shape(wkb)
+        self.assertFalse(multi_polygon.has_z)
+
+        self.assertEqual(len(multi_polygon.geoms[0].exterior.coords), 5)
+        self.assertEqual(len(multi_polygon.geoms[0].exterior.coords[0]), 2)
 
     def get_child_node(self, node, name):
         return next(

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -352,6 +352,124 @@ class TestRouteRest(BaseDocumentTestRest):
             first()
         self.assertIsNotNone(association_main_wp_log)
 
+    def test_post_success_3d(self):
+        """ Tests that routes with 3D tracks can be created and read.
+        """
+        body = {
+            'main_waypoint_id': self.waypoint.document_id,
+            'activities': ['hiking', 'skitouring'],
+            'geometry': {
+                'geom_detail':
+                    '{"type": "LineString", "coordinates": ' +
+                    '[[635956, 5723604, 1200], [635966, 5723644, 1210]]}'
+            },
+            'locales': [
+                {'lang': 'en', 'title': 'Some nice loop',
+                 'gear': 'shoes'}
+            ],
+            'associations': {
+                'waypoints': [{'document_id': self.waypoint.document_id}]
+            }
+        }
+
+        _, doc = self.post_success(body)
+        response = self.app.get(
+            self._prefix + '/' + str(doc.document_id), status=200)
+        body = response.json
+
+        geometry = body['geometry']
+        geom = json.loads(geometry['geom'])
+        self.assertEqual(len(geom['coordinates']), 2)
+        self.assertCoodinateEquals(geom['coordinates'], [635961.0, 5723624.0])
+
+        geom_detail = json.loads(geometry['geom_detail'])
+        self.assertEqual(len(geom_detail['coordinates']), 2)
+        self.assertEqual(len(geom_detail['coordinates'][0]), 3)
+        self.assertCoodinateEquals(
+            geom_detail['coordinates'][0], [635956.0, 5723604.0, 1200.0])
+        self.assertCoodinateEquals(
+            geom_detail['coordinates'][1], [635966.0, 5723644.0, 1210.0])
+
+    def test_post_success_3d_multiline(self):
+        """ Tests that routes with 3D multiline tracks can be created and read.
+        """
+        body = {
+            'main_waypoint_id': self.waypoint.document_id,
+            'activities': ['hiking', 'skitouring'],
+            'geometry': {
+                'geom_detail':
+                    '{"type": "MultiLineString", "coordinates": ' +
+                    '[[[635956, 5723604, 1200], [635966, 5723644, 1210]]]}'
+            },
+            'locales': [
+                {'lang': 'en', 'title': 'Some nice loop',
+                 'gear': 'shoes'}
+            ],
+            'associations': {
+                'waypoints': [{'document_id': self.waypoint.document_id}]
+            }
+        }
+
+        _, doc = self.post_success(body)
+        response = self.app.get(
+            self._prefix + '/' + str(doc.document_id), status=200)
+        body = response.json
+
+        geometry = body['geometry']
+        geom = json.loads(geometry['geom'])
+        self.assertEqual(len(geom['coordinates']), 2)
+        self.assertCoodinateEquals(geom['coordinates'], [635961.0, 5723624.0])
+
+        geom_detail = json.loads(geometry['geom_detail'])
+        self.assertEqual(len(geom_detail['coordinates']), 1)
+        self.assertEqual(len(geom_detail['coordinates'][0]), 2)
+        self.assertEqual(len(geom_detail['coordinates'][0][0]), 3)
+        self.assertCoodinateEquals(
+            geom_detail['coordinates'][0][0], [635956.0, 5723604.0, 1200.0])
+        self.assertCoodinateEquals(
+            geom_detail['coordinates'][0][1], [635966.0, 5723644.0, 1210.0])
+
+    def test_post_success_4d(self):
+        """ Tests that routes with 4D tracks can be created and read.
+        """
+        body = {
+            'main_waypoint_id': self.waypoint.document_id,
+            'activities': ['hiking', 'skitouring'],
+            'geometry': {
+                'geom_detail':
+                    '{"type": "LineString", "coordinates": ' +
+                    '[[635956, 5723604, 1200, 12345], '
+                    '[635966, 5723644, 1210, 12346]]}'
+            },
+            'locales': [
+                {'lang': 'en', 'title': 'Some nice loop',
+                 'gear': 'shoes'}
+            ],
+            'associations': {
+                'waypoints': [{'document_id': self.waypoint.document_id}]
+            }
+        }
+
+        _, doc = self.post_success(body)
+        response = self.app.get(
+            self._prefix + '/' + str(doc.document_id), status=200)
+        body = response.json
+
+        geometry = body['geometry']
+        geom = json.loads(geometry['geom'])
+        self.assertEqual(len(geom['coordinates']), 2)
+        self.assertCoodinateEquals(geom['coordinates'], [635961.0, 5723624.0])
+
+        geom_detail = json.loads(geometry['geom_detail'])
+        self.assertEqual(len(geom_detail['coordinates']), 2)
+        self.assertEqual(len(geom_detail['coordinates'][0]), 4)
+        self.assertCoodinateEquals(
+            geom_detail['coordinates'][0],
+            [635956.0, 5723604.0, 1200.0, 12345])
+        self.assertCoodinateEquals(
+            geom_detail['coordinates'][1],
+            [635966.0, 5723644.0, 1210.0, 12346])
+
     def test_post_default_geom_multi_line(self):
         body = {
             'main_waypoint_id': self.waypoint.document_id,

--- a/c2corg_api/tests/views/test_topo_map.py
+++ b/c2corg_api/tests/views/test_topo_map.py
@@ -155,6 +155,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
         links = self.session.query(TopoMapAssociation). \
             filter(
                 TopoMapAssociation.topo_map_id == doc.document_id). \
+            order_by(TopoMapAssociation.document_id). \
             all()
         self.assertEqual(len(links), 2)
         self.assertEqual(links[0].document_id, self.waypoint1.document_id)

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -3,6 +3,7 @@ import logging
 import collections
 import datetime
 
+from c2corg_api.ext.colander_ext import geojson_from_wkbelement
 from c2corg_api.models import DBSession
 from c2corg_api.models.document import ArchiveDocument
 from c2corg_api.models.document_history import HistoryMetaData, DocumentVersion
@@ -16,10 +17,6 @@ from cornice import Errors
 from cornice.util import json_error, _JSONError
 from cornice.resource import view
 from geoalchemy2 import WKBElement
-from geoalchemy2.shape import to_shape
-from shapely.geometry import mapping
-import json
-
 from sqlalchemy.inspection import inspect
 from sqlalchemy.sql.expression import over, and_
 from sqlalchemy.sql.functions import func
@@ -135,8 +132,7 @@ def serialize(data):
     if isinstance(data, (datetime.date, datetime.datetime)):
         return data.isoformat()
     if isinstance(data, WKBElement):
-        geometry = to_shape(data)
-        return json.dumps(mapping(geometry))
+        return geojson_from_wkbelement(data)
     if data is null:
         return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,13 +3,13 @@ bcrypt==3.1.1
 colander==1.2
 elasticsearch==2.3.0
 elasticsearch_dsl==2.0.0
-GeoAlchemy2==0.3.0
+geojson==1.3.3
+geomet==0.1.1
 gunicorn==19.6.0
 kombu==4.0.0
 # phpserialize is only required during the migration
 phpserialize==1.3.0
 psycopg2==2.6.2
-pyproj==1.9.5.1
 pyramid-jwtauth==0.1.3
 pyramid==1.7.3
 pyramid_debugtoolbar==3.0.5
@@ -23,6 +23,10 @@ SQLAlchemy==1.1.3
 transaction==1.6.1
 waitress==1.0.1
 zope.sqlalchemy==0.7.7
+
+# GeoAlchemy > 0.3.0
+# needs https://github.com/geoalchemy/geoalchemy2/pull/141
+git+https://github.com/geoalchemy/geoalchemy2.git@9cd4756
 
 # dogpile.cache
 # needs: https://bitbucket.org/zzzeek/dogpile.cache/pull-requests/58

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ kombu==4.0.0
 # phpserialize is only required during the migration
 phpserialize==1.3.0
 psycopg2==2.6.2
+pyproj==1.9.5.1
 pyramid-jwtauth==0.1.3
 pyramid==1.7.3
 pyramid_debugtoolbar==3.0.5


### PR DESCRIPTION
Closes https://github.com/c2corg/v6_api/issues/262

I had to do quite a few changes because Shapely does not support 4D geometries when parsing/writing WKB values.

I am currently running a full migration to test if all documents can be migrated.