### PR TITLE
Validate geometry type from geojson for each doc. type on API

### DIFF
--- a/c2corg_api/models/area.py
+++ b/c2corg_api/models/area.py
@@ -1,6 +1,6 @@
 from c2corg_api.models import schema, Base
 from c2corg_api.models.document import (
-    ArchiveDocument, Document, geometry_schema_overrides,
+    ArchiveDocument, Document, get_geometry_schema_overrides,
     schema_document_locale, schema_attributes)
 from c2corg_api.models.enums import area_type
 from c2corg_api.models.schema_utils import restrict_schema, \
@@ -81,7 +81,7 @@ schema_area = SQLAlchemySchemaNode(
         'locales': {
             'children': [schema_document_locale]
         },
-        'geometry': geometry_schema_overrides
+        'geometry': get_geometry_schema_overrides(['POLYGON', 'MULTIPOLYGON'])
     })
 
 schema_create_area = get_create_schema(schema_area)

--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -299,7 +299,7 @@ class _DocumentGeometryMixin(object):
                 spatial_index=self.__name__ != 'ArchiveDocumentGeometry'),
             info={
                 'colanderalchemy': {
-                    'typ': colander_ext.Geometry('POINT', srid=3857)
+                    'typ': colander_ext.Geometry(['POINT'], srid=3857)
                 }
             }
         )
@@ -314,7 +314,7 @@ class _DocumentGeometryMixin(object):
                 spatial_index=self.__name__ != 'ArchiveDocumentGeometry'),
             info={
                 'colanderalchemy': {
-                    'typ': colander_ext.Geometry('GEOMETRY', srid=3857)
+                    'typ': colander_ext.Geometry(['GEOMETRY'], srid=3857)
                 }
             }
         )
@@ -449,6 +449,21 @@ geometry_schema_overrides = {
         }
     }
 }
+
+
+def get_geometry_schema_overrides(geometry_types):
+    return {
+        # whitelisted attributes
+        'includes': ['version', 'geom', 'geom_detail'],
+        'overrides': {
+            'version': {
+                'missing': None
+            },
+            'geom_detail': {
+                'typ': colander_ext.Geometry(geometry_types, srid=3857)
+            }
+        }
+    }
 
 
 def get_available_langs(document_id):

--- a/c2corg_api/models/image.py
+++ b/c2corg_api/models/image.py
@@ -18,7 +18,7 @@ from colanderalchemy import SQLAlchemySchemaNode
 from c2corg_api.models import schema, enums, Base, DBSession
 from c2corg_api.models.utils import copy_attributes, ArrayOfEnum
 from c2corg_api.models.document import (
-    ArchiveDocument, Document, geometry_schema_overrides,
+    ArchiveDocument, Document, get_geometry_schema_overrides,
     schema_attributes, DocumentLocale,
     schema_locale_attributes)
 from c2corg_common import document_types
@@ -140,7 +140,7 @@ schema_image = SQLAlchemySchemaNode(
         'locales': {
             'children': [schema_image_locale]
         },
-        'geometry': geometry_schema_overrides
+        'geometry': get_geometry_schema_overrides(['POINT'])
     })
 
 schema_create_image = get_create_schema(schema_image)

--- a/c2corg_api/models/outing.py
+++ b/c2corg_api/models/outing.py
@@ -18,8 +18,8 @@ from c2corg_api.models.utils import ArrayOfEnum
 from c2corg_api.models.utils import copy_attributes
 from c2corg_api.models.document import (
     ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale,
-    geometry_schema_overrides, schema_locale_attributes,
-    schema_attributes)
+    schema_locale_attributes,
+    schema_attributes, get_geometry_schema_overrides)
 from c2corg_api.models import enums
 from c2corg_common import document_types
 
@@ -221,7 +221,8 @@ schema_outing = SQLAlchemySchemaNode(
         'activities': {
             'validator': colander.Length(min=1)
         },
-        'geometry': geometry_schema_overrides
+        'geometry': get_geometry_schema_overrides(
+            ['LINESTRING', 'MULTILINESTRING'])
     })
 
 schema_create_outing = get_create_schema(schema_outing)

