### PR TITLE
log in json in production

### DIFF
--- a/production.ini.in
+++ b/production.ini.in
@@ -28,7 +28,7 @@ port = 6543
 ###
 
 [loggers]
-keys = root, c2corg_api, sqlalchemy, c2corg_api_syncer
+keys = root, c2corg_api, sqlalchemy, c2corg_api_syncer, gunicorn.error, gunicorn.access
 
 [handlers]
 keys = console
@@ -62,6 +62,16 @@ qualname = sqlalchemy.engine
 # "level = INFO" logs SQL queries.
 # "level = DEBUG" logs SQL queries and results.
 # "level = WARN" logs neither.  (Recommended for production systems.)
+
+[logger_gunicorn.access]
+level = INFO
+handlers =
+qualname=gunicorn.access
+
+[logger_gunicorn.error]
+level = INFO
+handlers =
+qualname=gunicorn.error
 
 [handler_console]
 class = StreamHandler

--- a/production.ini.in
+++ b/production.ini.in
@@ -34,7 +34,7 @@ keys = root, c2corg_api, sqlalchemy, c2corg_api_syncer
 keys = console
 
 [formatters]
-keys = generic
+keys = generic,json
 
 [logger_root]
 level = WARN
@@ -67,7 +67,11 @@ qualname = sqlalchemy.engine
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
-formatter = generic
+formatter = json
 
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
+
+[formatter_json]
+class = pythonjsonlogger.jsonlogger.JsonFormatter
+format = %(message)%(levelname)%(name)%(asctime)%(funcName)%(lineno)%(pathname)%(stack_info)%(module)%(created)%(threadName)%(processName)%(getMessage)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pyramid==1.7.3
 pyramid_debugtoolbar==3.0.5
 pyramid_mailer==0.14.1
 pyramid_tm==1.0.1
+python-json-logger==0.1.5
 redis==2.10.5
 requests==2.11.1
 setuptools==28.8.0


### PR DESCRIPTION
The goal is to have all log messages wrapped in json objects, so they can be cleanly indexed in the downstream elasticsearch. Most importantly: this way the stacktraces are no longer split on multiple lines.

Example:
https://c2corgv6.kibana.infra.internal/kibana/#dashboard/temp/AVivtz-lM9QtOkkMtIRW

(BTW, you might want to take a look at this stack trace, as it seems to be a genuine error)