### PR TITLE
Add topic_id in create topic error response

### DIFF
--- a/c2corg_api/tests/views/test_forum.py
+++ b/c2corg_api/tests/views/test_forum.py
@@ -73,6 +73,7 @@ class TestForumTopicRest(BaseTestRest):
             status=400)
         errors = json.get('errors')
         self.assertEqual('Topic already exists', errors[0].get('description'))
+        self.assertEqual(1, errors[0].get('topic_id'))
 
     @patch('pydiscourse.client.DiscourseClient.create_post',
            side_effect=ConnectionError())

--- a/c2corg_api/views/forum.py
+++ b/c2corg_api/views/forum.py
@@ -61,7 +61,8 @@ def validate_topic_create(request, **kwargs):
     if locale.topic_id is not None:
         request.errors.add('body',
                            '{}_{}'.format(document_id, lang),
-                           'Topic already exists')
+                           'Topic already exists',
+                           topic_id=locale.topic_id)
 
 
 # Here path is required by cornice but related routes are not implemented


### PR DESCRIPTION
Add the ``topic_id`` in "topic exists" error, to be used by ui to show the existing topic in document page.

Relate https://github.com/c2corg/v6_ui/issues/1216#issuecomment-272490568