### PR TITLE
During cliff mifgration, add multi-pitch attribute

### DIFF
--- a/c2corg_api/scripts/migration/documents/waypoints/summit.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/summit.py
@@ -49,6 +49,7 @@ class MigrateSummits(MigrateWaypoints):
             version=version,
             waypoint_type=self.convert_type(
                 document_in.summit_type, MigrateSummits.summit_types),
+            climbing_outdoor_types=outdoor_types,
             protected=document_in.is_protected,
             redirects_to=document_in.redirects_to,
             elevation=document_in.elevation,
@@ -69,6 +70,14 @@ class MigrateSummits(MigrateWaypoints):
             description=description,
             summary=summary
         )
+
+    def get_climbing_outdoor_types(self, document_in):
+        outdoor_types = []
+        if document_in.summit_type == 4:
+            outdoor_types.append('multi')
+        
+        outdoor_types = outdoor_types if outdoor_types else None
+        return outdoor_types
 
     summit_types = {
         '1':   'summit',            # was 'culmen'

--- a/c2corg_api/scripts/migration/documents/waypoints/summit.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/summit.py
@@ -43,6 +43,7 @@ class MigrateSummits(MigrateWaypoints):
         )
 
     def get_document(self, document_in, version):
+        outdoor_types = self.get_climbing_outdoor_types(document_in)
         return dict(
             document_id=document_in.id,
             type=WAYPOINT_TYPE,

--- a/c2corg_api/scripts/migration/documents/waypoints/summit.py
+++ b/c2corg_api/scripts/migration/documents/waypoints/summit.py
@@ -76,7 +76,6 @@ class MigrateSummits(MigrateWaypoints):
         outdoor_types = []
         if document_in.summit_type == 4:
             outdoor_types.append('multi')
-        
         outdoor_types = outdoor_types if outdoor_types else None
         return outdoor_types
 


### PR DESCRIPTION
On the V6, a multi-pitch cliff or a single-pitch cliff are described by a climbing_outdoor waypoint, which has a field "routes_type" to indicate if the cliff has single pitch, multi pitch, clock, etc.
During the migration : 
- The V5 'sites' are migrated into climbing_outdoor waypoint, with 'routes_types' taking the V5 value.
- The V5 'summit' cliffs are migrated into climbing_outdoor waypoint. The 'routes_types' must be set to "multi', as a V5 summit-cliff can only has multi-pitch routes.

This PR changes the migration script to add the 'multi' attribute during the summti-cliff migration.

The script has not been tested.