--- a/c2corg_api/models/route.py
+++ b/c2corg_api/models/route.py
@@ -17,7 +17,7 @@ from c2corg_api.models.utils import ArrayOfEnum
 from c2corg_api.models.utils import copy_attributes
 from c2corg_api.models.document import (
     ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale,
-    geometry_schema_overrides, schema_locale_attributes, schema_attributes)
+    get_geometry_schema_overrides, schema_locale_attributes, schema_attributes)
 from c2corg_api.models import enums
 from sqlalchemy.orm import relationship
 from c2corg_common import document_types
@@ -316,7 +316,8 @@ schema_route = SQLAlchemySchemaNode(
         'activities': {
             'validator': colander.Length(min=1)
         },
-        'geometry': geometry_schema_overrides
+        'geometry': get_geometry_schema_overrides(
+            ['LINESTRING', 'MULTILINESTRING'])
     })
 
 schema_create_route = get_create_schema(schema_route)

--- a/c2corg_api/models/topo_map.py
+++ b/c2corg_api/models/topo_map.py
@@ -13,7 +13,7 @@ from colanderalchemy import SQLAlchemySchemaNode
 from c2corg_api.models import schema, Base
 from c2corg_api.models.utils import copy_attributes
 from c2corg_api.models.document import (
-    ArchiveDocument, Document, geometry_schema_overrides,
+    ArchiveDocument, Document, get_geometry_schema_overrides,
     schema_document_locale, schema_attributes)
 from c2corg_common import document_types
 
@@ -87,7 +87,7 @@ schema_topo_map = SQLAlchemySchemaNode(
         'locales': {
             'children': [schema_document_locale]
         },
-        'geometry': geometry_schema_overrides
+        'geometry': get_geometry_schema_overrides(['POLYGON', 'MULTIPOLYGON'])
     })
 
 schema_update_topo_map = get_update_schema(schema_topo_map)

--- a/c2corg_api/models/user_profile.py
+++ b/c2corg_api/models/user_profile.py
@@ -1,6 +1,6 @@
 from c2corg_api.models import schema, Base
 from c2corg_api.models.document import (
-    ArchiveDocument, Document, geometry_schema_overrides,
+    ArchiveDocument, Document, get_geometry_schema_overrides,
     schema_document_locale, schema_attributes, DocumentLocale)
 from c2corg_api.models.enums import user_category, activity_type
 from c2corg_api.models.schema_utils import restrict_schema, get_update_schema
@@ -99,7 +99,7 @@ schema_user_profile = SQLAlchemySchemaNode(
         'locales': {
             'children': [schema_user_profile_locale]
         },
-        'geometry': geometry_schema_overrides
+        'geometry': get_geometry_schema_overrides(['POINT'])
     })
 
 
@@ -117,7 +117,7 @@ schema_internal_user_profile = SQLAlchemySchemaNode(
         'locales': {
             'children': [schema_document_locale]
         },
-        'geometry': geometry_schema_overrides
+        'geometry': get_geometry_schema_overrides(['POINT'])
     })
 
 schema_update_user_profile = get_update_schema(schema_user_profile)

--- a/c2corg_api/models/waypoint.py
+++ b/c2corg_api/models/waypoint.py
@@ -15,7 +15,8 @@ from c2corg_api.models import schema, Base
 from c2corg_api.models.utils import copy_attributes, ArrayOfEnum
 from c2corg_api.models.document import (
     ArchiveDocument, Document, DocumentLocale, ArchiveDocumentLocale,
-    geometry_schema_overrides, schema_attributes, schema_locale_attributes)
+    schema_attributes, schema_locale_attributes,
+    get_geometry_schema_overrides)
 from c2corg_api.models import enums
 from c2corg_common import document_types
 
