### PR TITLE
Fix xreports diff of two documents

### DIFF
--- a/c2corg_api/tests/views/test_xreport.py
+++ b/c2corg_api/tests/views/test_xreport.py
@@ -168,15 +168,17 @@ class TestXreportRest(BaseDocumentTestRest):
 
         # check that the ETag header is set
         headers = response.headers
+
+        # TODO check etag as private
         etag = headers.get('ETag')
         self.assertIsNotNone(etag)
 
-        self.assertEqual(response.headers.get('Cache-Control'), 'private')
+        self.assertEqual(response.headers.get('Cache-Control'), None)
 
         # then request the document again with the etag
         auth_headers['If-None-Match'] = etag
         response = self.app.get(url, status=304, headers=auth_headers)
-        self.assertEqual(response.headers.get('Cache-Control'), 'private')
+        self.assertEqual(response.headers.get('Cache-Control'), None)
 
     def test_get_version_caching(self):
         headers = self.add_authorization_header(username='contributor')

--- a/c2corg_api/views/xreport.py
+++ b/c2corg_api/views/xreport.py
@@ -90,23 +90,19 @@ def _has_permission(request, xreport_id):
     return has_been_created_by(xreport_id, request.authenticated_userid)
 
 
-@resource(path='/xreports/{id}/{lang}/{version_id}',
-          cors_policy=cors_policy)
-class XreportsVersionRest(DocumentVersionRest):
-    @restricted_json_view(validators=[
-        validate_id, validate_lang, validate_version_id])
-    def get(self):
-        set_private_cache_header(self.request)
-        if not _has_permission(self.request, self.request.validated['id']):
-            raise HTTPForbidden(
-                'No permission to view the version of this xreport')
+@resource(path='/xreports/{id}/{lang}/{version_id}', cors_policy=cors_policy)
+class XreportVersionRest(DocumentVersionRest):
 
+    @view(validators=[validate_id, validate_lang, validate_version_id])
+    def get(self):
         return self._get_version(
-            ArchiveXreport, ArchiveXreportLocale, schema_xreport)
+            ArchiveXreport, ArchiveXreportLocale,
+            schema_xreport_without_personal)
 
 
 @resource(path='/xreports/{id}/{lang}/info', cors_policy=cors_policy)
-class XreportsInfoRest(DocumentInfoRest):
+class XreportInfoRest(DocumentInfoRest):
+
     @view(validators=[validate_id, validate_lang])
     def get(self):
         return self._get_document_info(Xreport)


### PR DESCRIPTION
Rename `class Xreports` to `Xreport`
Rename `test_report.py` to `test_xreport.py`

Disable private/public check and always return public version of the xreport