### PR TITLE
Check association permissions

### DIFF
--- a/c2corg_api/models/article.py
+++ b/c2corg_api/models/article.py
@@ -1,4 +1,4 @@
-from c2corg_api.models import schema, Base, enums
+from c2corg_api.models import schema, Base, enums, DBSession
 from c2corg_api.models.document import (
     ArchiveDocument, Document, schema_document_locale, schema_attributes)
 from c2corg_api.models.enums import article_category, activity_type
@@ -87,3 +87,11 @@ schema_create_article = get_create_schema(schema_article)
 schema_update_article = get_update_schema(schema_article)
 schema_listing_article = restrict_schema(
     schema_article, fields_article.get('listing'))
+
+
+def is_personal(article_id):
+    article_type = DBSession.query(Article.article_type). \
+        select_from(Article.__table__). \
+        filter(Article.document_id == article_id). \
+        scalar()
+    return article_type == 'personal'

--- a/c2corg_api/models/association.py
+++ b/c2corg_api/models/association.py
@@ -214,7 +214,8 @@ def create_associations(
 
 
 def synchronize_associations(
-        document, new_associations, user_id, check_association=None):
+        document, new_associations, user_id, check_association_add=None,
+        check_association_remove=None):
     """ Synchronize the associations when updating a document.
     """
     current_associations = _get_current_associations(
@@ -223,9 +224,10 @@ def synchronize_associations(
         new_associations, current_associations)
 
     added_associations = _apply_operation(
-        to_add, add_association, document, user_id, check_association)
+        to_add, add_association, document, user_id, check_association_add)
     removed_associations = _apply_operation(
-        to_remove, remove_association, document, user_id, check_association)
+        to_remove, remove_association, document, user_id,
+        check_association_remove)
 
     return added_associations, removed_associations
 

--- a/c2corg_api/models/image.py
+++ b/c2corg_api/models/image.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from colander import MappingSchema, SchemaNode, Sequence
 from colanderalchemy import SQLAlchemySchemaNode
 
-from c2corg_api.models import schema, enums, Base
+from c2corg_api.models import schema, enums, Base, DBSession
 from c2corg_api.models.utils import copy_attributes, ArrayOfEnum
 from c2corg_api.models.document import (
     ArchiveDocument, Document, geometry_schema_overrides,
@@ -156,3 +156,11 @@ class SchemaImageList(MappingSchema):
     images = SchemaNode(
         Sequence(), schema_create_image, missing=None)
 schema_create_image_list = SchemaImageList()
+
+
+def is_personal(image_id):
+    image_type = DBSession.query(Image.image_type). \
+        select_from(Image.__table__). \
+        filter(Image.document_id == image_id). \
+        scalar()
+    return image_type == 'personal'

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -61,7 +61,7 @@ class BaseTestRest(BaseTestCase):
             if description == error.get('description') and \
                     name == error.get('name'):
                 return
-        self.fail('no error ({0}, {1})'.format(name, description))
+        self.fail('no error ({}, {}) in {}'.format(name, description, errors))
 
     def get_error(self, errors, name):  # noqa
         for error in errors:

--- a/c2corg_api/tests/views/test_area.py
+++ b/c2corg_api/tests/views/test_area.py
@@ -270,13 +270,10 @@ class TestAreaRest(BaseDocumentTestRest):
                 'locales': [
                     {'lang': 'en', 'title': 'New title',
                      'version': self.locale_en.version}
-                ],
-                'associations': {
-                    'images': []
-                }
+                ]
             }
         }
-        (body, area) = self.put_success_all(body, self.area1, cache_version=3)
+        (body, area) = self.put_success_all(body, self.area1, cache_version=2)
 
         self.assertEquals(area.area_type, 'admin_limits')
         locale_en = area.get_locale('en')
@@ -301,11 +298,6 @@ class TestAreaRest(BaseDocumentTestRest):
         archive_locale = version_fr.document_locales_archive
         self.assertEqual(archive_locale.title, 'Chartreuse')
 
