### PR TITLE
Document deleting tool

### DIFF
--- a/alembic_migration/versions/8cc46db2c515_add_table_es_deleted_documents.py
+++ b/alembic_migration/versions/8cc46db2c515_add_table_es_deleted_documents.py
@@ -1,0 +1,31 @@
+"""Add table es_deleted_documents
+
+Revision ID: 8cc46db2c515
+Revises: 7e32b653172f
+Create Date: 2017-02-10 11:42:50.525024
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8cc46db2c515'
+down_revision = '7e32b653172f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'es_deleted_documents',
+        sa.Column('document_id', sa.Integer(), primary_key=True),
+        sa.Column('type', sa.String(1)),
+        sa.Column(
+            'deleted_at', sa.DateTime(timezone=True),
+            server_default=sa.text('now()'), nullable=False, index=True),
+        schema='guidebook')
+
+
+def downgrade():
+    op.drop_table('es_deleted_documents', schema='guidebook')

--- a/c2corg_api/models/es_sync.py
+++ b/c2corg_api/models/es_sync.py
@@ -1,7 +1,7 @@
 from c2corg_api.models import Base, schema
 from sqlalchemy.sql.functions import func
 from sqlalchemy.sql.schema import Column, CheckConstraint
-from sqlalchemy.sql.sqltypes import DateTime, Integer
+from sqlalchemy.sql.sqltypes import DateTime, Integer, String
 
 
 class ESSyncStatus(Base):
@@ -34,3 +34,18 @@ def mark_as_updated(session, new_update_time):
         update(
             {ESSyncStatus.last_update: new_update_time},
             synchronize_session=False)
+
+
+class ESDeletedDocument(Base):
+    """A table listing documents that have been deleted and that should be
+    removed from the ES index.
+    """
+    __tablename__ = 'es_deleted_documents'
+
+    document_id = Column(Integer, primary_key=True)
+
+    type = Column(String(1))
+
+    deleted_at = Column(
+        DateTime(timezone=True), default=func.now(), nullable=False,
+        index=True)

--- a/c2corg_api/scripts/es/sync.py
+++ b/c2corg_api/scripts/es/sync.py
@@ -3,6 +3,7 @@ from c2corg_api.models.area import Area
 from c2corg_api.models.association import AssociationLog, Association
 from c2corg_api.models.document import Document, DocumentGeometry
 from c2corg_api.models.document_history import DocumentVersion, HistoryMetaData
+from c2corg_api.models.es_sync import ESDeletedDocument
 from c2corg_api.models.outing import Outing, OUTING_TYPE
 from c2corg_api.models.route import Route, ROUTE_TYPE
 from c2corg_api.models.user import User
@@ -38,6 +39,13 @@ def sync_es(session, batch_size=1000):
     log.info('Number of changed documents: {}'.format(len(changed_documents)))
     if changed_documents:
         sync_documents(session, changed_documents, batch_size)
+
+    # get list of documents deleted since the last update
+    deleted_documents = get_deleted_documents(session, last_update)
+
+    log.info('Number of deleted documents: {}'.format(len(deleted_documents)))
+    if deleted_documents:
+        sync_deleted_documents(session, deleted_documents, batch_size)
 
     es_sync.mark_as_updated(session, date_now)
     log.info('Sync has finished')
@@ -234,6 +242,15 @@ def get_changed_outings_ro_uo(session, last_update):
         all()
 
 
+def get_deleted_documents(session, last_update):
+    """Returns the ids of documents deleted since the last update.
+    """
+    return session. \
+        query(ESDeletedDocument.document_id, ESDeletedDocument.type) . \
+        filter(ESDeletedDocument.deleted_at >= last_update). \
+        all()
+
+
 def sync_documents(session, changed_documents, batch_size):
     client = elasticsearch_config['client']
     batch = ElasticBatch(client, batch_size)
@@ -245,6 +262,24 @@ def sync_documents(session, changed_documents, batch_size):
                 docs = get_documents(
                     session, doc_type, batch_size, document_ids)
                 create_search_documents(doc_type, docs, batch)
+
+
+def sync_deleted_documents(session, deleted_documents, batch_size):
+    client = elasticsearch_config['client']
+    batch = ElasticBatch(client, batch_size)
+    index = elasticsearch_config['index']
+    n = 0
+    with batch:
+        for document_id, doc_type in deleted_documents:
+            batch.add({
+                '_index': index,
+                '_id': document_id,
+                '_type': doc_type,
+                'id': document_id,
+                '_op_type': 'delete'
+            })
+            n += 1
+        log.info('Removed {} document(s)'.format(n))
 
 
 def add_dependent_documents(session, docs_per_type):

--- a/c2corg_api/scripts/es/sync.py
+++ b/c2corg_api/scripts/es/sync.py
@@ -279,7 +279,7 @@ def sync_deleted_documents(session, deleted_documents, batch_size):
                 '_op_type': 'delete'
             })
             n += 1
-        log.info('Removed {} document(s)'.format(n))
+    log.info('Removed {} document(s)'.format(n))
 
 
 def add_dependent_documents(session, docs_per_type):

--- a/c2corg_api/tests/views/test_document_delete.py
+++ b/c2corg_api/tests/views/test_document_delete.py
@@ -9,6 +9,7 @@ from c2corg_api.models.document import (
     Document, DocumentLocale, DocumentGeometry, ArchiveDocument,
     ArchiveDocumentLocale, ArchiveDocumentGeometry, UpdateType)
 from c2corg_api.models.document_history import DocumentVersion
+from c2corg_api.models.document_topic import DocumentTopic
 from c2corg_api.models.feed import update_feed_document_create, DocumentChange
 from c2corg_api.models.image import Image, ArchiveImage
 from c2corg_api.models.outing import (
@@ -55,6 +56,7 @@ class TestDocumentDeleteRest(BaseTestRest):
                 WaypointLocale(
                     lang='en', title='Mont Blanc',
                     description='...',
+                    document_topic=DocumentTopic(topic_id=1),
                     summary='The heighest point in Europe')
             ])
         self.session.add(self.waypoint2)
@@ -65,10 +67,10 @@ class TestDocumentDeleteRest(BaseTestRest):
                 geom='SRID=3857;POINT(635956 5723604)'))
         self.waypoint3.locales.append(WaypointLocale(
             lang='en', title='Mont Granier', description='...',
-            access='yep'))
+            access='yep', document_topic=DocumentTopic(topic_id=2)))
         self.waypoint3.locales.append(WaypointLocale(
             lang='fr', title='Mont Granier', description='...',
-            access='ouai'))
+            access='ouai', document_topic=DocumentTopic(topic_id=3)))
         self.session.add(self.waypoint3)
         self.session.flush()
 
@@ -104,7 +106,8 @@ class TestDocumentDeleteRest(BaseTestRest):
         )
         self.route2.locales.append(RouteLocale(
             lang='en', title='Mont Blanc from the air', description='...',
-            title_prefix='Mont Blanc :', gear='paraglider'))
+            title_prefix='Mont Blanc :', gear='paraglider',
+            document_topic=DocumentTopic(topic_id=4)))
         self.session.add(self.route2)
         self.session.flush()
 
@@ -122,7 +125,8 @@ class TestDocumentDeleteRest(BaseTestRest):
         )
         self.route3.locales.append(RouteLocale(
             lang='en', title='Mont Blanc from the air', description='...',
-            title_prefix='Mont Blanc :', gear='paraglider'))
+            title_prefix='Mont Blanc :', gear='paraglider',
+            document_topic=DocumentTopic(topic_id=5)))
         self.session.add(self.route3)
         self.session.flush()
 
@@ -148,7 +152,7 @@ class TestDocumentDeleteRest(BaseTestRest):
             locales=[
                 OutingLocale(
                     lang='en', title='...', description='...',
-                    weather='sunny')
+                    weather='sunny', document_topic=DocumentTopic(topic_id=6))
             ]
         )
         self.session.add(self.outing1)
@@ -169,7 +173,7 @@ class TestDocumentDeleteRest(BaseTestRest):
             locales=[
                 OutingLocale(
                     lang='en', title='...', description='...',
-                    weather='sunny')
+                    weather='sunny', document_topic=DocumentTopic(topic_id=7))
             ]
         )
         self.session.add(self.outing2)
@@ -187,7 +191,8 @@ class TestDocumentDeleteRest(BaseTestRest):
             locales=[
                 DocumentLocale(
                     lang='en', title='Some article',
-                    description='Some content')
+                    description='Some content',
+                    document_topic=DocumentTopic(topic_id=8))
             ]
         )
         self.session.add(self.article1)
@@ -204,7 +209,8 @@ class TestDocumentDeleteRest(BaseTestRest):
             locales=[
                 DocumentLocale(
                     lang='en', title='Some book',
-                    description='Some content')
+                    description='Some content',
+                    document_topic=DocumentTopic(topic_id=9))
             ]
         )
         self.session.add(self.book1)
@@ -221,10 +227,12 @@ class TestDocumentDeleteRest(BaseTestRest):
             locales=[
                 XreportLocale(
                     lang='en', title='Lac d\'Annecy',
-                    place='some place descrip. in english'),
+                    place='some place descrip. in english',
+                    document_topic=DocumentTopic(topic_id=10)),
                 XreportLocale(
                     lang='fr', title='Lac d\'Annecy',
-                    place='some place descrip. in french')
+                    place='some place descrip. in french',
+                    document_topic=DocumentTopic(topic_id=11))
             ]
         )
         self.session.add(self.xreport1)
@@ -243,7 +251,8 @@ class TestDocumentDeleteRest(BaseTestRest):
             locales=[
                 DocumentLocale(
                     lang='en', title='Mont Blanc from the air',
-                    description='...')])
+                    description='...',
+                    document_topic=DocumentTopic(topic_id=12))])
         self.session.add(self.image1)
         self.session.flush()
 
@@ -268,7 +277,8 @@ class TestDocumentDeleteRest(BaseTestRest):
             locales=[
                 DocumentLocale(
                     lang='en', title='Mont Blanc from the air',
-                    description='...')])
+                    description='...',
+                    document_topic=DocumentTopic(topic_id=13))])
         self.session.add(self.image2)
         self.session.flush()
 
@@ -462,8 +472,6 @@ class TestDocumentDeleteRest(BaseTestRest):
             DocumentChange.document_id == document_id
         ).count()
         self.assertEqual(0, feed_count)
-
-        # TODO check comments have been cleared
 
     def test_delete_waypoint(self):
         self._test_delete(

--- a/c2corg_api/tests/views/test_document_delete.py
+++ b/c2corg_api/tests/views/test_document_delete.py
@@ -7,7 +7,7 @@ from c2corg_api.models.document import (
     Document, DocumentLocale, DocumentGeometry, ArchiveDocument,
     ArchiveDocumentLocale, ArchiveDocumentGeometry, UpdateType)
 from c2corg_api.models.document_history import DocumentVersion
-from c2corg_api.models.feed import update_feed_document_create
+from c2corg_api.models.feed import update_feed_document_create, DocumentChange
 from c2corg_api.models.image import Image, ArchiveImage
 from c2corg_api.models.outing import (
     Outing, OutingLocale, ArchiveOuting, ArchiveOutingLocale)
@@ -408,7 +408,13 @@ class TestDocumentDeleteRest(BaseTestRest):
         self.assertEqual(0, association_log_count)
 
         # TODO check cache_versions have been updated
-        # TODO check the feed has been cleared
+
+        # Check the feed has been cleared
+        feed_count = self.session.query(DocumentChange).filter(
+            DocumentChange.document_id == document_id
+        ).count()
+        self.assertEqual(0, feed_count)
+
         # TODO check comments have been cleared
 
     def test_delete_waypoint(self):

--- a/c2corg_api/tests/views/test_document_delete.py
+++ b/c2corg_api/tests/views/test_document_delete.py
@@ -1,0 +1,332 @@
+import datetime
+
+from c2corg_api.models.association import Association
+from c2corg_api.models.document import (
+    Document, DocumentLocale, DocumentGeometry, ArchiveDocument,
+    ArchiveDocumentLocale, ArchiveDocumentGeometry)
+from c2corg_api.models.document_history import DocumentVersion
+from c2corg_api.models.feed import update_feed_document_create
+from c2corg_api.models.outing import (
+    Outing, OutingLocale, ArchiveOuting, ArchiveOutingLocale)
+from c2corg_api.models.route import (
+    Route, RouteLocale, ArchiveRoute, ArchiveRouteLocale)
+from c2corg_api.models.waypoint import (
+    Waypoint, WaypointLocale, ArchiveWaypoint, ArchiveWaypointLocale)
+from c2corg_api.views.document import DocumentRest
+from c2corg_api.tests.views import BaseTestRest
+
+
+class TestDocumentDeleteRest(BaseTestRest):
+
+    def setUp(self):  # noqa
+        super(TestDocumentDeleteRest, self).setUp()
+        self._prefix = '/documents/delete/'
+
+        user_id = self.global_userids['contributor']
+
+        self.waypoint1 = Waypoint(
+            waypoint_type='summit', elevation=2000,
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POINT(635956 5723604)'),
+            locales=[
+                WaypointLocale(
+                    lang='fr', title='Dent de Crolles',
+                    description='...',
+                    summary='La Dent de Crolles')
+            ])
+        self.session.add(self.waypoint1)
+
+        self.waypoint2 = Waypoint(
+            waypoint_type='summit', elevation=4985,
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POINT(635956 5723604)'),
+            locales=[
+                WaypointLocale(
+                    lang='en', title='Mont Blanc',
+                    description='...',
+                    summary='The heighest point in Europe')
+            ])
+        self.session.add(self.waypoint2)
+
+        self.waypoint3 = Waypoint(
+            waypoint_type='summit', elevation=3,
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POINT(635956 5723604)'))
+        self.waypoint3.locales.append(WaypointLocale(
+            lang='en', title='Mont Granier', description='...',
+            access='yep'))
+        self.waypoint3.locales.append(WaypointLocale(
+            lang='fr', title='Mont Granier', description='...',
+            access='ouai'))
+        self.session.add(self.waypoint3)
+        self.session.flush()
+
+        DocumentRest.create_new_version(self.waypoint1, user_id)
+        update_feed_document_create(self.waypoint1, user_id)
+        DocumentRest.create_new_version(self.waypoint2, user_id)
+        update_feed_document_create(self.waypoint2, user_id)
+        DocumentRest.create_new_version(self.waypoint3, user_id)
+        update_feed_document_create(self.waypoint3, user_id)
+        self.session.flush()
+
+        route1_geometry = DocumentGeometry(
+            geom_detail='SRID=3857;LINESTRING(635956 5723604, 635966 5723644)',
+            geom='SRID=3857;POINT(635961 5723624)')
+        self.route1 = Route(
+            activities=['skitouring'], elevation_max=1500, elevation_min=700,
+            height_diff_up=800, height_diff_down=800, durations='1',
+            main_waypoint_id=self.waypoint1.document_id,
+            geometry=route1_geometry
+        )
+        self.route1.locales.append(RouteLocale(
+            lang='en', title='Mont Blanc from the air', description='...',
+            title_prefix='Mont Blanc :', gear='paraglider'))
+        self.session.add(self.route1)
+
+        route2_geometry = DocumentGeometry(
+            geom_detail='SRID=3857;LINESTRING(635956 5723604, 635966 5723644)',
+            geom='SRID=3857;POINT(635961 5723624)')
+        self.route2 = Route(
+            activities=['skitouring'], elevation_max=1500, elevation_min=700,
+            height_diff_up=800, height_diff_down=800, durations='1',
+            geometry=route2_geometry
+        )
+        self.route2.locales.append(RouteLocale(
+            lang='en', title='Mont Blanc from the air', description='...',
+            title_prefix='Mont Blanc :', gear='paraglider'))
+        self.session.add(self.route2)
+        self.session.flush()
+
+        self.session.add(Association.create(
+            parent_document=self.waypoint1,
+            child_document=self.route1))
+        self.session.add(Association.create(
+            parent_document=self.waypoint2,
+            child_document=self.route2))
+        self.session.flush()
+
+        route3_geometry = DocumentGeometry(
+            geom_detail='SRID=3857;LINESTRING(635956 5723604, 635966 5723644)',
+            geom='SRID=3857;POINT(635961 5723624)')
+        self.route3 = Route(
+            activities=['skitouring'], elevation_max=1500, elevation_min=700,
+            height_diff_up=800, height_diff_down=800, durations='1',
+            geometry=route3_geometry
+        )
+        self.route3.locales.append(RouteLocale(
+            lang='en', title='Mont Blanc from the air', description='...',
+            title_prefix='Mont Blanc :', gear='paraglider'))
+        self.session.add(self.route3)
+        self.session.flush()
+
+        DocumentRest.create_new_version(self.route1, user_id)
+        update_feed_document_create(self.route1, user_id)
+        DocumentRest.create_new_version(self.route2, user_id)
+        update_feed_document_create(self.route2, user_id)
+        DocumentRest.create_new_version(self.route3, user_id)
+        update_feed_document_create(self.route3, user_id)
+
+        self.session.add(Association.create(
+            parent_document=self.waypoint1,
+            child_document=self.route3))
+        self.session.add(Association.create(
+            parent_document=self.waypoint2,
+            child_document=self.route3))
+        self.session.add(Association.create(
+            parent_document=self.waypoint3,
+            child_document=self.route3))
+        self.session.flush()
+
+        outing1_geometry = DocumentGeometry(
+            geom_detail='SRID=3857;LINESTRING(635956 5723604, 635966 5723644)',
+            geom='SRID=3857;POINT(635961 5723624)')
+        self.outing1 = Outing(
+            activities=['skitouring'], date_start=datetime.date(2016, 1, 1),
+            date_end=datetime.date(2016, 1, 1),
+            geometry=outing1_geometry,
+            locales=[
+                OutingLocale(
+                    lang='en', title='...', description='...',
+                    weather='sunny')
+            ]
+        )
+        self.session.add(self.outing1)
+        self.session.flush()
+
+        DocumentRest.create_new_version(self.outing1, user_id)
+        update_feed_document_create(self.outing1, user_id)
+        self.session.add(Association.create(
+            parent_document=self.route1,
+            child_document=self.outing1))
+        self.session.flush()
+
+        outing2_geometry = DocumentGeometry(
+            geom_detail='SRID=3857;LINESTRING(635956 5723604, 635966 5723644)',
+            geom='SRID=3857;POINT(635961 5723624)')
+        self.outing2 = Outing(
+            activities=['skitouring'], date_start=datetime.date(2016, 1, 1),
+            date_end=datetime.date(2016, 1, 1),
+            geometry=outing2_geometry,
+            locales=[
+                OutingLocale(
+                    lang='en', title='...', description='...',
+                    weather='sunny')
+            ]
+        )
+        self.session.add(self.outing2)
+        self.session.flush()
+
+        DocumentRest.create_new_version(self.outing2, user_id)
+        update_feed_document_create(self.outing2, user_id)
+        self.session.add(Association.create(
+            parent_document=self.route2,
+            child_document=self.outing2))
+        self.session.add(Association.create(
+            parent_document=self.route3,
+            child_document=self.outing2))
+        self.session.flush()
+
+    def _delete(self, document_id, expected_status):
+        headers = self.add_authorization_header(username='moderator')
+        return self.app.delete_json(
+            self._prefix + str(document_id),
+            headers=headers, status=expected_status)
+
+    def test_non_unauthorized(self):
+        self.app.delete_json(
+            self._prefix + str(self.waypoint1.document_id), {}, status=403)
+
+        headers = self.add_authorization_header(username='contributor')
+        return self.app.delete_json(
+            self._prefix + str(self.waypoint1.document_id), {},
+            headers=headers, status=403)
+
+    def test_non_existing_document(self):
+        self._delete(-9999999, 400)
+
+    def test_delete_main_waypoint(self):
+        """ Test that a main waypoint cannot be deleted.
+        """
+        response = self._delete(self.waypoint1.document_id, 400)
+        errors = response.json.get('errors')
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].get('name'), 'Bad Request')
+        self.assertEqual(
+            errors[0].get('description'),
+            'This waypoint cannot be deleted because it is a main waypoint.')
+
+    def test_delete_only_waypoint_of_route(self):
+        """ Test that the only waypoint of a route cannot be deleted.
+        """
+        response = self._delete(self.waypoint2.document_id, 400)
+        errors = response.json.get('errors')
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].get('name'), 'Bad Request')
+        self.assertEqual(
+            errors[0].get('description'),
+            'This waypoint cannot be deleted because '
+            'it is the only waypoint associated to some routes.')
+
+    def test_delete_only_route_of_outing(self):
+        """ Test that a route cannot be deleted if it is the only route
+            of some outing."""
+        response = self._delete(self.route1.document_id, 400)
+        errors = response.json.get('errors')
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].get('name'), 'Bad Request')
+        self.assertEqual(
+            errors[0].get('description'),
+            'This route cannot be deleted because '
+            'it is the only route associated to some outings.')
+
+    def _test_delete(
+            self, document_id, clazz, clazz_locale, archive_clazz,
+            archive_clazz_locale):
+
+        # Get the number of documents before deleting
+        initial_count = self.session.query(clazz).count()
+        initial_doc_count = self.session.query(Document).count()
+
+        self._delete(document_id, 200)
+
+        # Check that only one document has been deleted
+        count = self.session.query(clazz).count()
+        self.assertEqual(count, initial_count - 1)
+        count = self.session.query(Document).count()
+        self.assertEqual(count, initial_doc_count - 1)
+
+        # Check that the document versions table is cleared
+        count = self.session.query(DocumentVersion). \
+            filter(DocumentVersion.document_id == document_id).count()
+        self.assertEqual(0, count)
+
+        # Check that entries have been removed in the main tables
+        count = self.session.query(clazz). \
+            filter(getattr(clazz, 'document_id') == document_id).count()
+        self.assertEqual(0, count)
+        count = self.session.query(Document). \
+            filter(Document.document_id == document_id).count()
+        self.assertEqual(0, count)
+        if clazz_locale:
+            count = self.session.query(clazz_locale). \
+                filter(getattr(clazz_locale, 'document_id') == document_id). \
+                count()
+            self.assertEqual(0, count)
+        count = self.session.query(DocumentLocale). \
+            filter(DocumentLocale.document_id == document_id).count()
+        self.assertEqual(0, count)
+        count = self.session.query(DocumentGeometry). \
+            filter(DocumentGeometry.document_id == document_id).count()
+        self.assertEqual(0, count)
+
+        # Check the archives have been cleared too
+        count = self.session.query(archive_clazz). \
+            filter(getattr(archive_clazz, 'document_id') == document_id). \
+            count()
+        self.assertEqual(0, count)
+        count = self.session.query(ArchiveDocument). \
+            filter(ArchiveDocument.document_id == document_id).count()
+        self.assertEqual(0, count)
+        if archive_clazz_locale:
+            count = self.session.query(archive_clazz_locale). \
+                filter(getattr(
+                    archive_clazz_locale, 'document_id') == document_id). \
+                count()
+            self.assertEqual(0, count)
+        count = self.session.query(ArchiveDocumentLocale). \
+            filter(ArchiveDocumentLocale.document_id == document_id).count()
+        self.assertEqual(0, count)
+        count = self.session.query(ArchiveDocumentGeometry). \
+            filter(ArchiveDocumentGeometry.document_id == document_id).count()
+        self.assertEqual(0, count)
+
+        # TODO check associations have been cleared
+        # TODO check cache_versions have been updated
+        # TODO check the feed has been cleared
+        # TODO check comments have been cleared
+
+    def test_delete_waypoint(self):
+        self._test_delete(
+            self.waypoint3.document_id,
+            Waypoint, WaypointLocale, ArchiveWaypoint, ArchiveWaypointLocale)
+
+    def test_delete_route(self):
+        self._test_delete(
+            self.route3.document_id,
+            Route, RouteLocale, ArchiveRoute, ArchiveRouteLocale)
+
+    def test_delete_outing(self):
+        self._test_delete(
+            self.outing1.document_id,
+            Outing, OutingLocale, ArchiveOuting, ArchiveOutingLocale)
+
+    def test_delete_outing_route_waypoint(self):
+        self._test_delete(
+            self.outing2.document_id,
+            Outing, OutingLocale, ArchiveOuting, ArchiveOutingLocale)
+        self._test_delete(
+            self.route2.document_id,
+            Route, RouteLocale, ArchiveRoute, ArchiveRouteLocale)
+        self._test_delete(
+            self.waypoint2.document_id,
+            Waypoint, WaypointLocale, ArchiveWaypoint, ArchiveWaypointLocale)

--- a/c2corg_api/tests/views/test_document_merge.py
+++ b/c2corg_api/tests/views/test_document_merge.py
@@ -242,14 +242,8 @@ class TestDocumentMergeRest(BaseTestRest):
         @all_requests
         def image_service_mock(url, request):
             call['times'] += 1
-
-            self.assertEqual(
-                request.body,
-                'filenames=image1.1.jpg&filenames=image1.jpg&secret=test')
-            self.assertEqual(
-                request.url,
-                'http://images.demov6.camptocamp.org/delete')
-
+            call['request.body'] = request.body.split('&')
+            call['request.url'] = request.url
             return {
                 'status_code': 200,
                 'content': ''
@@ -261,6 +255,11 @@ class TestDocumentMergeRest(BaseTestRest):
                 'target_document_id': self.image2.document_id
             }, 200)
             self.assertEqual(call['times'], 1)
+            self.assertIn('filenames=image1.1.jpg', call['request.body'])
+            self.assertIn('filenames=image1.jpg', call['request.body'])
+            self.assertEqual(
+                call['request.url'],
+                self.settings['image_backend.url'] + '/delete')
 
     def test_merge_image_error_deleting_files(self):
         """ Test that the merge request is also successful if the image files
