### PR TITLE
debug migration of article categories

### DIFF
--- a/c2corg_api/scripts/migration/documents/articles.py
+++ b/c2corg_api/scripts/migration/documents/articles.py
@@ -96,7 +96,8 @@ class MigrateArticles(MigrateDocuments):
 
     article_categories = {
         '1': 'mountain_environment',
-        '2': 'gear_and_technique',
+        '2': 'gear',
+        '11': 'technical',
         '4': 'topoguide_supplements',
         '7': 'soft_mobility',
         '8': 'expeditions',
@@ -105,6 +106,5 @@ class MigrateArticles(MigrateDocuments):
         '10': 'tags',
         '5': 'site_info',
         '6': 'association',
-        '100': 'draft',
-        '11': None
+        '100': None
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ git+https://github.com/tsauerwein/cornice.git@nested-none-2.1.0-c2corg
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@4ed593e
+git+https://github.com/c2corg/v6_common.git@910bb28
 
 # Discourse API client
 git+https://github.com/c2corg/pydiscourse.git@65e398343bbbc74fdb71cca4637c9f808e5adfb2


### PR DESCRIPTION
The article categories migration was based on a old V5 dump.
Since 19 january 2016, the 'gear_and_technique' category has been splitted into 'gear' and 'technical'.
This pull request update the migration.

See also the pull request for the category list : https://github.com/c2corg/v6_common/pull/45