### PR TITLE
Check permission for associations with outings

### DIFF
--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -322,3 +322,40 @@ def _get_associations_to_add(new_associations, current_associations):
                 to_add.append(doc)
 
     return to_add
+
+association_keys = {
+    'routes': ROUTE_TYPE,
+    'waypoints': WAYPOINT_TYPE,
+    'waypoint_children': WAYPOINT_TYPE,
+    'users': USERPROFILE_TYPE,
+    'images': IMAGE_TYPE,
+    'articles': ARTICLE_TYPE,
+    'areas': AREA_TYPE,
+    'books': BOOK_TYPE,
+    'outings': OUTING_TYPE
+}
+
+association_keys_for_types = {
+    ROUTE_TYPE: 'routes',
+    WAYPOINT_TYPE: 'waypoints',
+    USERPROFILE_TYPE: 'users',
+    ARTICLE_TYPE: 'articles',
+    BOOK_TYPE: 'books',
+    IMAGE_TYPE: 'images',
+    AREA_TYPE: 'areas',
+    OUTING_TYPE: 'outings'
+}
+
+# associations that can be updated/created when updating/creating a document
+# e.g. when creating a route, route and waypoint associations can be created
+updatable_associations = {
+    ROUTE_TYPE: {'articles', 'routes', 'waypoints', 'books'},
+    WAYPOINT_TYPE: {'articles', 'waypoints', 'waypoint_children'},
+    OUTING_TYPE: {'articles', 'routes', 'users'},
+    IMAGE_TYPE: {'routes', 'waypoints', 'images', 'users', 'articles',
+                 'areas', 'outings', 'books'},
+    ARTICLE_TYPE: {'articles', 'images', 'users', 'routes', 'waypoints',
+                   'outings', 'books'},
+    AREA_TYPE: {'images'},
+    BOOK_TYPE: {'routes', 'articles', 'images', 'waypoints'}
+}

--- a/c2corg_api/views/association.py
+++ b/c2corg_api/views/association.py
@@ -5,6 +5,8 @@ from c2corg_api.models.feed import update_feed_association_update
 from c2corg_api.models.route import Route
 from c2corg_api.scripts.es import sync
 from c2corg_api.search.notify_sync import notify_es_syncer
+from c2corg_api.views.validation import validate_outing_association, \
+    check_permission_for_outing_association
 from c2corg_common.associations import valid_associations
 from cornice.resource import resource
 from cornice.validators import colander_body_validator
@@ -47,6 +49,11 @@ def validate_association(request, **kwargs):
         if association_type not in valid_associations:
             request.errors.add(
                 'body', 'association', 'invalid association type')
+        else:
+            validate_outing_association(
+                request,
+                parent_document_id, parent_document_type,
+                child_document_id, child_document_type)
 
 
 @resource(collection_path='/associations', path='/associations/{id}',
@@ -108,6 +115,8 @@ class AssociationRest(object):
             raise HTTPBadRequest(
                 'as the main waypoint of the route, this waypoint can not '
                 'be disassociated')
+
+        check_permission_for_outing_association(self.request, association)
 
         log = association.get_log(
             self.request.authenticated_userid, is_creation=False)

--- a/c2corg_api/views/validation.py
+++ b/c2corg_api/views/validation.py
@@ -1,5 +1,9 @@
+from functools import partial
+
 from c2corg_api.models import DBSession
 from c2corg_api.models.area import AREA_TYPE
+from c2corg_api.models.association import Association, \
+    updatable_associations, association_keys
 from c2corg_api.models.book import BOOK_TYPE
 from c2corg_api.models.document import Document
 from c2corg_api.models.article import ARTICLE_TYPE
@@ -191,6 +195,24 @@ def validate_token(request, **kwargs):
         request.errors.add('querystring', 'token', 'invalid format')
 
 
+
+def has_permission_for_outing(request, outing_id):
+    """Check if the user with the given id has permission to change an
+    outing. That is only users that are currently assigned to the outing
+    can modify it.
+    """
+    if request.has_permission('moderator'):
+        # moderators can change everything
+        return True
+
+    user_id = request.authenticated_userid
+    return DBSession.query(exists().where(
+        and_(
+            Association.parent_document_id == user_id,
+            Association.child_document_id == outing_id
+        ))).scalar()
+
+
 def validate_required_json_string(key, request):
     """Checks if a given key is present in the request.
     """
@@ -353,40 +375,3 @@ def _is_parent_of_association(main_document_type, other_document_type):
         return True
     else:
         return None
-
-association_keys = {
-    'routes': ROUTE_TYPE,
-    'waypoints': WAYPOINT_TYPE,
-    'waypoint_children': WAYPOINT_TYPE,
-    'users': USERPROFILE_TYPE,
-    'images': IMAGE_TYPE,
-    'articles': ARTICLE_TYPE,
-    'areas': AREA_TYPE,
-    'books': BOOK_TYPE,
-    'outings': OUTING_TYPE
-}
-
-association_keys_for_types = {
-    ROUTE_TYPE: 'routes',
-    WAYPOINT_TYPE: 'waypoints',
-    USERPROFILE_TYPE: 'users',
-    ARTICLE_TYPE: 'articles',
-    BOOK_TYPE: 'books',
-    IMAGE_TYPE: 'images',
-    AREA_TYPE: 'areas',
-    OUTING_TYPE: 'outings'
-}
-
-# associations that can be updated/created when updating/creating a document
-# e.g. when creating a route, route and waypoint associations can be created
-updatable_associations = {
-    ROUTE_TYPE: {'articles', 'routes', 'waypoints', 'books'},
-    WAYPOINT_TYPE: {'articles', 'waypoints', 'waypoint_children'},
-    OUTING_TYPE: {'articles', 'routes', 'users'},
-    IMAGE_TYPE: {'routes', 'waypoints', 'images', 'users', 'articles',
-                 'areas', 'outings', 'books'},
-    ARTICLE_TYPE: {'articles', 'images', 'users', 'routes', 'waypoints',
-                   'outings', 'books'},
-    AREA_TYPE: {'images'},
-    BOOK_TYPE: {'routes', 'articles', 'images', 'waypoints'}
-}


### PR DESCRIPTION
Only moderators and participants can create or remove associations to an outing.

Closes https://github.com/c2corg/v6_api/issues/414