### PR TITLE
Only search in title field for advanced search

### DIFF
--- a/c2corg_api/scripts/es/sync.py
+++ b/c2corg_api/scripts/es/sync.py
@@ -278,8 +278,13 @@ def get_documents(session, doc_type, document_ids=None):
     if document_ids:
         base_query = base_query.filter(clazz.document_id.in_(document_ids))
 
+    locale_fields = ['title']
+    if clazz == Route:
+        locale_fields.append('title_prefix')
+
     base_query = base_query. \
-        options(joinedload(clazz.locales.of_type(locales_clazz))). \
+        options(joinedload(clazz.locales.of_type(locales_clazz)).
+                load_only(*locale_fields)). \
         options(joinedload(clazz.geometry).load_only(DocumentGeometry.lon_lat))
 
     if clazz != Area:

--- a/c2corg_api/search/mapping.py
+++ b/c2corg_api/search/mapping.py
@@ -3,7 +3,6 @@ import json
 from c2corg_api.models.document import Document
 from c2corg_api.search.mapping_types import Enum, QEnumArray, QLong, \
     QEnumRange
-from c2corg_api.search.utils import strip_bbcodes
 from c2corg_common.attributes import default_langs
 from c2corg_common.sortable_search_attributes import sortable_quality_types
 from elasticsearch_dsl import DocType, String, MetaField, Long, GeoPoint
@@ -127,10 +126,12 @@ class SearchDocument(DocType):
             for locale in document.locales:
                 available_locales.append(locale.lang)
                 search_document['title_' + locale.lang] = locale.title
-                search_document['summary_' + locale.lang] = \
-                    strip_bbcodes(locale.summary)
-                search_document['description_' + locale.lang] = \
-                    strip_bbcodes(locale.description)
+                # FIXME currently the full-text search only searches the title,
+                # so summary and description are not indexed
+                # search_document['summary_' + locale.lang] = \
+                #     strip_bbcodes(locale.summary)
+                # search_document['description_' + locale.lang] = \
+                #     strip_bbcodes(locale.description)
             search_document['available_locales'] = available_locales
 
             if document.quality:

--- a/c2corg_api/search/search_filters.py
+++ b/c2corg_api/search/search_filters.py
@@ -7,7 +7,7 @@ from c2corg_api.search.mapping_types import reserved_query_fields
 from functools import partial
 
 from c2corg_api.search import create_search, search_documents, \
-    get_text_query
+    get_text_query_on_title
 from elasticsearch_dsl.query import Range, Term, Terms, Bool, GeoBoundingBox, \
     Missing
 
@@ -22,7 +22,7 @@ def build_query(url_params, meta_params, doc_type):
     search = create_search(doc_type)
     if search_term:
         search = search.query(
-            get_text_query(search_term, meta_params.get('lang')))
+            get_text_query_on_title(search_term, meta_params.get('lang')))
 
     search_model = search_documents[doc_type]
     for param in url_params:

--- a/c2corg_api/tests/scripts/es/test_fill_index.py
+++ b/c2corg_api/tests/scripts/es/test_fill_index.py
@@ -146,7 +146,7 @@ class FillIndexTest(BaseTestCase):
         self.assertIsNotNone(waypoint1)
         self.assertEqual(waypoint1.title_en, 'Mont Granier')
         self.assertEqual(waypoint1.title_fr, 'Mont Granier')
-        self.assertEqual(waypoint1.summary_fr, 'Le Mont  Granier ')
+        # self.assertEqual(waypoint1.summary_fr, 'Le Mont  Granier ')
         self.assertEqual(waypoint1.doc_type, 'w')
         self.assertEqual(waypoint1.quality, 2)
         self.assertEqual(waypoint1.access_time, 3)

--- a/c2corg_api/tests/scripts/es/test_sync.py
+++ b/c2corg_api/tests/scripts/es/test_sync.py
@@ -88,7 +88,7 @@ class SyncTest(BaseTestCase):
         self.assertEqual(doc['_op_type'], 'index')
         self.assertEqual(doc['_id'], self.route1.document_id)
         self.assertEqual(doc['title_en'], 'Mont Blanc : Face N')
-        self.assertEqual(doc['description_en'], '...')
+        # self.assertEqual(doc['description_en'], '...')
         self.assertEqual(doc['geom'], [6, 46])
 
     def test_create_search_documents_user_profile(self):
@@ -105,10 +105,10 @@ class SyncTest(BaseTestCase):
         self.assertEqual(doc['_id'], document_id)
         self.assertEqual(
             doc['title_en'], 'Contributor contributor')
-        self.assertEqual(doc['description_en'], 'Me')
+        # self.assertEqual(doc['description_en'], 'Me')
         self.assertEqual(
             doc['title_fr'], 'Contributor contributor')
-        self.assertEqual(doc['description_fr'], 'Moi')
+        # self.assertEqual(doc['description_fr'], 'Moi')
 
     @patch('c2corg_api.scripts.es.sync.ElasticBatch')
     def test_sync_documents(self, mock):

--- a/c2corg_api/tests/scripts/es/test_syncer.py
+++ b/c2corg_api/tests/scripts/es/test_syncer.py
@@ -45,5 +45,5 @@ class SyncWorkerTest(BaseTestCase):
         index = elasticsearch_config['index']
         doc = SearchWaypoint.get(id=51251, index=index)
         self.assertEqual(doc['title_fr'], 'Mont Granier')
-        self.assertEqual(doc['summary_fr'], 'Le Mont  Granier ')
+        # self.assertEqual(doc['summary_fr'], 'Le Mont  Granier ')
         self.assertEqual(doc['doc_type'], 'w')

--- a/c2corg_api/tests/search/test_search_filters.py
+++ b/c2corg_api/tests/search/test_search_filters.py
@@ -1,4 +1,4 @@
-from c2corg_api.search import create_search, get_text_query
+from c2corg_api.search import create_search, get_text_query_on_title
 from c2corg_api.search.mappings.image_mapping import SearchImage
 from c2corg_api.search.mappings.route_mapping import SearchRoute
 from c2corg_api.search.search_filters import create_filter, build_query, \
@@ -25,7 +25,7 @@ class AdvancedSearchTest(BaseTestCase):
         }
         query = build_query(params, meta_params, 'w')
         expected_query = create_search('w'). \
-            query(get_text_query('search word')). \
+            query(get_text_query_on_title('search word')). \
             filter(Term(available_locales='fr')).\
             filter(Terms(areas=[1234, 4567])). \
             filter(Range(elevation={'gte': 1500})). \
@@ -45,7 +45,7 @@ class AdvancedSearchTest(BaseTestCase):
         }
         query = build_query(params, meta_params, 'w')
         expected_query = create_search('w'). \
-            query(get_text_query('search word')). \
+            query(get_text_query_on_title('search word')). \
             filter(Range(elevation={'gte': 1500})). \
             filter(GeoBoundingBox(
                 geom={
@@ -66,7 +66,7 @@ class AdvancedSearchTest(BaseTestCase):
         }
         query = build_query(params, meta_params, 'w')
         expected_query = create_search('w'). \
-            query(get_text_query('search word')). \
+            query(get_text_query_on_title('search word')). \
             fields([]).\
             extra(from_=40, size=20)
         self.assertQueryEqual(query, expected_query)


### PR DESCRIPTION
The full-text search of the advanced search is a bit too vague. This PR proposes only to search in the title field, as it is already the case for the simple search.

Now, also only the title field will be indexed in ElasticSearch. If we later want to enable the search on summary/description these fields can be added to the index again.

Closes https://github.com/c2corg/v6_api/issues/397