@@ -271,14 +270,8 @@ class TestDocumentMergeRest(BaseTestRest):
         @all_requests
         def image_service_mock(url, request):
             call['times'] += 1
-
-            self.assertEqual(
-                request.body,
-                'filenames=image1.1.jpg&filenames=image1.jpg&secret=test')
-            self.assertEqual(
-                request.url,
-                'http://images.demov6.camptocamp.org/delete')
-
+            call['request.body'] = request.body.split('&')
+            call['request.url'] = request.url
             return {
                 'status_code': 500,
                 'content': 'some random error'
@@ -290,3 +283,8 @@ class TestDocumentMergeRest(BaseTestRest):
                 'target_document_id': self.image2.document_id
             }, 200)
             self.assertEqual(call['times'], 1)
+            self.assertIn('filenames=image1.1.jpg', call['request.body'])
+            self.assertIn('filenames=image1.jpg', call['request.body'])
+            self.assertEqual(
+                call['request.url'],
+                self.settings['image_backend.url'] + '/delete')

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -1473,11 +1473,13 @@ class TestWaypointRest(BaseDocumentTestRest):
             geometry=DocumentGeometry(
                 geom='SRID=3857;POINT(635956 5723604)'))
         self.session.add(self.waypoint2)
+
         self.waypoint3 = Waypoint(
             waypoint_type='summit', elevation=3,
             geometry=DocumentGeometry(
                 geom='SRID=3857;POINT(635956 5723604)'))
         self.session.add(self.waypoint3)
