### PR TITLE
Check and test NaN in BBOX (adv. search filter)

### DIFF
--- a/c2corg_api/search/search_filters.py
+++ b/c2corg_api/search/search_filters.py
@@ -321,6 +321,9 @@ def create_bbox_filter(query_term):
     xmin, ymin = transform(bbox3857[0], bbox3857[1])
     xmax, ymax = transform(bbox3857[2], bbox3857[3])
 
+    if xmin == xmax or ymin == ymax:
+        return None
+
     return GeoBoundingBox(
         geom={'left': xmin, 'bottom': ymin, 'right': xmax, 'top': ymax},
         type='indexed'
@@ -350,7 +353,10 @@ def parse_num(s):
         try:
             return int(s)
         except ValueError:
-            return float(s)
+            val = float(s)
+            if math.isnan(val):
+                return None
+            return val
     except ValueError:
         return None
 

--- a/c2corg_api/tests/search/test_search_filters.py
+++ b/c2corg_api/tests/search/test_search_filters.py
@@ -410,6 +410,13 @@ class AdvancedSearchTest(BaseTestCase):
         self.assertEqual(create_bbox_filter('a,b,c,d'), None)
         self.assertEqual(create_bbox_filter('1,2,3'), None)
         self.assertEqual(create_bbox_filter('1,2,3,d'), None)
+        self.assertEqual(create_bbox_filter('NaN,NaN,NaN,NaN'), None)
+        self.assertEqual(
+            create_bbox_filter('650000,4500000,650000,5700000'), None)
+        self.assertEqual(
+            create_bbox_filter('500000,5700000,650000,5700000'), None)
+        self.assertEqual(
+            create_bbox_filter('650000,5700000,650000,5700000'), None)
         self.assertBboxFilterEqual(
             create_bbox_filter('699398,5785365,699498,5785465').to_dict(),
             GeoBoundingBox(


### PR DESCRIPTION
Close https://github.com/c2corg/v6_api/issues/582

I think this caused the error (in my tests). With this fix, it should be ok.

```
...
File "/home/davidk/git/c2c/v6_api/c2corg_api/tests/search/test_search_filters.py", line 413, in test_create_bbox_filter
    self.assertEqual(create_bbox_filter('NaN,NaN,NaN,NaN'), None)
  File "/usr/lib/python3.5/unittest/case.py", line 820, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/usr/lib/python3.5/unittest/case.py", line 813, in _baseAssertEqual
    raise self.failureException(msg)
AssertionError: GeoBoundingBox(geom={'left': nan, 'right'[45 chars]xed') != None
-------------------- >> begin captured logging << --------------------
sqlalchemy.engine.base.Engine: INFO: BEGIN (implicit)
sqlalchemy.engine.base.Engine: INFO: ROLLBACK
--------------------- >> end captured logging << ---------------------
```