### PR TITLE
Make sure routes and outings have a default geometry

### DIFF
--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -479,7 +479,7 @@ class BaseDocumentTestRest(BaseTestRest):
         return body
 
     def post_success(self, request_body, user='contributor',
-                     validate_with_auth=False):
+                     validate_with_auth=False, skip_validation=False):
         response = self.app_post_json(self._prefix, request_body, status=403)
 
         headers = self.add_authorization_header(username=user)
@@ -487,7 +487,14 @@ class BaseDocumentTestRest(BaseTestRest):
                                       headers=headers, status=200)
 
         body = response.json
-        return self._validate_document(body, headers, validate_with_auth)
+        if skip_validation:
+            document_id = body.get('document_id')
+            response = self.app.get(
+                self._prefix + '/' + str(document_id), status=200)
+            doc = self.session.query(self._model).get(document_id)
+            return response.json, doc
+        else:
+            return self._validate_document(body, headers, validate_with_auth)
 
     def _validate_document(self, body, headers=None, validate_with_auth=False):
         document_id = body.get('document_id')

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -828,6 +828,44 @@ class TestOutingRest(BaseDocumentTestRest):
             body, self.outing, user='moderator')
         self._assert_default_geometry(body, x=635000, y=5723000)
 
+    def test_put_update_default_geom_from_linked_routes(self):
+        """Tests that the default geometry is updated from linked routes.
+        """
+        body = {
+            'message': 'Changing figures',
+            'document': {
+                'document_id': self.outing2.document_id,
+                'version': self.outing2.version,
+                'quality': quality_types[1],
+                'activities': ['skitouring'],
+                'date_start': '2016-01-01',
+                'date_end': '2016-01-01',
+                'elevation_min': 700,
+                'elevation_max': 1600,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'locales': [
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
+                     'description': '...', 'weather': 'sunny',
+                     'version': self.locale_en.version}
+                ],
+                'associations': {
+                    'users': [{
+                        'document_id': self.global_userids['contributor']
+                    }],
+                    'routes': [{'document_id': self.route.document_id}]
+                }
+            }
+        }
+        headers = self.add_authorization_header(username='moderator')
+        self.app_put_json(
+            self._prefix + '/' + str(self.outing2.document_id), body,
+            headers=headers, status=200)
+        response = self.app.get(
+            self._prefix + '/' + str(self.outing2.document_id), status=200)
+        body = response.json
+        self._assert_default_geometry(body, x=635961, y=5723624)
+
     def test_put_success_lang_only(self):
         body = {
             'message': 'Changing lang',
@@ -1047,9 +1085,19 @@ class TestOutingRest(BaseDocumentTestRest):
 
         self.outing2 = Outing(
             activities=['skitouring'], date_start=datetime.date(2016, 2, 1),
-            date_end=datetime.date(2016, 2, 1)
+            date_end=datetime.date(2016, 2, 1),
+            locales=[
+                OutingLocale(
+                    lang='en', title='Mont Blanc from the air',
+                    description='...',
+                    weather='sunny')
+            ],
+            geometry=DocumentGeometry(geom='SRID=3857;POINT(0 0)')
         )
         self.session.add(self.outing2)
+        self.session.flush()
+        DocumentRest.create_new_version(self.outing2, user_id)
+
         self.outing3 = Outing(
             activities=['skitouring'], date_start=datetime.date(2016, 2, 1),
             date_end=datetime.date(2016, 2, 2)

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -198,18 +198,22 @@ class TestRouteRest(BaseDocumentTestRest):
     def test_post_error(self):
         body = self.post_error({})
         errors = body.get('errors')
-        self.assertEqual(len(errors), 1)
-        self.assertCorniceRequired(errors[0], 'activities')
+        self.assertEqual(len(errors), 2)
+        self.assertError(
+            errors, 'activities', 'Required')
+        self.assertError(
+            errors, 'associations.waypoints', 'at least one waypoint required')
 
-    def test_post_empty_activities_error(self):
+    def test_post_empty_activities_and_associations_error(self):
         body = self.post_error({
             'activities': []
         })
         errors = body.get('errors')
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(
-            errors[0].get('description'), 'Shorter than minimum length 1')
-        self.assertEqual(errors[0].get('name'), 'activities')
+        self.assertEqual(len(errors), 2)
+        self.assertError(
+            errors, 'activities', 'Shorter than minimum length 1')
+        self.assertError(
+            errors, 'associations.waypoints', 'at least one waypoint required')
 
     def test_post_invalid_activity(self):
         body_post = {
@@ -227,7 +231,12 @@ class TestRouteRest(BaseDocumentTestRest):
             },
             'locales': [
                 {'lang': 'en', 'title': 'Some nice loop'}
-            ]
+            ],
+            'associations': {
+                'waypoints': [
+                    {'document_id': self.waypoint.document_id}
+                ]
+            }
         }
         body = self.post_error(body_post)
         errors = body.get('errors')