@@ -311,7 +312,7 @@ schema_waypoint = SQLAlchemySchemaNode(
         'locales': {
             'children': [schema_waypoint_locale]
         },
-        'geometry': geometry_schema_overrides
+        'geometry': get_geometry_schema_overrides(['POINT'])
     })
 
 schema_create_waypoint = get_create_schema(schema_waypoint)

--- a/c2corg_api/models/xreport.py
+++ b/c2corg_api/models/xreport.py
@@ -20,7 +20,7 @@ from c2corg_api.models.utils import copy_attributes
 from c2corg_api.models.document import (
     ArchiveDocument,
     Document,
-    geometry_schema_overrides,
+    get_geometry_schema_overrides,
     schema_attributes, DocumentLocale, ArchiveDocumentLocale,
     schema_locale_attributes)
 from c2corg_common import document_types
@@ -259,7 +259,7 @@ schema_xreport = SQLAlchemySchemaNode(
         'activities': {
             'validator': colander.Length(min=1)
         },
-        'geometry': geometry_schema_overrides
+        'geometry': get_geometry_schema_overrides(['POINT'])
     })
 
 # schema that hides personal information of a xreport
@@ -271,7 +271,7 @@ schema_xreport_without_personal = SQLAlchemySchemaNode(
         'locales': {
             'children': [schema_xreport_locale],
         },
-        'geometry': geometry_schema_overrides
+        'geometry': get_geometry_schema_overrides(['POINT'])
     })
 
 

--- a/c2corg_api/tests/models/test_route.py
+++ b/c2corg_api/tests/models/test_route.py
@@ -48,18 +48,18 @@ class TestRoute(BaseTestCase):
         """ Check that geometries are only compared in 2D when updating a
         document.
         """
-        geom1 = wkbelement_from_geojson(
+        geom1 = wkbelement_from_geojson(json.loads(
             '{"type": "LineString", "coordinates": ' +
-            '[[635956, 5723604, 1200], [635966, 5723644, 1210]]}', 3857)
+            '[[635956, 5723604, 1200], [635966, 5723644, 1210]]}'), 3857)
         route_db = Route(
             document_id=1, activities=['hiking'],
             geometry=DocumentGeometry(
                 document_id=1, geom=None, geom_detail=geom1)
         )
 