+
         self.waypoint4 = Waypoint(
             waypoint_type='summit', elevation=4,
             protected=True,
@@ -1490,6 +1492,7 @@ class TestWaypointRest(BaseDocumentTestRest):
             lang='fr', title='Mont Granier', description='...',
             access='ouai'))
         self.session.add(self.waypoint4)
+
         self.waypoint5 = Waypoint(
             waypoint_type='summit', elevation=3,
             redirects_to=self.waypoint.document_id,
@@ -1500,10 +1503,9 @@ class TestWaypointRest(BaseDocumentTestRest):
             access='yep'))
         self.session.add(self.waypoint5)
         self.session.flush()
-        DocumentRest.create_new_version(
-            self.waypoint4, self.global_userids['contributor'])
-        DocumentRest.create_new_version(
-            self.waypoint5, self.global_userids['contributor'])
+
+        DocumentRest.create_new_version(self.waypoint4, user_id)
+        DocumentRest.create_new_version(self.waypoint5, user_id)
 
         # add some associations
         route1_geometry = DocumentGeometry(

--- a/c2corg_api/views/document_delete.py
+++ b/c2corg_api/views/document_delete.py
@@ -130,6 +130,10 @@ class DeleteDocumentRest(object):
         # Note: if an error occurs while deleting, SqlAlchemy will
         # automatically cancel all DB changes.
 
+        if document_type == IMAGE_TYPE:
+            # Files are actually removed only if the transaction succeeds
+            delete_all_files_for_image(document_id, self.request)
+
         _remove_from_cache(document_id)
 
         # Remove associations and update cache of formerly associated docs
@@ -156,9 +160,6 @@ class DeleteDocumentRest(object):
         # When all references have been deleted, finally remove the main
         # document entry
         _remove_document(document_id)
-
-        if document_type == IMAGE_TYPE:
-            delete_all_files_for_image(document_id, self.request)
 
         _update_deleted_documents_list(document_id, document_type)
         notify_es_syncer(self.request.registry.queue_config)

--- a/c2corg_api/views/document_delete.py
+++ b/c2corg_api/views/document_delete.py
@@ -1,4 +1,5 @@
 from c2corg_api.models import DBSession
+from c2corg_api.models.area_association import AreaAssociation
 from c2corg_api.models.article import ARTICLE_TYPE, Article, ArchiveArticle
 from c2corg_api.models.association import Association, AssociationLog
 from c2corg_api.models.book import BOOK_TYPE, Book, ArchiveBook
@@ -16,6 +17,7 @@ from c2corg_api.models.outing import (
     OUTING_TYPE, Outing, OutingLocale, ArchiveOuting, ArchiveOutingLocale)
 from c2corg_api.models.route import (
     ROUTE_TYPE, Route, RouteLocale, ArchiveRoute, ArchiveRouteLocale)
+from c2corg_api.models.topo_map_association import TopoMapAssociation
 from c2corg_api.models.waypoint import (
     WAYPOINT_TYPE, Waypoint, WaypointLocale, ArchiveWaypoint,
     ArchiveWaypointLocale)
@@ -312,6 +314,10 @@ def _remove_associations(document_id):
             AssociationLog.parent_document_id == document_id,
             AssociationLog.child_document_id == document_id
         )).delete()