@@ -275,7 +284,9 @@ class TestRouteRest(BaseDocumentTestRest):
                 {'lang': 'en', 'title': 'Some nice loop',
                  'gear': 'shoes'}
             ],
-            'associations': {}
+            'associations': {
+                'waypoints': [{'document_id': self.waypoint.document_id}]
+            }
         }
         self.post_non_whitelisted_attribute(body)
 
@@ -557,8 +568,13 @@ class TestRouteRest(BaseDocumentTestRest):
             'locales': [
                 {'lang': 'en', 'title': 'Some nice loop',
                  'gear': 'shoes'}
-            ]
+            ],
             # no association for the main waypoint
+            'associations': {
+                'waypoints': [
+                    {'document_id': self.waypoint2.document_id}
+                ]
+            }
         }
         body = self.post_error(body_post)
         errors = body.get('errors')
@@ -581,7 +597,10 @@ class TestRouteRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'none',
                      'version': self.locale_en.version}
-                ]
+                ],
+                'associations': {
+                    'waypoints': [{'document_id': self.waypoint.document_id}]
+                }
             }
         }
         self.put_wrong_document_id(body)
@@ -601,7 +620,10 @@ class TestRouteRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'none',
                      'version': self.locale_en.version}
-                ]
+                ],
+                'associations': {
+                    'waypoints': [{'document_id': self.waypoint.document_id}]
+                }
             }
         }
         self.put_wrong_version(body, self.route.document_id)
@@ -621,7 +643,10 @@ class TestRouteRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'none',
                      'version': -9999}
-                ]
+                ],
+                'associations': {
+                    'waypoints': [{'document_id': self.waypoint.document_id}]
+                }
             }
         }
         self.put_wrong_version(body, self.route.document_id)
@@ -641,7 +666,10 @@ class TestRouteRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'none',
                      'version': self.locale_en.version}
-                ]
+                ],
+                'associations': {
+                    'waypoints': [{'document_id': self.waypoint.document_id}]
+                }
             }
         }
         self.put_wrong_ids(body, self.route.document_id)
@@ -672,6 +700,9 @@ class TestRouteRest(BaseDocumentTestRest):
                     'geom_detail':
                         '{"type": "LineString", "coordinates": ' +
                         '[[635956, 5723604], [635976, 5723654]]}'
+                },
+                'associations': {
+                    'waypoints': [{'document_id': self.waypoint.document_id}]
                 }
             }
         }
@@ -722,7 +753,10 @@ class TestRouteRest(BaseDocumentTestRest):
                      'description': '...', 'gear': 'paraglider',
                      'version': self.locale_en.version,
                      'title_prefix': 'Should be ignored'}
-                ]
+                ],
+                'associations': {
+                    'waypoints': [{'document_id': self.waypoint.document_id}]
+                }
             }
         }
         (body, route) = self.put_success_figures_only(body, self.route)
@@ -759,6 +793,9 @@ class TestRouteRest(BaseDocumentTestRest):
                         '[[635956, 5723604], [635976, 5723654]]}',
                     'geom':
                         '{"type": "Point", "coordinates": [635000, 5723000]}'
+                },
+                'associations': {
+                    'waypoints': [{'document_id': self.waypoint.document_id}]
                 }
             }
         }
