### PR TITLE
Continue to operate if Redis is down

### DIFF
--- a/c2corg_api/caching.py
+++ b/c2corg_api/caching.py
@@ -72,3 +72,26 @@ def configure_caches(settings):
             },
             replace_existing_backend=True
         )
+
+
+def get_or_create(cache, key, creator):
+    """ Try to get the value for the given key from the cache. In case of
+    errors fallback to the creator function (e.g. load from the database).
+    """
+    try:
+        return cache.get_or_create(key, creator, expiration_time=-1)
+    except:
+        log.error('Getting value from cache failed', exc_info=True)
+        return creator()
+
+
+def get_or_create_multi(cache, keys, creator, should_cache_fn=None):
+    """ Try to get the values for the given keys from the cache. In case of
+    errors fallback to the creator function (e.g. load from the database).
+    """
+    try:
+        return cache.get_or_create_multi(
+            keys, creator, expiration_time=-1, should_cache_fn=should_cache_fn)
+    except:
+        log.error('Getting values from cache failed', exc_info=True)
+        return creator(*keys)

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -266,3 +266,4 @@ def reset_cache_key():
     cache_version = settings['cache_version']
     caching.CACHE_VERSION = '{0}-{1}-{2}'.format(
         cache_version, int(time.time()), randint(0, 10**9))
+    caching.cache_status = caching.CacheStatus()

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -1,6 +1,6 @@
 import logging
 
-from c2corg_api.caching import cache_document_detail
+from c2corg_api.caching import cache_document_detail, get_or_create
 from c2corg_api.models import DBSession
 from c2corg_api.models.area import AREA_TYPE, schema_listing_area
 from c2corg_api.models.area_association import update_areas_for_document, \
@@ -114,8 +114,8 @@ class DocumentRest(object):
                 # request equals the current etag, return 'NotModified'
                 etag_cache(self.request, cache_key)
 
-                return cache_document_detail.get_or_create(
-                    cache_key, create_response, expiration_time=-1)
+                return get_or_create(
+                    cache_document_detail, cache_key, create_response)
 
         # don't cache if requesting a document for editing
         return create_response()

--- a/c2corg_api/views/document_history.py
+++ b/c2corg_api/views/document_history.py
@@ -1,4 +1,4 @@
-from c2corg_api.caching import cache_document_history
+from c2corg_api.caching import cache_document_history, get_or_create
 from c2corg_api.models import DBSession
 from c2corg_api.models.cache_version import get_cache_key
 from c2corg_api.models.document import DocumentLocale
@@ -36,8 +36,8 @@ class HistoryDocumentRest(object):
             # request equals the current etag, return 'NotModified'
             etag_cache(self.request, cache_key)
 
-            return cache_document_history.get_or_create(
-                cache_key, create_response, expiration_time=-1)
+            return get_or_create(
+                cache_document_history, cache_key, create_response)
 
     def _get_history(self, document_id, lang):
         # FIXME conditional permission check (when outings implemented)

--- a/c2corg_api/views/document_info.py
+++ b/c2corg_api/views/document_info.py
@@ -1,4 +1,4 @@
-from c2corg_api.caching import cache_document_info
+from c2corg_api.caching import cache_document_info, get_or_create
 from c2corg_api.models import DBSession
 from c2corg_api.models.cache_version import get_cache_key
 from c2corg_api.models.document import DocumentLocale, Document, \
@@ -42,8 +42,8 @@ class DocumentInfoRest(object):
         else:
             etag_cache(self.request, cache_key)
 
-            return cache_document_info.get_or_create(
-                cache_key, create_response, expiration_time=-1)
+            return get_or_create(
+                cache_document_info, cache_key, create_response)
 
     def _load_document_info(self, document_id, lang, clazz):
         is_route = clazz == Route

--- a/c2corg_api/views/document_listings.py
+++ b/c2corg_api/views/document_listings.py
@@ -1,4 +1,4 @@
-from c2corg_api.caching import cache_document_listing
+from c2corg_api.caching import cache_document_listing, get_or_create_multi
 from c2corg_api.models import DBSession
 from c2corg_api.models.area import schema_listing_area
 from c2corg_api.models.cache_version import get_document_id, \