+    DBSession.query(TopoMapAssociation). \
+        filter(TopoMapAssociation.document_id == document_id).delete()
+    DBSession.query(AreaAssociation). \
+        filter(AreaAssociation.document_id == document_id).delete()
 
 
 def _update_deleted_documents_list(document_id, document_type):

--- a/c2corg_api/views/document_delete.py
+++ b/c2corg_api/views/document_delete.py
@@ -220,14 +220,15 @@ def _remove_archive_locale(archive_clazz_locale, document_id):
 
 
 def _remove_locale(clazz_locale, document_id):
+    document_locale_ids = DBSession.query(DocumentLocale.id). \
+        filter(DocumentLocale.document_id == document_id). \
+        subquery()
+    # Remove links to comments (comments themselves are not removed)
+    DBSession.execute(DocumentTopic.__table__.delete().where(
+        DocumentTopic.document_locale_id.in_(document_locale_ids)
+    ))
+
     if clazz_locale:
-        document_locale_ids = DBSession.query(DocumentLocale.id). \
-            filter(DocumentLocale.document_id == document_id). \
-            subquery()
-        # Remove links to comments (comments themselves are not removed)
-        DBSession.execute(DocumentTopic.__table__.delete().where(
-            DocumentTopic.document_locale_id.in_(document_locale_ids)
-        ))
         DBSession.execute(clazz_locale.__table__.delete().where(
             getattr(clazz_locale, 'id').in_(document_locale_ids)
         ))