@@ -930,7 +967,10 @@ class TestRouteRest(BaseDocumentTestRest):
                     {'lang': 'en', 'title': 'Mont Blanc from the air',
                      'description': '...', 'gear': 'none',
                      'version': self.locale_en.version}
-                ]
+                ],
+                'associations': {
+                    'waypoints': [{'document_id': self.waypoint.document_id}]
+                }
             }
         }
         (body, route) = self.put_success_lang_only(body, self.route)
@@ -956,7 +996,10 @@ class TestRouteRest(BaseDocumentTestRest):
                 'locales': [
                     {'lang': 'es', 'title': 'Mont Blanc del cielo',
                      'description': '...', 'gear': 'si'}
-                ]
+                ],
+                'associations': {
+                    'waypoints': [{'document_id': self.waypoint.document_id}]
+                }
             }
         }
         (body, route) = self.put_success_new_lang(body, self.route)

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -274,7 +274,8 @@ class TestRouteRest(BaseDocumentTestRest):
             'locales': [
                 {'lang': 'en', 'title': 'Some nice loop',
                  'gear': 'shoes'}
-            ]
+            ],
+            'associations': {}
         }
         self.post_non_whitelisted_attribute(body)
 
@@ -519,6 +520,27 @@ class TestRouteRest(BaseDocumentTestRest):
             }
         }
         body, doc = self.post_success(body)
+        self.assertIsNotNone(doc.geometry.geom)
+        self.assertIsNone(doc.geometry.geom_detail)
+        self._assert_default_geometry(body, x=635956, y=5723604)
+
+    def test_post_default_geom_from_associated_wps(self):
+        body = {
+            'activities': ['hiking', 'skitouring'],
+            'elevation_min': 700,
+            'elevation_max': 1500,
+            'height_diff_up': 800,
+            'height_diff_down': 800,
+            'durations': ['1'],
+            'locales': [
+                {'lang': 'en', 'title': 'Some nice loop',
+                 'gear': 'shoes'}
+            ],
+            'associations': {
+                'waypoints': [{'document_id': self.waypoint.document_id}]
+            }
+        }
+        body, doc = self.post_success(body, skip_validation=True)
         self.assertIsNotNone(doc.geometry.geom)
         self.assertIsNone(doc.geometry.geom_detail)
         self._assert_default_geometry(body, x=635956, y=5723604)
@@ -776,6 +798,70 @@ class TestRouteRest(BaseDocumentTestRest):
         (body, route) = self.put_success_figures_only(body, self.route2)
         self._assert_default_geometry(body, x=635956, y=5723604)
 
+    def test_put_success_update_default_geom_from_wps_new(self):
+        """Test that the default geom is updated with associated waypoints if
+        no track exists (and no default geom was set yet).
+        """
+        body = {
+            'message': 'Changing figures',
+            'document': {
+                'document_id': self.route2.document_id,
+                'version': self.route2.version,
+                'quality': quality_types[1],
+                'activities': ['skitouring'],
+                'glacier_gear': 'no',
+                'elevation_min': 700,
+                'elevation_max': 1600,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'durations': ['1'],
+                'locales': [
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
+                     'description': '...', 'gear': 'paraglider',
+                     'version': self.route2.locales[0].version}
+                ],
+                'associations': {
+                    'waypoints': [
+                        {'document_id': self.waypoint.document_id}
+                    ]
+                }
+            }
+        }
+        (body, route) = self.put_success_figures_only(body, self.route2)
+        self._assert_default_geometry(body, x=635956, y=5723604)
+
+    def test_put_success_update_default_geom_from_wps(self):
+        """Test that the default geom is updated with associated waypoints if
+        no track exists.
+        """
+        body = {
+            'message': 'Changing figures',
+            'document': {
+                'document_id': self.route3.document_id,
+                'version': self.route3.version,
+                'quality': quality_types[1],
+                'activities': ['skitouring'],
+                'glacier_gear': 'no',
+                'elevation_min': 700,
+                'elevation_max': 1600,
+                'height_diff_up': 800,
+                'height_diff_down': 800,
+                'durations': ['1'],
+                'locales': [
+                    {'lang': 'en', 'title': 'Mont Blanc from the air',
+                     'description': '...', 'gear': 'paraglider',
+                     'version': self.route3.locales[0].version}
+                ],
+                'associations': {
+                    'waypoints': [
+                        {'document_id': self.waypoint.document_id}
+                    ]
+                }
+            }
+        }
+        (body, route) = self.put_success_figures_only(body, self.route3)
+        self._assert_default_geometry(body, x=635956, y=5723604)
+
     def test_put_success_main_wp_changed(self):
         body = {
             'message': 'Changing figures',
@@ -1018,8 +1104,21 @@ class TestRouteRest(BaseDocumentTestRest):
 
         self.route3 = Route(
             activities=['skitouring'], elevation_max=1500, elevation_min=700,
-            height_diff_up=500, height_diff_down=500, durations='1')
+            height_diff_up=500, height_diff_down=500, durations='1',
+            locales=[
+                RouteLocale(
+                    lang='en', title='Mont Blanc from the air',
+                    description='...', gear='paraglider'),
+                RouteLocale(
+                    lang='fr', title='Mont Blanc du ciel', description='...',
+                    gear='paraglider')]
+        )
+
+        self.route3.geometry = DocumentGeometry(geom='SRID=3857;POINT(0 0)')
         self.session.add(self.route3)