-        # check that existing link to the image is removed
-        association_image = self.session.query(Association).get(
-            (area.document_id, self.image.document_id))
-        self.assertIsNone(association_image)
-
     def test_put_success_all_as_moderator(self):
         body = {
             'message': 'Update',
@@ -321,13 +313,17 @@ class TestAreaRest(BaseDocumentTestRest):
                 'locales': [
                     {'lang': 'en', 'title': 'New title',
                      'version': self.locale_en.version}
-                ]
+                ],
+                'associations': {
+                    'images': []
+                }
             }
         }
-        (body, map1) = self.put_success_all(body, self.area1, user='moderator')
+        (body, area) = self.put_success_all(
+            body, self.area1, user='moderator', cache_version=3)
 
         # version with lang 'en'
-        version_en = map1.versions[2]
+        version_en = area.versions[2]
 
         # geometry has been changed because the user is a moderator
         archive_geometry_en = version_en.document_geometry_archive
@@ -345,6 +341,11 @@ class TestAreaRest(BaseDocumentTestRest):
         self.check_cache_version(self.route.document_id, 2)
         # waypoint 2 is no longer associated, the cache key was incremented
         self.check_cache_version(self.waypoint2.document_id, 2)
+
+        # check that existing link to the image is removed
+        association_image = self.session.query(Association).get(
+            (area.document_id, self.image.document_id))
+        self.assertIsNone(association_image)
 
     def test_put_success_figures_only(self):
         body = {

--- a/c2corg_api/tests/views/test_association.py
+++ b/c2corg_api/tests/views/test_association.py
@@ -136,7 +136,7 @@ class TestAssociationRest(BaseTestRest):
             'no rights to modify associations with outing {}'.format(
                 self.outing.document_id))
 
-    def test_add_association_wa_article_collab(self):
+    def test_add_association_wc_article_collab(self):
         """ Check that associations with articles can only be changed by
         everyone.
         """
@@ -149,7 +149,7 @@ class TestAssociationRest(BaseTestRest):
             TestAssociationRest.prefix, request_body, headers=headers,
             status=200)
 
-    def test_add_association_wa_article_personal_unauthorized(self):
+    def test_add_association_wc_article_personal_unauthorized(self):
         """ Check that associations with personal articles can only be changed
         by the creator and moderators.
         """
@@ -171,7 +171,7 @@ class TestAssociationRest(BaseTestRest):
             'no rights to modify associations with article {}'.format(
                 self.article1.document_id))
 
-    def test_add_association_wa_article_personal_authorized(self):
+    def test_add_association_wc_article_personal_authorized(self):
         """ Check that associations with personal articles can only be changed
         by the creator and moderators.
         """
@@ -187,7 +187,7 @@ class TestAssociationRest(BaseTestRest):
             TestAssociationRest.prefix, request_body, headers=headers,
             status=200)
 
-    def test_add_association_aa_article_personal_unauthorized(self):
+    def test_add_association_cc_article_personal_unauthorized(self):
         """ Check that associations with personal articles can only be changed
         by the creator and moderators.
         """
@@ -528,6 +528,35 @@ class TestAssociationRest(BaseTestRest):
         self.app.delete_json(
             TestAssociationRest.prefix, request_body, headers=headers,
             status=400)