@@ -65,8 +65,8 @@ def get_documents(documents_config, meta_params, search_documents):
         return docs
 
     # get the documents from the cache or from the database
-    documents = cache_document_listing.get_or_create_multi(
-        cache_keys, get_documents_from_cache_keys, expiration_time=-1,
+    documents = get_or_create_multi(
+        cache_document_listing, cache_keys, get_documents_from_cache_keys,
         should_cache_fn=lambda v: v is not None)
 
     documents = [doc for doc in documents if doc]

--- a/c2corg_api/views/document_version.py
+++ b/c2corg_api/views/document_version.py
@@ -1,4 +1,4 @@
-from c2corg_api.caching import cache_document_version
+from c2corg_api.caching import cache_document_version, get_or_create
 from c2corg_api.models import DBSession
 from c2corg_api.models.cache_version import get_cache_key
 from c2corg_api.models.document_history import DocumentVersion
@@ -37,8 +37,8 @@ class DocumentVersionRest(object):
             # request equals the current etag, return 'NotModified'
             etag_cache(self.request, cache_key)
 
-            return cache_document_version.get_or_create(
-                cache_key, create_response, expiration_time=-1)
+            return get_or_create(
+                cache_document_version, cache_key, create_response)
 
     def _load_version(
             self, document_id, lang, version_id, clazz, locale_clazz, schema,

--- a/c2corg_api/views/sitemap.py
+++ b/c2corg_api/views/sitemap.py
@@ -2,7 +2,7 @@ import functools
 import logging
 
 from c2corg_api import DBSession
-from c2corg_api.caching import cache_sitemap
+from c2corg_api.caching import cache_sitemap, get_or_create
 from c2corg_api.models.cache_version import CacheVersion
 from c2corg_api.models.document import Document, DocumentLocale
 from c2corg_api.models.route import ROUTE_TYPE, RouteLocale
@@ -64,8 +64,8 @@ class SitemapRest(object):
         cache_key = _get_cache_key()
         etag_cache(self.request, cache_key)
 
-        return cache_sitemap.get_or_create(
-            cache_key, _get_sitemap_index, expiration_time=-1)
+        return get_or_create(
+            cache_sitemap, cache_key, _get_sitemap_index)
 
     @view(validators=[validate_page, validate_document_type])
     def get(self):
@@ -78,10 +78,10 @@ class SitemapRest(object):
         cache_key = _get_cache_key(doc_type, i)
         etag_cache(self.request, cache_key)
 
-        return cache_sitemap.get_or_create(
+        return get_or_create(
+            cache_sitemap,
             cache_key,
-            functools.partial(_get_sitemap, doc_type, i),
-            expiration_time=-1)
+            functools.partial(_get_sitemap, doc_type, i))
 
 
 def _get_cache_key(doc_type=None, i=None):

--- a/common.ini.in
+++ b/common.ini.in
@@ -37,6 +37,9 @@ redis.queue_pool = 20
 # cache configuration
 redis.cache_key_prefix = {redis_cache_key_prefix}
 redis.cache_pool = 50
+# status refresh period (in seconds): if a request to Redis failed in the last
+# x seconds, no new request will be made.
+redis.cache_status_refresh_period = {redis_cache_status_refresh_period}
 
 cache_version = {version}
 cache_version_timestamp = False

--- a/config/default
+++ b/config/default
@@ -26,6 +26,7 @@ export redis_db_cache = 5
 export redis_exchange = c2corg_$(instanceid)
 export redis_queue_es = c2corg_$(instanceid)_es_sync
 export redis_cache_key_prefix = c2corg_$(instanceid)
+export redis_cache_status_refresh_period = 30
 
 export image_backend_url = http://c2corgv6-images.demo-camptocamp.com
 export image_url = http://c2corgv6-images.demo-camptocamp.com/active/


### PR DESCRIPTION
* If requests to the cache fail, load data from database.
* If a request to Redis failed in the last 30 seconds (on the same Gunicorn worker thread), directly get data from database without making a new request to the database.

Closes https://github.com/c2corg/v6_api/issues/573

The same is coming for the UI.

ping @mfournier 