### PR TITLE
Fix parsing of feed continuation token

### DIFF
--- a/c2corg_api/tests/views/test_validation.py
+++ b/c2corg_api/tests/views/test_validation.py
@@ -3,8 +3,10 @@ from c2corg_api.models.route import Route, ROUTE_TYPE
 from c2corg_api.models.user_profile import UserProfile
 from c2corg_api.models.waypoint import Waypoint, WAYPOINT_TYPE
 from c2corg_api.tests import BaseTestCase
-from c2corg_api.views.validation import validate_associations_in
+from c2corg_api.views.validation import validate_associations_in, \
+    parse_datetime
 from cornice.errors import Errors
+from dateutil import parser as datetime_parser
 
 
 class TestValidation(BaseTestCase):
@@ -168,3 +170,13 @@ class TestValidation(BaseTestCase):
             error['description'],
             'document "' + str(self.waypoint1.document_id) +
             '" is not of type "r"')
+
+    def test_parse_datetime(self):
+        self.assertEqual(parse_datetime(None), None)
+        self.assertEqual(
+            parse_datetime('2016-11-28T23:57:30.090459+01:00'),
+            datetime_parser.parse('2016-11-28T23:57:30.090459+01:00'))
+
+        self.assertEqual(
+            parse_datetime('2016-11-28T23%3A57%3A30.090459%2B01%3A00'),
+            datetime_parser.parse('2016-11-28T23:57:30.090459+01:00'))

--- a/c2corg_api/views/validation.py
+++ b/c2corg_api/views/validation.py
@@ -22,6 +22,7 @@ from pyramid.httpexceptions import HTTPBadRequest
 from sqlalchemy.sql.expression import exists, and_
 from webob.descriptors import parse_int_safe
 from dateutil import parser as datetime_parser
+import urllib
 
 
 # Validation functions
@@ -173,6 +174,7 @@ def parse_datetime(time_raw):
     if time_raw is None or time_raw == '':
         return None
     try:
+        time_raw = urllib.parse.unquote(time_raw)
         return datetime_parser.parse(time_raw)
     except ValueError:
         return None


### PR DESCRIPTION
Reported by @asaunier:

>It seems also that the homepage feed is broken: the initial request is OK but when scrolling (either authenticated or not) the API request fails because:
>
> https://api.demov6.camptocamp.org/feed?pl=fr&token=111488%2C2016-11-28T22%253A57%253A30.090459%252B00%253A00
400 Bad Request
{"status": "error", "errors": [{"name": "token", "location": "querystring", "description": "invalid format"}]}