+
+    def test_delete_association_wc_article_personal(self):
+        """ Test that associations with personal articles require special
+        rights.
+        """
+        self.article1.article_type = 'personal'
+        self.session.flush()
+
+        # first create an association with the article
+        request_body = {
+            'parent_document_id': self.waypoint1.document_id,
+            'child_document_id': self.article1.document_id,
+        }
+        headers = self.add_authorization_header(username='contributor')
+        self.app_post_json(
+            TestAssociationRest.prefix, request_body, headers=headers,
+            status=200)
+
+        # then try to delete the association again with a different user
+        headers = self.add_authorization_header(username='contributor2')
+        response = self.app.delete_json(
+            TestAssociationRest.prefix, request_body, headers=headers,
+            status=400)
+        body = response.json
+
+        self.assertError(
+            body['errors'], 'Bad Request',
+            'no rights to modify associations with article {}'.format(
+                self.article1.document_id))
 
     def test_delete_association_wp_r_last_waypoint(self):
         request_body1 = {

--- a/c2corg_api/tests/views/test_association.py
+++ b/c2corg_api/tests/views/test_association.py
@@ -2,13 +2,16 @@ import datetime
 
 from c2corg_api.models.association import Association, AssociationLog
 from c2corg_api.models.article import Article
+from c2corg_api.models.document import DocumentLocale
 from c2corg_api.models.feed import update_feed_document_create
 from c2corg_api.models.image import Image
 from c2corg_api.models.outing import Outing, OUTING_TYPE
 from c2corg_api.models.route import Route
 from c2corg_api.models.user_profile import USERPROFILE_TYPE
 from c2corg_api.models.waypoint import Waypoint
+from c2corg_api.models.xreport import Xreport, XreportLocale
 from c2corg_api.tests.views import BaseTestRest
+from c2corg_api.views.document import DocumentRest
 
 
 class TestAssociationRest(BaseTestRest):
@@ -132,6 +135,172 @@ class TestAssociationRest(BaseTestRest):
             body['errors'], 'associations.outings',
             'no rights to modify associations with outing {}'.format(
                 self.outing.document_id))