-        geom2 = wkbelement_from_geojson(
+        geom2 = wkbelement_from_geojson(json.loads(
             '{"type": "LineString", "coordinates": ' +
-            '[[635956, 5723604, 9999], [635966, 5723644, 9999]]}', 3857)
+            '[[635956, 5723604, 9999], [635966, 5723644, 9999]]}'), 3857)
         route_in = Route(
             document_id=1, activities=['hiking'],
             geometry=DocumentGeometry(
@@ -68,9 +68,9 @@ class TestRoute(BaseTestCase):
         route_db.update(route_in)
         self.assertIs(route_db.geometry.geom_detail, geom1)
 
-        geom3 = wkbelement_from_geojson(
+        geom3 = wkbelement_from_geojson(json.loads(
             '{"type": "LineString", "coordinates": ' +
-            '[[635956, 5723608, 1200], [635966, 5723644, 1210]]}', 3857)
+            '[[635956, 5723608, 1200], [635966, 5723644, 1210]]}'), 3857)
         route_in = Route(
             document_id=1, activities=['hiking'],
             geometry=DocumentGeometry(
@@ -81,9 +81,10 @@ class TestRoute(BaseTestCase):
         self.assertIs(route_db.geometry.geom_detail, geom3)
 
     def test_simplify(self):
-        geom = wkbelement_from_geojson(
+        geom = wkbelement_from_geojson(json.loads(
             '{"type": "LineString", "coordinates": ' +
-            '[[635900, 5723600], [635902, 5723600], [635905, 5723600]]}', 3857)
+            '[[635900, 5723600], [635902, 5723600], [635905, 5723600]]}'),
+            3857)
         route = Route(
             activities=['hiking'],
             geometry=DocumentGeometry(geom=None, geom_detail=geom))
@@ -98,9 +99,10 @@ class TestRoute(BaseTestCase):
         self.assertEqual(len(geojson['coordinates']), 2)
 
         # check that the line was simplified after an update
-        route.geometry.geom_detail = wkbelement_from_geojson(
+        route.geometry.geom_detail = wkbelement_from_geojson(json.loads(
             '{"type": "LineString", "coordinates": ' +
-            '[[635901, 5723600], [635902, 5723600], [635905, 5723600]]}', 3857)
+            '[[635901, 5723600], [635902, 5723600], [635905, 5723600]]}'),
+            3857)
 
         self.session.flush()
         simplified_geom = route.geometry

--- a/c2corg_api/tests/models/test_utils.py
+++ b/c2corg_api/tests/models/test_utils.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 from c2corg_api.ext.colander_ext import wkbelement_from_geojson
@@ -31,17 +32,17 @@ class TestUtils(unittest.TestCase, AssertionsMixin):
         self.assertHasNotField(locale_node, 'access_period')
 
     def test_wkb_to_shape_point(self):
-        wkb = wkbelement_from_geojson(
-            '{"type": "Point", "coordinates": [1.0, 2.0, 3.0, 4.0]}', 3857)
+        wkb = wkbelement_from_geojson(json.loads(
+            '{"type": "Point", "coordinates": [1.0, 2.0, 3.0, 4.0]}'), 3857)
         point = wkb_to_shape(wkb)
         self.assertFalse(point.has_z)
         self.assertAlmostEquals(point.x, 1.0)
         self.assertAlmostEquals(point.y, 2.0)
 
     def test_wkb_to_shape_linestring(self):
-        wkb = wkbelement_from_geojson(
+        wkb = wkbelement_from_geojson(json.loads(
             '{"type": "LineString", "coordinates": ' +
-            '[[635956, 5723604, 1200], [635966, 5723644, 1210]]}', 3857)
+            '[[635956, 5723604, 1200], [635966, 5723644, 1210]]}'), 3857)
         line = wkb_to_shape(wkb)
         self.assertFalse(line.has_z)
 
@@ -53,9 +54,9 @@ class TestUtils(unittest.TestCase, AssertionsMixin):
             line.coords[1], [635966.0, 5723644.0])
 
     def test_wkb_to_shape_multilinestring(self):
-        wkb = wkbelement_from_geojson(
+        wkb = wkbelement_from_geojson(json.loads(
             '{"type": "MultiLineString", "coordinates": ' +
-            '[[[635956, 5723604, 1200], [635966, 5723644, 1210]]]}', 3857)
+            '[[[635956, 5723604, 1200], [635966, 5723644, 1210]]]}'), 3857)
         line = wkb_to_shape(wkb)
         self.assertFalse(line.has_z)
 
@@ -68,10 +69,10 @@ class TestUtils(unittest.TestCase, AssertionsMixin):
             line.geoms[0].coords[1], [635966.0, 5723644.0])
 
     def test_wkb_to_shape_polygon(self):
-        wkb = wkbelement_from_geojson(
+        wkb = wkbelement_from_geojson(json.loads(
             '{"type": "Polygon", "coordinates": ' +
             '[[[100.0, 0.0, 1200], [101.0, 0.0, 1200], [101.0, 1.0, 1200], '
-            '[100.0, 1.0, 1200], [100.0, 0.0, 1200]]]}', 3857)
+            '[100.0, 1.0, 1200], [100.0, 0.0, 1200]]]}'), 3857)
         polygon = wkb_to_shape(wkb)
         self.assertFalse(polygon.has_z)
 
@@ -79,10 +80,10 @@ class TestUtils(unittest.TestCase, AssertionsMixin):
         self.assertEqual(len(polygon.exterior.coords[0]), 2)
 
     def test_wkb_to_shape_multipolygon(self):
-        wkb = wkbelement_from_geojson(
+        wkb = wkbelement_from_geojson(json.loads(
             '{"type": "MultiPolygon", "coordinates": ' +
             '[[[[100.0, 0.0, 1200], [101.0, 0.0, 1200], [101.0, 1.0, 1200], '
-            '[100.0, 1.0, 1200], [100.0, 0.0, 1200]]]]}', 3857)
+            '[100.0, 1.0, 1200], [100.0, 0.0, 1200]]]]}'), 3857)
         multi_polygon = wkb_to_shape(wkb)
         self.assertFalse(multi_polygon.has_z)
 

--- a/c2corg_api/tests/views/__init__.py
+++ b/c2corg_api/tests/views/__init__.py
@@ -398,6 +398,20 @@ class BaseDocumentTestRest(BaseTestRest):
         self.assertCorniceRequired(errors[0], 'geometry.geom')
         return body
 
+    def post_wrong_geom_type(self, request_body):
+        response = self.app_post_json(self._prefix, request_body,
+                                      expect_errors=True, status=403)
+
+        headers = self.add_authorization_header(username='contributor')
+        response = self.app_post_json(
+            self._prefix, request_body, headers=headers,
+            expect_errors=True, status=400)
+
+        body = response.json
+        self.assertEqual(body.get('status'), 'error')
+        errors = body.get('errors')
+        return errors
+
     def post_missing_locales(self, request_body):
         response = self.app_post_json(self._prefix, request_body,
                                       expect_errors=True, status=403)

--- a/c2corg_api/tests/views/test_area.py
+++ b/c2corg_api/tests/views/test_area.py
@@ -98,7 +98,7 @@ class TestAreaRest(BaseDocumentTestRest):
         body_post = {
             'area_type': 'range',
             'geometry': {
-                'geom_detail': '{"type": "Point", "coordinates": [635956, 5723604]}'  # noqa
+                'geom_detail': '{"type":"Polygon","coordinates":[[[668519.249382151,5728802.39591739],[668518.249382151,5745465.66808356],[689156.247019149,5745465.66808356],[689156.247019149,5728802.39591739],[668519.249382151,5728802.39591739]]]}'  # noqa
             },
             'locales': [
                 {'lang': 'en'}
@@ -112,7 +112,7 @@ class TestAreaRest(BaseDocumentTestRest):
             'protected': True,
             'geometry': {
                 'id': 5678, 'version': 6789,
-                'geom_detail': '{"type": "Point", "coordinates": [635956, 5723604]}'  # noqa
+                'geom_detail': '{"type":"Polygon","coordinates":[[[668519.249382151,5728802.39591739],[668518.249382151,5745465.66808356],[689156.247019149,5745465.66808356],[689156.247019149,5728802.39591739],[668519.249382151,5728802.39591739]]]}'  # noqa
             },
             'locales': [
                 {'lang': 'en', 'title': 'Chartreuse'}

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -404,6 +404,63 @@ class TestRouteRest(BaseDocumentTestRest):
         self.assertCoodinateEquals(
             geom_detail['coordinates'][1], [635966.0, 5723644.0, 1210.0])
 
+    def test_post_wrong_geom_type(self):
+        body = {
+            'main_waypoint_id': self.waypoint.document_id,
+            'activities': ['hiking', 'skitouring'],
+            'elevation_min': 700,
+            'elevation_max': 1500,
+            'height_diff_up': 800,
+            'height_diff_down': 800,
+            'durations': ['1'],
+            'geometry': {
+                'id': 5678, 'version': 6789,
+                'geom_detail':
+                    '{"type": "Point", "coordinates": ' +
+                    '[635956, 5723604]}'
+            },
+            'locales': [
+                {'lang': 'en', 'title': 'Some nice loop',
+                 'description': '...', 'gear': 'shoes'}
+            ],
+            'associations': {
+                'waypoints': [{'document_id': self.waypoint.document_id}]
+            }
+        }
+        errors = self.post_wrong_geom_type(body)
+        self.assertEqual(
+            errors[0]['description'], "Invalid geometry type. Expected: "
+            "['LINESTRING', 'MULTILINESTRING']. Got: POINT.")
+
+    def test_post_corrupted_geojson_geom(self):
+        body = {
+            'main_waypoint_id': self.waypoint.document_id,
+            'activities': ['hiking', 'skitouring'],
+            'elevation_min': 700,
+            'elevation_max': 1500,
+            'height_diff_up': 800,
+            'height_diff_down': 800,
+            'durations': ['1'],
+            'geometry': {
+                'id': 5678, 'version': 6789,
+                'geom_detail':
+                    '{"type": "LineString", "coordinates": ' +
+                    '[[[[[[635956, 5723604, 12345, 67890, 13579]]]]]]}'
+            },
+            'locales': [
+                {'lang': 'en', 'title': 'Some nice loop',
+                 'description': '...', 'gear': 'shoes'}
+            ],
+            'associations': {
+                'waypoints': [{'document_id': self.waypoint.document_id}]
+            }
+        }
+        errors = self.post_wrong_geom_type(body)
+        self.assertEqual(
+            errors[0]['description'], 'Invalid geometry: {"type": '
+            '"LineString", "coordinates": '
+            '[[[[[[635956, 5723604, 12345, 67890, 13579]]]]]]}')
+
     def test_post_success_3d_multiline(self):
         """ Tests that routes with 3D multiline tracks can be created and read.
         """

--- a/c2corg_api/tests/views/test_topo_map.py
+++ b/c2corg_api/tests/views/test_topo_map.py
@@ -6,7 +6,7 @@ from c2corg_api.models.topo_map_association import TopoMapAssociation
 from c2corg_api.models.waypoint import Waypoint
 from c2corg_api.tests.search import reset_search_index
 from c2corg_common.attributes import quality_types
-from shapely.geometry import shape, Point
+from shapely.geometry import shape, Polygon
 
 from c2corg_api.models.document import (
     DocumentGeometry, ArchiveDocumentLocale, DocumentLocale)
@@ -92,7 +92,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
             'code': '3432OT',
             'geometry': {
                 'id': 5678, 'version': 6789,
-                'geom_detail': '{"type": "Point", "coordinates": [635956, 5723604]}'  # noqa
+                'geom_detail': '{"type":"Polygon","coordinates":[[[668519.249382151,5728802.39591739],[668518.249382151,5745465.66808356],[689156.247019149,5745465.66808356],[689156.247019149,5728802.39591739],[668519.249382151,5728802.39591739]]]}'  # noqa
             },
             'locales': [
                 {'lang': 'en'}
@@ -108,7 +108,7 @@ class TestTopoMapRest(BaseDocumentTestRest):
             'protected': True,
             'geometry': {
                 'id': 5678, 'version': 6789,
-                'geom_detail': '{"type": "Point", "coordinates": [635956, 5723604]}'  # noqa
+                'geom_detail': '{"type":"Polygon","coordinates":[[[668519.249382151,5728802.39591739],[668518.249382151,5745465.66808356],[689156.247019149,5745465.66808356],[689156.247019149,5728802.39591739],[668519.249382151,5728802.39591739]]]}'  # noqa
             },
             'locales': [
                 {'lang': 'en', 'title': 'Lac d\'Annecy'}
@@ -359,10 +359,8 @@ class TestTopoMapRest(BaseDocumentTestRest):
         self.assertIsNotNone(geometry.get('geom_detail'))
 
         geom = geometry.get('geom_detail')
-        point = shape(json.loads(geom))
-        self.assertIsInstance(point, Point)
-        self.assertAlmostEqual(point.x, 635956)
-        self.assertAlmostEqual(point.y, 5723604)
+        polygon = shape(json.loads(geom))
+        self.assertIsInstance(polygon, Polygon)
 
     def _add_test_data(self):
         self.map1 = TopoMap(editor='IGN', scale='25000', code='3431OT')
@@ -374,7 +372,8 @@ class TestTopoMapRest(BaseDocumentTestRest):
         self.map1.locales.append(self.locale_fr)
 
         self.map1.geometry = DocumentGeometry(
-            geom_detail='SRID=3857;POINT(635956 5723604)')
+            geom_detail='SRID=3857;POLYGON((611774 5706934,611774 5744215,'
+                        '642834 5744215,642834 5706934,611774 5706934))')
 
         self.session.add(self.map1)
         self.session.flush()

--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -660,6 +660,35 @@ class TestWaypointRest(BaseDocumentTestRest):
             feed_change.area_ids, [self.area1.document_id]
         )
 
+    def test_post_wrong_geom_type(self):
+        body = {
+            'document_id': 1234,
+            'version': 2345,
+            'geometry': {
+                'document_id': 5678, 'version': 6789,
+                'geom': '{"type": "LineString", "coordinates": '
+                        '[[635956, 5723604], [635960, 5723610]]}',
+                'geom_detail':
+                    '{"type": "Point", "coordinates": [635956, 5723604]}'
+            },
+            'waypoint_type': 'summit',
+            'elevation': 3779,
+            'locales': [{
+                'id': 3456, 'version': 4567,
+                'lang': 'en', 'title': 'Mont Pourri',
+                'access': 'y'}
+            ],
+            'associations': {
+                'waypoint_children': [
+                    {'document_id': self.waypoint2.document_id}
+                ]
+            }
+        }
+        errors = self.post_wrong_geom_type(body)
+        self.assertEqual(
+            errors[0]['description'], "Invalid geometry type. Expected: "
+            "['POINT']. Got: LINESTRING.")
+
     def test_put_wrong_document_id(self):
         body = {
             'document': {

--- a/c2corg_api/tests/views/test_xreport.py
+++ b/c2corg_api/tests/views/test_xreport.py
@@ -256,6 +256,36 @@ class TestXreportRest(BaseDocumentTestRest):
     def test_post_missing_content_type(self):
         self.post_missing_content_type({})
 
+    def test_post_wrong_geom_type(self):
+        body = {
+            'document_id': 123456,
+            'version': 567890,
+            'activities': ['hiking'],
+            'event_type': ['stone_fall'],
+            'nb_participants': 5,
+            'associations': {
+                'images': [
+                    {'document_id': self.image2.document_id}
+                ],
+                'articles': [
+                    {'document_id': self.article2.document_id}
+                ]
+            },
+            'geometry': {
+                'id': 5678, 'version': 6789,
+                'geom':
+                    '{"type": "LineString", "coordinates": ' +
+                    '[[635956, 5723604], [635966, 5723644]]}'
+            },
+            'locales': [
+                {'title': 'Lac d\'Annecy', 'lang': 'en'}
+            ]
+        }
+        errors = self.post_wrong_geom_type(body)
+        self.assertEqual(
+            errors[0]['description'],
+            "Invalid geometry type. Expected: ['POINT']. Got: LINESTRING.")
+
     def test_post_success(self):
         body = {
             'document_id': 123456,


### PR DESCRIPTION
related to https://github.com/c2corg/v6_api/issues/580

TODO
- As we discussed, it is probably better to validate geometry by geometry type stored in GeoJson before it is converted from GeoJson to WKB. Problem is that we are missing doctype in there https://github.com/c2corg/v6_api/blob/master/c2corg_api/ext/colander_ext.py#L47-L52

Right now this solution validates 2d geometries using Shapely and higher dimensions using separate DB query. If there is no geometry or geometry is taken from associated documents - nothing is validated.

Feel free to adjust...

**Possible problems...?**
- I am not sure about validation of associated geometries (now they are skipped). (example test https://github.com/c2corg/v6_api/blob/a4edbc11b90ca20053ae84ad944d7b0127b823f7/c2corg_api/tests/views/test_route.py#L870 )
- sometimes WPs have `geom` + `geom_detail` (LS, MLS) and now I validate only geom, which should contain `Point` goemetry