### PR TITLE
Fix xreport ES date search filter

### DIFF
--- a/c2corg_api/search/mappings/xreport_mapping.py
+++ b/c2corg_api/search/mappings/xreport_mapping.py
@@ -59,3 +59,4 @@ class SearchXreport(SearchDocument):
 
 SearchXreport.queryable_fields = QueryableMixin.get_queryable_fields(
     SearchXreport)
+SearchXreport.queryable_fields['date'] = QDate('xdate', 'date')


### PR DESCRIPTION
Previously I could not filter xreports by date and now I can (date field was missing [here](https://github.com/c2corg/v6_api/blob/master/c2corg_api/search/search_filters.py#L64-L65) )...

Probably related to https://github.com/c2corg/v6_ui/issues/1054 where this line is also missing for images. We have to check when the date range filter will be added to images (now there is one search box).