+
+    def test_add_association_wa_article_collab(self):
+        """ Check that associations with articles can only be changed by
+        everyone.
+        """
+        request_body = {
+            'parent_document_id': self.waypoint1.document_id,
+            'child_document_id': self.article1.document_id,
+        }
+        headers = self.add_authorization_header(username='contributor2')
+        self.app_post_json(
+            TestAssociationRest.prefix, request_body, headers=headers,
+            status=200)
+
+    def test_add_association_wa_article_personal_unauthorized(self):
+        """ Check that associations with personal articles can only be changed
+        by the creator and moderators.
+        """
+        self.article1.article_type = 'personal'
+        self.session.flush()
+
+        request_body = {
+            'parent_document_id': self.waypoint1.document_id,
+            'child_document_id': self.article1.document_id,
+        }
+        headers = self.add_authorization_header(username='contributor2')
+        response = self.app_post_json(
+            TestAssociationRest.prefix, request_body, headers=headers,
+            status=400)
+        body = response.json
+
+        self.assertError(
+            body['errors'], 'associations.articles',
+            'no rights to modify associations with article {}'.format(
+                self.article1.document_id))
+
+    def test_add_association_wa_article_personal_authorized(self):
+        """ Check that associations with personal articles can only be changed
+        by the creator and moderators.
+        """
+        self.article1.article_type = 'personal'
+        self.session.flush()
+
+        request_body = {
+            'parent_document_id': self.waypoint1.document_id,
+            'child_document_id': self.article1.document_id,
+        }
+        headers = self.add_authorization_header(username='contributor')
+        self.app_post_json(
+            TestAssociationRest.prefix, request_body, headers=headers,
+            status=200)
+
+    def test_add_association_aa_article_personal_unauthorized(self):
+        """ Check that associations with personal articles can only be changed
+        by the creator and moderators.
+        """
+        request_body = {
+            'parent_document_id': self.article2.document_id,
+            'child_document_id': self.article1.document_id,
+        }
+        headers = self.add_authorization_header(username='contributor2')
+        response = self.app_post_json(
+            TestAssociationRest.prefix, request_body, headers=headers,
+            status=400)
+        body = response.json
+
+        self.assertError(
+            body['errors'], 'associations.articles',
+            'no rights to modify associations with article {}'.format(
+                self.article2.document_id))
+
+    def test_add_association_wi_image_personal_unauthorized(self):
+        """ Check that associations with personal images can only be changed
+        by the creator and moderators.
+        """
+        self.image1.image_type = 'personal'
+        self.session.flush()
+
+        request_body = {
+            'parent_document_id': self.waypoint1.document_id,
+            'child_document_id': self.image1.document_id,
+        }
+        headers = self.add_authorization_header(username='contributor2')
+        response = self.app_post_json(
+            TestAssociationRest.prefix, request_body, headers=headers,
+            status=400)
+        body = response.json
+
+        self.assertError(
+            body['errors'], 'associations.images',
+            'no rights to modify associations with image {}'.format(
+                self.image1.document_id))
+
+    def test_add_association_wi_image_personal_authorized(self):
+        """ Check that associations with personal images can only be changed
+        by the creator and moderators.
+        """
+        self.article1.article_type = 'personal'
+        self.session.flush()
+
+        request_body = {
+            'parent_document_id': self.waypoint1.document_id,
+            'child_document_id': self.image1.document_id,
+        }
+        headers = self.add_authorization_header(username='contributor')
+        self.app_post_json(
+            TestAssociationRest.prefix, request_body, headers=headers,
+            status=200)
+
+    def test_add_association_wx_xreport_unauthorized(self):
+        """ Check that associations with x-reports can only be changed
+        by the creator and moderators.
+        """
+        request_body = {
+            'parent_document_id': self.waypoint1.document_id,
+            'child_document_id': self.report1.document_id,
+        }
+        headers = self.add_authorization_header(username='contributor2')
+        response = self.app_post_json(
+            TestAssociationRest.prefix, request_body, headers=headers,
+            status=400)
+        body = response.json
+
+        self.assertError(
+            body['errors'], 'associations.xreports',
+            'no rights to modify associations with xreport {}'.format(
+                self.report1.document_id))
+
+    def test_add_association_wx_xreport_authorized(self):
+        """ Check that associations with x-reports can only be changed
+        by the creator and moderators.
+        """
+        request_body = {
+            'parent_document_id': self.waypoint1.document_id,
+            'child_document_id': self.report1.document_id,
+        }
+        headers = self.add_authorization_header(username='contributor')
+        self.app_post_json(
+            TestAssociationRest.prefix, request_body, headers=headers,
+            status=200)
+
+    def test_add_association_wc_xreport_article_unauthorized(self):
+        """ Check an association between a xreport and article that both
+        do not accept associations from contributor2.
+        """
+        self.article1.article_type = 'personal'
+        self.session.flush()
+
+        request_body = {
+            'parent_document_id': self.report1.document_id,
+            'child_document_id': self.article1.document_id,
+        }
+        headers = self.add_authorization_header(username='contributor2')
+        response = self.app_post_json(
+            TestAssociationRest.prefix, request_body, headers=headers,
+            status=400)
+        body = response.json
+
+        self.assertError(
+            body['errors'], 'associations.xreports',
+            'no rights to modify associations with xreport {}'.format(
+                self.report1.document_id))
+        self.assertError(
+            body['errors'], 'associations.articles',
+            'no rights to modify associations with article {}'.format(
+                self.article1.document_id))
 
     def test_add_association_duplicate(self):
         """ Test that there is only one association between two documents.
@@ -437,6 +606,8 @@ class TestAssociationRest(BaseTestRest):
             TestAssociationRest.prefix, request_body1, headers=headers)
 
     def _add_test_data(self):
+        user_id = self.global_userids['contributor']
+
         self.waypoint1 = Waypoint(
             waypoint_type='summit', elevation=2203)
         self.session.add(self.waypoint1)
@@ -452,13 +623,36 @@ class TestAssociationRest(BaseTestRest):
         self.route2 = Route(activities=['skitouring'])
         self.session.add(self.route2)
 
-        self.image1 = Image(filename='image.jpg')
+        self.image1 = Image(
+            filename='image.jpg',
+            locales=[
+                DocumentLocale(lang='en', title='Mont Blanc from the air')])
         self.session.add(self.image1)
+        self.session.flush()
+        DocumentRest.create_new_version(self.image1, user_id)
 
         self.article1 = Article(
             categories=['site_info'], activities=['hiking'],
-            article_type='collab')
+            article_type='collab',
+            locales=[DocumentLocale(lang='en', title='Lac d\'Annecy')])
         self.session.add(self.article1)
+        self.session.flush()
+        DocumentRest.create_new_version(self.article1, user_id)
+
+        self.article2 = Article(
+            categories=['site_info'], activities=['hiking'],
+            article_type='personal',
+            locales=[DocumentLocale(lang='en', title='Lac d\'Annecy')])
+        self.session.add(self.article2)
+        self.session.flush()
+        DocumentRest.create_new_version(self.article2, user_id)
+
+        self.report1 = Xreport(
+            activities=['hiking'],
+            locales=[XreportLocale(lang='en', title='Lac d\'Annecy')])
+        self.session.add(self.report1)
+        self.session.flush()
+        DocumentRest.create_new_version(self.report1, user_id)
 
         self.outing = Outing(
             activities=['skitouring'], date_start=datetime.date(2016, 1, 1),
@@ -467,7 +661,6 @@ class TestAssociationRest(BaseTestRest):
         self.session.add(self.outing)
         self.session.flush()
 
-        user_id = self.global_userids['contributor']
         self.session.add(Association(
             parent_document_id=user_id,
             parent_document_type=USERPROFILE_TYPE,

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -411,7 +411,7 @@ class TestImageRest(BaseTestImage):
         body = response.json
         self.assertError(
             body.get('errors'), 'Bad Request',
-            'no rights to modify association with outing {}'.format(
+            'no rights to modify associations with outing {}'.format(
                 self.outing1.document_id))
 
     def test_put_wrong_document_id(self):
@@ -627,7 +627,7 @@ class TestImageRest(BaseTestImage):
         body = response.json
         self.assertError(
             body.get('errors'), 'Bad Request',
-            'no rights to modify association with outing {}'.format(
+            'no rights to modify associations with outing {}'.format(
                 self.outing1.document_id))
 
     def test_put_success_as_contributor2(self):

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -627,8 +627,9 @@ class TestImageRest(BaseTestImage):
         body = response.json
         self.assertError(
             body.get('errors'), 'Bad Request',
-            'no rights to modify associations with outing {}'.format(
-                self.outing1.document_id))
+            'no rights to modify associations between '
+            'document o ({}) and i ({})'.format(
+                self.outing1.document_id, self.image.document_id))
 
     def test_put_success_as_contributor2(self):
         """ Try to update an image with contributor2 who has no permission to

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -926,7 +926,8 @@ class TestRouteRest(BaseDocumentTestRest):
                 }
             }
         }
