### PR TITLE
Make syncer more resilient

### DIFF
--- a/c2corg_api/scripts/es/sync.py
+++ b/c2corg_api/scripts/es/sync.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 
 def sync_es(session, batch_size=1000):
     last_update, date_now = es_sync.get_status(session)
+    log.info('Last update time: {}'.format(last_update))
 
     if not last_update:
         raise Exception('No last update time, run `fill_index` to do an '
@@ -34,10 +35,12 @@ def sync_es(session, batch_size=1000):
         get_changed_users(session, last_update) + \
         get_changed_documents_for_associations(session, last_update)
 
+    log.info('Number of changed documents: {}'.format(len(changed_documents)))
     if changed_documents:
         sync_documents(session, changed_documents, batch_size)
 
     es_sync.mark_as_updated(session, date_now)
+    log.info('Sync has finished')
 
 
 def get_changed_documents(session, last_update):

--- a/c2corg_api/scripts/es/syncer.py
+++ b/c2corg_api/scripts/es/syncer.py
@@ -29,6 +29,7 @@ class SyncWorker(ConsumerMixin):
         self.batch_size = batch_size
         self.session = session
         self.session_factory = session_factory
+        self.connect_max_retries = 3
 
     def get_consumers(self, consumer_factory, channel):
         return [consumer_factory(

--- a/development.ini.in
+++ b/development.ini.in
@@ -43,7 +43,7 @@ port = {debug_port}
 ###
 
 [loggers]
-keys = root, c2corg_api, sqlalchemy, c2corg_api_syncer
+keys = root, c2corg_api, sqlalchemy, c2corg_api_syncer, kombu
 
 [handlers]
 keys = console
@@ -64,6 +64,11 @@ qualname = c2corg_api
 level = DEBUG
 handlers =
 qualname = c2corg_api_syncer
+
+[logger_kombu]
+level = WARN
+handlers =
+qualname = kombu
 
 [logger_c2corg_api_background_jobs]
 level = DEBUG

--- a/production.ini.in
+++ b/production.ini.in
@@ -28,7 +28,7 @@ port = 6543
 ###
 
 [loggers]
-keys = root, c2corg_api, sqlalchemy, c2corg_api_syncer, gunicorn.error, gunicorn.access
+keys = root, c2corg_api, sqlalchemy, c2corg_api_syncer, c2corg_api_sync, kombu, gunicorn.error, gunicorn.access
 
 [handlers]
 keys = console
@@ -49,6 +49,16 @@ qualname = c2corg_api
 level = INFO
 handlers =
 qualname = c2corg_api_syncer
+
+[logger_c2corg_api_sync]
+level = INFO
+handlers =
+qualname = c2corg_api.scripts.es.sync
+
+[logger_kombu]
+level = WARN
+handlers =
+qualname = kombu
 
 [logger_c2corg_api_background_jobs]
 level = INFO


### PR DESCRIPTION
* Be more verbose in the logs
* In case the connection to Redis fails in the syncer, 3 retries are made. After that the syncer script crashes.
* In the API when pushing a message into the Redis queue: So far the Redis queue was created when the API instance was started. When the queue was deleted because of a problem with Redis, the API could no longer write into the queue. Now, the Redis queue is re-created.

Closes https://github.com/c2corg/v6_api/issues/534
Closes https://github.com/c2corg/v6_ui/issues/1169

ping @mfournier 