### PR TITLE
Add author field to xreport detail

### DIFF
--- a/c2corg_api/tests/views/test_xreport.py
+++ b/c2corg_api/tests/views/test_xreport.py
@@ -69,6 +69,12 @@ class TestXreportRest(BaseDocumentTestRest):
         self.assertNotIn('xreport', body)
         self.assertIn('geometry', body)
         self.assertIsNone(body.get('geometry'))
+
+        self.assertIn('author', body)
+        author = body.get('author')
+        self.assertEqual(
+            self.global_userids['contributor'], author.get('user_id'))
+
         associations = body['associations']
         self.assertIn('images', associations)
         self.assertIn('articles', associations)

--- a/c2corg_api/views/xreport.py
+++ b/c2corg_api/views/xreport.py
@@ -13,6 +13,7 @@ from c2corg_api.views.document_version import DocumentVersionRest
 from c2corg_common.fields_xreport import fields_xreport
 from cornice.resource import resource, view
 from cornice.validators import colander_body_validator
+from c2corg_api.views import set_creator as set_creator_on_documents
 
 from c2corg_api.views.document_schemas import xreport_documents_config
 from c2corg_api.views.document import DocumentRest, make_validator_create, \
@@ -48,11 +49,13 @@ class XreportRest(DocumentRest):
             # only moderators and the author of a xreport can access the full
             # xreport (including personal information)
             return self._get(Xreport, schema_xreport_without_personal,
-                             clazz_locale=XreportLocale)
+                             clazz_locale=XreportLocale,
+                             set_custom_fields=set_author)
 
         return self._get(Xreport, schema_xreport,
                          clazz_locale=XreportLocale,
-                         custom_cache_key='private')
+                         custom_cache_key='private',
+                         set_custom_fields=set_author)
 
     @restricted_json_view(
             schema=schema_create_xreport,
@@ -106,3 +109,9 @@ class XreportInfoRest(DocumentInfoRest):
     @view(validators=[validate_id, validate_lang])
     def get(self):
         return self._get_document_info(Xreport)
+
+
+def set_author(xreport):
+    """Set the creator (the user who is an author) of the report.
+    """
+    set_creator_on_documents([xreport], 'author')


### PR DESCRIPTION
Add xreport's author to the API response (similar as for articles).

![image](https://cloud.githubusercontent.com/assets/6165660/20928887/19f067a4-bbc8-11e6-9491-0f3c3f54a380.png)