+        self.session.flush()
+        DocumentRest.create_new_version(self.route3, user_id)
+
         self.route4 = Route(
             activities=['skitouring'], elevation_max=1500, elevation_min=700,
             height_diff_up=500, height_diff_down=500, durations='1')

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -184,7 +184,7 @@ class DocumentRest(object):
         document.document_id = None
 
         if before_add:
-            before_add(document, user_id=user_id)
+            before_add(document, user_id)
 
         DBSession.add(document)
         DBSession.flush()

--- a/c2corg_api/views/route.py
+++ b/c2corg_api/views/route.py
@@ -1,3 +1,5 @@
+import logging
+
 import functools
 
 from c2corg_api.models import DBSession
@@ -20,13 +22,15 @@ from c2corg_api.models.route import Route, schema_route, schema_update_route, \
 from c2corg_api.views.document import DocumentRest, make_validator_create, \
     make_validator_update, NUM_RECENT_OUTINGS
 from c2corg_api.views import cors_policy, restricted_json_view, \
-    get_best_locale
+    get_best_locale, set_default_geom_from_associations
 from c2corg_api.views.validation import validate_id, validate_pagination, \
     validate_lang, validate_version_id, validate_lang_param, \
     validate_preferred_lang_param, validate_associations
 from c2corg_common.fields_route import fields_route
 from c2corg_common.attributes import activities
 from sqlalchemy.orm import load_only
+
+log = logging.getLogger(__name__)
 
 validate_route_create = make_validator_create(
     fields_route, 'activities', activities)
@@ -85,8 +89,12 @@ class RouteRest(DocumentRest):
             validate_associations_create,
             functools.partial(validate_main_waypoint, True)])
     def collection_post(self):
+        linked_waypoints = self.request.validated. \
+            get('associations', {}).get('waypoints', [])
         return self._collection_post(
-            schema_route, before_add=set_default_geometry,
+            schema_route,
+            before_add=functools.partial(
+                set_default_geometry, linked_waypoints),
             after_add=init_title_prefix)
 
     @restricted_json_view(
@@ -100,10 +108,13 @@ class RouteRest(DocumentRest):
     def put(self):
         old_main_waypoint_id = DBSession.query(Route.main_waypoint_id). \
             filter(Route.document_id == self.request.validated['id']).scalar()
+        linked_waypoints = self.request.validated. \
+            get('associations', {}).get('waypoints', [])
         return self._put(
             Route, schema_route,
             before_update=functools.partial(
-                update_default_geometry, old_main_waypoint_id),
+                update_default_geometry, old_main_waypoint_id,
+                linked_waypoints),
             after_update=update_title_prefix)
 
     @staticmethod