--- a/c2corg_api/views/document_delete.py
+++ b/c2corg_api/views/document_delete.py
@@ -1,6 +1,6 @@
 from c2corg_api.models import DBSession
 from c2corg_api.models.article import ARTICLE_TYPE, Article, ArchiveArticle
-from c2corg_api.models.association import Association
+from c2corg_api.models.association import Association, AssociationLog
 from c2corg_api.models.book import BOOK_TYPE, Book, ArchiveBook
 from c2corg_api.models.cache_version import CacheVersion, \
     update_cache_version_full
@@ -289,6 +289,11 @@ def _remove_associations(document_id):
         filter(or_(
             Association.parent_document_id == document_id,
             Association.child_document_id == document_id
+        )).delete()
+    DBSession.query(AssociationLog). \
+        filter(or_(
+            AssociationLog.parent_document_id == document_id,
+            AssociationLog.child_document_id == document_id
         )).delete()
 
 

--- a/c2corg_api/views/document_delete.py
+++ b/c2corg_api/views/document_delete.py
@@ -1,0 +1,294 @@
+from c2corg_api.models import DBSession
+from c2corg_api.models.article import ARTICLE_TYPE, Article, ArchiveArticle
+from c2corg_api.models.association import Association
+from c2corg_api.models.book import BOOK_TYPE, Book, ArchiveBook
+from c2corg_api.models.cache_version import CacheVersion, \
+    update_cache_version_full
+from c2corg_api.models.document import (
+    Document, DocumentLocale, ArchiveDocumentLocale,
+    ArchiveDocument, DocumentGeometry, ArchiveDocumentGeometry)
+from c2corg_api.models.document_history import HistoryMetaData, DocumentVersion
+from c2corg_api.models.document_topic import DocumentTopic
+from c2corg_api.models.feed import DocumentChange
+from c2corg_api.models.image import IMAGE_TYPE, Image, ArchiveImage
+from c2corg_api.models.outing import (
+    OUTING_TYPE, Outing, OutingLocale, ArchiveOuting, ArchiveOutingLocale)
+from c2corg_api.models.route import (
+    ROUTE_TYPE, Route, RouteLocale, ArchiveRoute, ArchiveRouteLocale)
+from c2corg_api.models.waypoint import (
+    WAYPOINT_TYPE, Waypoint, WaypointLocale, ArchiveWaypoint,
+    ArchiveWaypointLocale)
+from c2corg_api.models.xreport import (
+    XREPORT_TYPE, Xreport, XreportLocale, ArchiveXreport,
+    ArchiveXreportLocale)
+from c2corg_api.views import cors_policy, restricted_json_view
+from c2corg_api.views.image import delete_all_files_for_image
+from c2corg_api.views.validation import validate_id
+from cornice.resource import resource
+from pyramid.httpexceptions import HTTPNotFound, HTTPBadRequest
+from sqlalchemy.sql.expression import or_, and_, exists
+from sqlalchemy.sql.functions import func
+
+
+def validate_document(request, **kwargs):
+    if 'id' not in request.validated:
+        return
+
+    document_id = request.validated['id']
+    document = DBSession.query(Document.type). \
+        filter(Document.document_id == document_id).first()
+
+    if not document:
+        raise HTTPNotFound('document not found')
+
+    document_type = document.type
+
+    if document_type == WAYPOINT_TYPE:
+        if _is_main_waypoint_of_route(document_id):
+            raise HTTPBadRequest(
+                'This waypoint cannot be deleted '
+                'because it is a main waypoint.')
+
+        if _is_only_waypoint_of_route(document_id):
+            raise HTTPBadRequest(
+                'This waypoint cannot be deleted because '
+                'it is the only waypoint associated to some routes.')
+
+    elif document_type == ROUTE_TYPE:
+        if _is_only_route_of_outing(document_id):
+            raise HTTPBadRequest(
+                'This route cannot be deleted because '
+                'it is the only route associated to some outings.')
+
+    request.validated['document_type'] = document_type
+
+
+def _is_main_waypoint_of_route(document_id):
+    return DBSession.query(
+        exists().
+        where(Route.main_waypoint_id == document_id)
+    ).scalar()
+
+
+def _is_only_waypoint_of_route(document_id):
+    routes = DBSession.query(Association.child_document_id). \
+        filter(and_(
+            Association.parent_document_id == document_id,
+            Association.child_document_type == ROUTE_TYPE,
+        )).subquery()
+    only_waypoint = DBSession.query(Association). \
+        filter(and_(
+            Association.child_document_id == routes.c.child_document_id,
+            Association.parent_document_type == WAYPOINT_TYPE
+        )). \
+        group_by(Association.child_document_id). \
+        having(func.count('*') == 1). \
+        exists()
+    return DBSession.query(only_waypoint).scalar()
+
+
+def _is_only_route_of_outing(document_id):
+    outings = DBSession.query(Association.child_document_id). \
+        filter(and_(
+            Association.parent_document_id == document_id,
+            Association.child_document_type == OUTING_TYPE,
+        )).subquery()
+    only_route = DBSession.query(Association). \
+        filter(and_(
+            Association.child_document_id == outings.c.child_document_id,
+            Association.parent_document_type == ROUTE_TYPE
+        )). \
+        group_by(Association.child_document_id). \
+        having(func.count('*') == 1). \
+        exists()
+    return DBSession.query(only_route).scalar()
+
+
+@resource(path='/documents/delete/{id}', cors_policy=cors_policy)
+class DeleteDocumentRest(object):
+
+    def __init__(self, request):
+        self.request = request
+
+    @restricted_json_view(
+        permission='moderator',
+        validators=[validate_id, validate_document])
+    def delete(self):
+        """
+        Delete a document.
+
+        Request:
+            `DELETE` `/documents/delete/{id}`
+        """
+        document_id = self.request.validated['id']
+        document_type = self.request.validated['document_type']
+
+        # Note: if an error occurs while deleting, SqlAlchemy will
+        # automatically cancel all DB changes.
+
+        _remove_from_cache(document_id)
+
+        # Remove associations and update cache of formerly associated docs
+        update_cache_version_full(document_id, document_type)
+        _remove_associations(document_id)
+
+        clazz, clazz_locale, archive_clazz, archive_clazz_locale = _get_models(
+            document_type)
+
+        # Order of removals depends on foreign key constraints
+        _remove_history_metadata(document_id)
+        _remove_archive_locale(archive_clazz_locale, document_id)
+        _remove_archive_geometry(document_id)
+        _remove_archive(archive_clazz, document_id)
+        _remove_locale(clazz_locale, document_id)
+        _remove_geometry(document_id)
+        _remove_figures(clazz, document_id)
+        _remove_from_feed(document_id)
+
+        if document_type == IMAGE_TYPE:
+            # Remove this image references from the feed
+            _remove_image_from_feed(document_id)
+
+        # When all references have been deleted, finally remove the main
+        # document entry
+        _remove_document(document_id)
+
+        if document_type == IMAGE_TYPE:
+            delete_all_files_for_image(document_id, self.request)
+
+        _notify_es_syncer(self.request.registry.queue_config)
+
+        return {}
+
+
+def _get_models(document_type):
+    if document_type == WAYPOINT_TYPE:
+        return Waypoint, WaypointLocale, ArchiveWaypoint, ArchiveWaypointLocale
+    if document_type == ROUTE_TYPE:
+        return Route, RouteLocale, ArchiveRoute, ArchiveRouteLocale
+    if document_type == OUTING_TYPE:
+        return Outing, OutingLocale, ArchiveOuting, ArchiveOutingLocale
+    if document_type == IMAGE_TYPE:
+        return Image, None, ArchiveImage, None
+    if document_type == ARTICLE_TYPE:
+        return Article, None, ArchiveArticle, None
+    if document_type == BOOK_TYPE:
+        return Book, None, ArchiveBook, None
+    if document_type == XREPORT_TYPE:
+        return Xreport, XreportLocale, ArchiveXreport, ArchiveXreportLocale
+    raise HTTPBadRequest('Unsupported type when deleting document')
+
+
+def _remove_from_cache(document_id):
+    DBSession.query(CacheVersion). \
+        filter(CacheVersion.document_id == document_id).delete()
+
+
+def _remove_history_metadata(document_id):
+    history_metadata_ids = DBSession. \
+        query(DocumentVersion.history_metadata_id). \
+        filter(DocumentVersion.document_id == document_id). \
+        all()
+    DBSession.query(DocumentVersion). \
+        filter(DocumentVersion.document_id == document_id). \
+        delete()
+    DBSession.execute(HistoryMetaData.__table__.delete().where(
+        HistoryMetaData.id.in_(history_metadata_ids)
+    ))
+
+
+def _remove_archive_locale(archive_clazz_locale, document_id):
+    if archive_clazz_locale:
+        archive_document_locale_ids = DBSession. \
+            query(ArchiveDocumentLocale.id). \
+            filter(ArchiveDocumentLocale.document_id == document_id). \
+            subquery()
+        # FIXME document topic => to do with normal model instead?
+        DBSession.execute(DocumentTopic.__table__.delete().where(
+            DocumentTopic.document_locale_id.in_(
+                archive_document_locale_ids)
+        ))
+        DBSession.execute(archive_clazz_locale.__table__.delete().where(
+            getattr(archive_clazz_locale, 'id').in_(
+                archive_document_locale_ids)
+        ))
+
+    DBSession.query(ArchiveDocumentLocale). \
+        filter(ArchiveDocumentLocale.document_id == document_id). \
+        delete()
+
+
+def _remove_locale(clazz_locale, document_id):
+    if clazz_locale:
+        doc_locale_ids = DBSession.query(DocumentLocale.id). \
+            filter(DocumentLocale.document_id == document_id). \
+            subquery()
+        DBSession.execute(clazz_locale.__table__.delete().where(
+            getattr(clazz_locale, 'id').in_(doc_locale_ids)
+        ))
+
+    DBSession.query(DocumentLocale). \
+        filter(DocumentLocale.document_id == document_id). \
+        delete()
+
+
+def _remove_archive_geometry(document_id):
+    DBSession.query(ArchiveDocumentGeometry). \
+        filter(ArchiveDocumentGeometry.document_id == document_id). \
+        delete()
+
+
+def _remove_geometry(document_id):
+    DBSession.query(DocumentGeometry). \
+        filter(DocumentGeometry.document_id == document_id). \
+        delete()
+
+
+def _remove_archive(archive_clazz, document_id):
+    archive_document_ids = DBSession.query(ArchiveDocument.id). \
+        filter(ArchiveDocument.document_id == document_id). \
+        subquery()
+    DBSession.execute(archive_clazz.__table__.delete().where(
+        getattr(archive_clazz, 'id').in_(archive_document_ids)
+    ))
+
+    DBSession.query(ArchiveDocument). \
+        filter(ArchiveDocument.document_id == document_id). \
+        delete()
+
+
+def _remove_figures(clazz, document_id):
+    DBSession.query(clazz). \
+        filter(getattr(clazz, 'document_id') == document_id). \
+        delete()
+
+
+def _remove_document(document_id):
+    DBSession.query(Document). \
+        filter(Document.document_id == document_id). \
+        delete()
+
+
+def _remove_from_feed(document_id):
+    DBSession.query(DocumentChange). \
+        filter(DocumentChange.document_id == document_id). \
+        delete()
+
+
+def _remove_image_from_feed(document_id):
+    # TODO if removed doc is an image, it might be needed to remove
+    # any reference to this image in feed items
+    pass
+
+
+def _remove_associations(document_id):
+    DBSession.query(Association). \
+        filter(or_(
+            Association.parent_document_id == document_id,
+            Association.child_document_id == document_id
+        )).delete()
+
+
+def _notify_es_syncer(config):
+    # TODO
+    pass


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_api/issues/465

Delete view:
* [x] Add document id to a special table where ES can figure out what doc should be removed from the index
* [x] when removing an image, update the feed entries that reference it
* [x] when removing an image, delete the files from the images storage (see https://github.com/c2corg/v6_images/issues/35 and https://github.com/c2corg/v6_api/blob/merge-documents/c2corg_api/views/image.py#L116-L137)
* [x] remove geoassociations

Unit tests:
* [x] make sure the existing doc/archives test are correct
* [x] check associations have been cleared
* [x] check cache_versions have been updated?
* [x] check the feed has been cleared
* [x] check comments have been cleared?
* [x] check image files have been removed?
* [ ] check ES index is updated => see https://github.com/c2corg/v6_api/issues/629

Add tests for
* [x] articles
* [x] books
* [x] images
* [x] outings
* [x] xreports