### PR TITLE
Make batch size for ElasticSearch import configurable

### DIFF
--- a/c2corg_api/search/__init__.py
+++ b/c2corg_api/search/__init__.py
@@ -26,8 +26,6 @@ from elasticsearch_dsl.query import MultiMatch, Bool
 from kombu.connection import Connection
 from kombu import Exchange, Queue, pools
 
-batch_size = 1000
-
 # the maximum number of documents that can be returned for each document type
 SEARCH_LIMIT_MAX = 50
 

--- a/c2corg_api/tests/scripts/es/test_sync.py
+++ b/c2corg_api/tests/scripts/es/test_sync.py
@@ -128,7 +128,7 @@ class SyncTest(BaseTestCase):
             (self.route1.document_id, 'r'),
             (self.outing1.document_id, 'o'),
             (user_id, 'u')]
-        sync_documents(self.session, changed_documents)
+        sync_documents(self.session, changed_documents, 1000)
         self.assertEqual(len(search_documents), 5)
 
         redirected_doc = next(

--- a/c2corg_api/tests/scripts/es/test_syncer.py
+++ b/c2corg_api/tests/scripts/es/test_syncer.py
@@ -38,7 +38,7 @@ class SyncWorkerTest(BaseTestCase):
         t.commit()
 
         syncer = SyncWorker(
-            self.queue_config.connection, self.queue_config.queue,
+            self.queue_config.connection, self.queue_config.queue, 1000,
             session=self.session)
         next(syncer.consume(limit=1))
 

--- a/common.ini.in
+++ b/common.ini.in
@@ -17,6 +17,12 @@ elasticsearch.port = {elasticsearch_port}
 elasticsearch.index = {elasticsearch_index}
 elasticsearch.pool = 50
 
+# batch size for fill_index
+elasticsearch.batch_size.fill_index = {elasticsearch_batch_size_fill_index}
+
+# batch size for es_syncer script
+elasticsearch.batch_size.syncer = {elasticsearch_batch_size_syncer}
+
 # Redis is used as queue to notify the syncer script of changed documents
 # and also as cache
 redis.url = {redis_url}

--- a/config/default
+++ b/config/default
@@ -17,6 +17,8 @@ export db_name = c2corg
 export elasticsearch_host = localhost
 export elasticsearch_port = 9200
 export elasticsearch_index = c2corg
+export elasticsearch_batch_size_fill_index = 1000
+export elasticsearch_batch_size_syncer = 1000
 
 export redis_url = redis://localhost:6379/
 export redis_db_queue = 4


### PR DESCRIPTION
```
# batch size for fill_index
elasticsearch.batch_size.fill_index = {elasticsearch_batch_size_fill_index}

# batch size for es_syncer script
elasticsearch.batch_size.syncer = {elasticsearch_batch_size_syncer}
```

cc @mfournier 