@@ -151,9 +162,11 @@ class RouteInfoRest(DocumentInfoRest):
         return self._get_document_info(Route)
 
 
-def set_default_geometry(route, user_id):
+def set_default_geometry(linked_waypoints, route, user_id):
     """When creating a new route, set the default geometry to the middle point
-    of a given track, if not to the geometry of the associated main waypoint.
+    of a given track, if not to the geometry of the associated main waypoint
+    (if a main waypoint is set), otherwise to the centroid of the convex hull
+    of all associated waypoints.
     """
     if route.geometry is not None and route.geometry.geom is not None:
         # default geometry already set
@@ -163,39 +176,54 @@ def set_default_geometry(route, user_id):
         # track is given, obtain a default point from the track
         route.geometry.geom = get_mid_point(route.geometry.geom_detail)
     elif route.main_waypoint_id:
-        # get default point from main waypoint
-        main_wp_point = DBSession.query(DocumentGeometry.geom).filter(
-            DocumentGeometry.document_id == route.main_waypoint_id).scalar()
-        if main_wp_point is not None:
-            route.geometry = DocumentGeometry(geom=main_wp_point)
+        _set_default_geom_from_main_wp(route)
+
+    set_default_geom_from_associations(route, linked_waypoints)
 
 
-def update_default_geometry(old_main_waypoint_id, route, route_in, user_id):
+def _set_default_geom_from_main_wp(route):
+    main_wp_point = _get_default_geom_from_main_wp(route)
+    if main_wp_point is not None:
+        route.geometry = DocumentGeometry(geom=main_wp_point)
+
+
+def _get_default_geom_from_main_wp(route):
+    return DBSession.query(DocumentGeometry.geom).filter(
+        DocumentGeometry.document_id == route.main_waypoint_id).scalar()
+
+
+def update_default_geometry(
+        old_main_waypoint_id, linked_waypoints, route, route_in, user_id):
+    geometry = route.geometry
     geometry_in = route_in.geometry
     if geometry_in is not None and geometry_in.geom is not None:
         # default geom is manually set in the request
         return
     elif geometry_in is not None and geometry_in.geom_detail is not None:
         # update the default geom with the new track
-        route.geometry.geom = get_mid_point(route.geometry.geom_detail)
-    elif main_waypoint_has_changed(route_in, old_main_waypoint_id):
-        # when the main waypoint has changed, use the waypoint geom
-        main_wp_point = DBSession.query(DocumentGeometry.geom).filter(
-            DocumentGeometry.document_id == route.main_waypoint_id).scalar()
-        if main_wp_point is not None:
-            if route.geometry is not None:
-                if route.geometry.geom_detail is None:
-                    # only update if no own track
+        geometry.geom = get_mid_point(geometry.geom_detail)
+        return
+    elif geometry is not None and geometry.geom_detail is not None:
+        # default geom is already set and no new track is provided
+        return
+    elif geometry is None or geometry.geom_detail is None:
+        # only update if no own track
+        if route.main_waypoint_id and \
+                main_waypoint_has_changed(route, old_main_waypoint_id):
+            main_wp_point = _get_default_geom_from_main_wp(route)
+            if main_wp_point is not None:
+                if geometry is not None:
                     route.geometry.geom = main_wp_point
-            else:
-                route.geometry = DocumentGeometry(geom=main_wp_point)
+                else:
+                    route.geometry = DocumentGeometry(geom=main_wp_point)
+                return
+
+    set_default_geom_from_associations(
+        route, linked_waypoints, update_always=True)
 
 
 def main_waypoint_has_changed(route, old_main_waypoint_id):
-    if route.main_waypoint_id is None:
-        return False
-    else:
-        return old_main_waypoint_id != route.main_waypoint_id
+    return old_main_waypoint_id != route.main_waypoint_id
 
 
 def init_title_prefix(route, user_id):


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/959

* If a route has no track geometry or main waypoint, the centroid of the convex hull of all associated waypoints is used.
* If an outing has no track geometry, the centroid of the convex hull of the default geometry of all associated routes is used.

This PR also checks that the last associated waypoint of a route and the last associated route of an outing, can not be disassociated.