-        (body, route) = self.put_success_figures_only(body, self.route)
+        (body, route) = self.put_success_figures_only(
+            body, self.route, user='moderator')
         # tests that the default geometry has not changed (main wp has changed
         # but the route has a track)
         self._assert_default_geometry(body)

--- a/c2corg_api/views/association.py
+++ b/c2corg_api/views/association.py
@@ -8,7 +8,7 @@ from c2corg_api.models.waypoint import WAYPOINT_TYPE
 from c2corg_api.scripts.es import sync
 from c2corg_api.search.notify_sync import notify_es_syncer
 from c2corg_api.views.validation import validate_association_permission, \
-    check_permission_for_outing_association
+    check_permission_for_association
 from c2corg_common.associations import valid_associations
 from cornice.resource import resource
 from cornice.validators import colander_body_validator
@@ -114,7 +114,7 @@ class AssociationRest(object):
                 raise HTTPBadRequest('association does not exist')
 
         _check_required_associations(association)
-        check_permission_for_outing_association(self.request, association)
+        check_permission_for_association(self.request, association)
 
         log = association.get_log(
             self.request.authenticated_userid, is_creation=False)

--- a/c2corg_api/views/association.py
+++ b/c2corg_api/views/association.py
@@ -7,7 +7,7 @@ from c2corg_api.models.route import Route, ROUTE_TYPE
 from c2corg_api.models.waypoint import WAYPOINT_TYPE
 from c2corg_api.scripts.es import sync
 from c2corg_api.search.notify_sync import notify_es_syncer
-from c2corg_api.views.validation import validate_outing_association, \
+from c2corg_api.views.validation import validate_association_permission, \
     check_permission_for_outing_association
 from c2corg_common.associations import valid_associations
 from cornice.resource import resource
