### PR TITLE
Set syncer and scheduler log level to info in production

### DIFF
--- a/production.ini.in
+++ b/production.ini.in
@@ -46,12 +46,12 @@ handlers =
 qualname = c2corg_api
 
 [logger_c2corg_api_syncer]
-level = WARN
+level = INFO
 handlers =
 qualname = c2corg_api_syncer
 
 [logger_c2corg_api_background_jobs]
-level = WARN
+level = INFO
 handlers =
 qualname = c2corg_api_background_jobs
 


### PR DESCRIPTION
With this, it would be easier to ensure that syncer and scheduler correctly work in production.

Relate #285