### PR TITLE
Add image filename unicity constraint back

### DIFF
--- a/c2corg_api/models/image.py
+++ b/c2corg_api/models/image.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     SmallInteger,
     String
     )
+from sqlalchemy.ext.declarative import declared_attr
 
 from colander import MappingSchema, SchemaNode, Sequence
 from colanderalchemy import SQLAlchemySchemaNode
@@ -43,7 +44,11 @@ class _ImageMixin(object):
 
     file_size = Column(Integer)
 
-    filename = Column(String(30), nullable=False)
+    @declared_attr
+    def filename(self):
+        return Column(String(30),
+                      nullable=False,
+                      unique=(self.__name__ == 'Image'))
 
     date_time = Column(DateTime(timezone=True))
 


### PR DESCRIPTION
Revert 7e0fd123ce50ad15db6915de6ee581b8a919f1aa

@arnaud-morvan I let you merge this PR when you think it is OK.
I have asked the association to have a look at possible filename duplicates before the v5 prod DB is dumped.