@@ -52,7 +52,7 @@ def validate_association(request, **kwargs):
             request.errors.add(
                 'body', 'association', 'invalid association type')
         else:
-            validate_outing_association(
+            validate_association_permission(
                 request,
                 parent_document_id, parent_document_type,
                 child_document_id, child_document_type)

--- a/c2corg_api/views/association.py
+++ b/c2corg_api/views/association.py
@@ -8,7 +8,7 @@ from c2corg_api.models.waypoint import WAYPOINT_TYPE
 from c2corg_api.scripts.es import sync
 from c2corg_api.search.notify_sync import notify_es_syncer
 from c2corg_api.views.validation import validate_association_permission, \
-    check_permission_for_association
+    check_permission_for_association_removal
 from c2corg_common.associations import valid_associations
 from cornice.resource import resource
 from cornice.validators import colander_body_validator
@@ -114,7 +114,7 @@ class AssociationRest(object):
                 raise HTTPBadRequest('association does not exist')
 
         _check_required_associations(association)
-        check_permission_for_association(self.request, association)
+        check_permission_for_association_removal(self.request, association)
 
         log = association.get_log(
             self.request.authenticated_userid, is_creation=False)

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -28,7 +28,7 @@ import c2corg_api.views.document_associations as doc_associations
 from c2corg_api.views.document_listings import add_load_for_locales, \
     add_load_for_profiles, get_documents
 from c2corg_api.views.validation import check_required_fields, \
-    check_duplicate_locales, outing_association_checker
+    check_duplicate_locales, association_permission_checker
 from functools import partial
 from pyramid.httpexceptions import HTTPNotFound, HTTPConflict, \
     HTTPBadRequest, HTTPForbidden
@@ -200,8 +200,8 @@ class DocumentRest(object):
             after_add(document, user_id=user_id)
 
         if document_in.get('associations', None):
-            check_association = outing_association_checker(self.request) if \
-                document.type != OUTING_TYPE else None
+            check_association = association_permission_checker(
+                self.request, skip_outing_check=document.type == OUTING_TYPE)
 
             added_associations = create_associations(
                 document, document_in['associations'], user_id,
@@ -272,8 +272,7 @@ class DocumentRest(object):
 
         associations = self.request.validated.get('associations', None)
         if associations:
-            check_association = outing_association_checker(self.request) if \
-                document.type != OUTING_TYPE else None
+            check_association = association_permission_checker(self.request)
 
             added_associations, removed_associations = \
                 synchronize_associations(

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -28,7 +28,8 @@ import c2corg_api.views.document_associations as doc_associations
 from c2corg_api.views.document_listings import add_load_for_locales, \
     add_load_for_profiles, get_documents
 from c2corg_api.views.validation import check_required_fields, \
-    check_duplicate_locales, association_permission_checker
+    check_duplicate_locales, association_permission_checker, \
+    association_permission_removal_checker
 from functools import partial
 from pyramid.httpexceptions import HTTPNotFound, HTTPConflict, \
     HTTPBadRequest, HTTPForbidden
@@ -272,12 +273,16 @@ class DocumentRest(object):
 
         associations = self.request.validated.get('associations', None)
         if associations:
-            check_association = association_permission_checker(self.request)
+            check_association_add = \
+                association_permission_checker(self.request)
+            check_association_remove = \
+                association_permission_removal_checker(self.request)
 
             added_associations, removed_associations = \
                 synchronize_associations(
                     document, associations, user_id,
-                    check_association=check_association)
+                    check_association_add=check_association_add,
+                    check_association_remove=check_association_remove)
 
         if update_types or associations:
             # update search index


### PR DESCRIPTION
* Moderators are allowed to do everything
* Normal users can add associations to outings if they are participant of the outing
* Normal users can add associations to reports, personal images and personal articles if they are creator of the document
* Normal users are not allowed to remove associations from collaborative documents (except associations to personal documents)

Closes https://github.com/c2corg/v6_api/issues/520