### PR TITLE
Image sorting by date_time

### DIFF
--- a/c2corg_api/search/search_filters.py
+++ b/c2corg_api/search/search_filters.py
@@ -2,8 +2,6 @@ import math
 
 import pyproj
 import re
-
-from c2corg_api.models.image import IMAGE_TYPE
 from c2corg_api.models.outing import OUTING_TYPE
 from c2corg_api.models.xreport import XREPORT_TYPE
 from c2corg_api.search.mapping_types import reserved_query_fields
@@ -50,9 +48,6 @@ def build_query(url_params, meta_params, doc_type):
         if doc_type == OUTING_TYPE:
             search = search.sort(
                 {'date_end': {'order': 'desc'}}, {'id': {'order': 'desc'}})
-        elif doc_type == IMAGE_TYPE:
-            search = search.sort(
-                {'date_time': {'order': 'desc'}}, {'id': {'order': 'desc'}})
         elif doc_type == XREPORT_TYPE:
             search = search.sort(
               {'date': {'order': 'desc'}}, {'id': {'order': 'desc'}})

--- a/c2corg_api/search/search_filters.py
+++ b/c2corg_api/search/search_filters.py
@@ -2,6 +2,8 @@ import math
 
 import pyproj
 import re
+
+from c2corg_api.models.image import IMAGE_TYPE
 from c2corg_api.models.outing import OUTING_TYPE
 from c2corg_api.models.xreport import XREPORT_TYPE
 from c2corg_api.search.mapping_types import reserved_query_fields
@@ -48,6 +50,9 @@ def build_query(url_params, meta_params, doc_type):
         if doc_type == OUTING_TYPE:
             search = search.sort(
                 {'date_end': {'order': 'desc'}}, {'id': {'order': 'desc'}})
+        elif doc_type == IMAGE_TYPE:
+            search = search.sort(
+                {'date_time': {'order': 'desc'}}, {'id': {'order': 'desc'}})
         elif doc_type == XREPORT_TYPE:
             search = search.sort(
               {'date': {'order': 'desc'}}, {'id': {'order': 'desc'}})

--- a/c2corg_api/views/document_associations.py
+++ b/c2corg_api/views/document_associations.py
@@ -16,7 +16,7 @@ from c2corg_api.views.document_schemas import waypoint_documents_config, \
     image_documents_config, article_documents_config, area_documents_config, \
     outing_documents_config, book_documents_config, xreport_documents_config
 from c2corg_api.views.validation import updatable_associations
-from sqlalchemy.sql.expression import or_, and_, desc
+from sqlalchemy.sql.expression import or_, and_, asc
 
 associations_to_include = {
     WAYPOINT_TYPE: {
@@ -180,7 +180,7 @@ def get_linked_images(document, lang):
                 Association.child_document_id == Image.document_id,
                 Association.parent_document_id == document.document_id)
             ).
-        order_by(desc(Image.date_time)).
+        order_by(asc(Image.date_time)).
         group_by(Image.document_id).
         all())
 

--- a/c2corg_api/views/document_associations.py
+++ b/c2corg_api/views/document_associations.py
@@ -16,7 +16,7 @@ from c2corg_api.views.document_schemas import waypoint_documents_config, \
     image_documents_config, article_documents_config, area_documents_config, \
     outing_documents_config, book_documents_config, xreport_documents_config
 from c2corg_api.views.validation import updatable_associations
-from sqlalchemy.sql.expression import or_, and_
+from sqlalchemy.sql.expression import or_, and_, desc
 
 associations_to_include = {
     WAYPOINT_TYPE: {
@@ -180,6 +180,7 @@ def get_linked_images(document, lang):
                 Association.child_document_id == Image.document_id,
                 Association.parent_document_id == document.document_id)
             ).
+        order_by(desc(Image.date_time)).
         group_by(Image.document_id).
         all())
 


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_api/issues/596

Previously while browsing images ( https://www.camptocamp.org/images#offset=120 ) they were not sorted and while I was going through pages some of them had were newer/older date_time than others (some didn't show any date on detail view page).

I am not sure about sorting of linked images on View pages because I am not sure how exactly JS for image slider works and if it works correctly (also with latest changes related `date_time`).
It looks correctly ordered now when I click on the image and info icon.

Another thing to add and discuss
- for Outings/Xreport, it would be probably good to see images from the beginning to the end of a trip so the users can go through as time was passing.
- for Waypoint/Route it should be probably sorted by latest images first (opposite). Users probably want to look at WP to see current conditions rather than some historical photos.
- article?