### PR TITLE
Handle validation errors without crashing for /images/list

### DIFF
--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -920,6 +920,26 @@ class TestImageListRest(BaseTestImage):
         self.assertIsNotNone(feed_change.image2_id)
         self.assertNotEqual(feed_change.image1_id, feed_change.image2_id)
 
+    @patch('c2corg_api.views.image.requests.post',
+           return_value=Mock(status_code=200))
+    def test_post_validation_error(self, post_mock):
+        request_body = {
+            'images': [
+                self._post_success_document({
+                    'geometry': {
+                        'geom': '{"coordinates": [1, null], "type": "Point"}'
+                    }
+                })
+            ]
+        }
+
+        headers = self.add_authorization_header(username='contributor')
+        response = self.app_post_json('/images/list', request_body,
+                                      headers=headers, status=400)
+
+        body = response.json
+        self.assertErrorsContain(body, 'images.0.geometry.geom')
+
 
 class TestImageProxyRest(BaseTestRest):
 

--- a/c2corg_api/views/image.py
+++ b/c2corg_api/views/image.py
@@ -75,6 +75,9 @@ validate_associations_update = functools.partial(
 
 
 def validate_list_image_create(request, **kwargs):
+    if not request.validated.get('images'):
+        return
+
     for image in request.validated['images']:
         validate_document(image, request, fields_image.get('required'),
                           updating=False)
@@ -82,6 +85,9 @@ def validate_list_image_create(request, **kwargs):
 
 
 def validate_list_associations_create(request, **kwargs):
+    if not request.validated.get('images'):
+        return
+
     for document in request.validated['images']:
         associations_in = document.get('associations', None)
         if not associations_in:


### PR DESCRIPTION
Validation errors as reported in https://github.com/c2corg/v6_api/issues/600 should not lead to a crash, instead the validation errors should be returned.