### PR TITLE
Browse latest changes on the API

### DIFF
--- a/c2corg_api/tests/views/test_document_changes.py
+++ b/c2corg_api/tests/views/test_document_changes.py
@@ -1,0 +1,140 @@
+from c2corg_api.models.document import DocumentGeometry
+from c2corg_api.models.document_history import DocumentVersion, HistoryMetaData
+from c2corg_api.models.route import Route, RouteLocale
+from c2corg_api.models.waypoint import Waypoint, WaypointLocale
+from c2corg_api.tests.views import BaseTestRest
+from c2corg_api.tests.views.test_feed import get_document_ids
+from c2corg_api.views.document import DocumentRest
+
+
+class TestChangesDocumentRest(BaseTestRest):
+
+    def setUp(self):
+        super(TestChangesDocumentRest, self).setUp()
+        self._prefix = '/documents/changes'
+
+        contributor_id = self.global_userids['contributor']
+
+        self.waypoint1 = Waypoint(
+            waypoint_type='summit', elevation=2000,
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POINT(635956 5723604)'),
+            locales=[
+                WaypointLocale(
+                    lang='fr', title='Dent de Crolles',
+                    description='...',
+                    summary='La Dent de Crolles')
+            ])
+        self.session.add(self.waypoint1)
+        self.session.flush()
+        DocumentRest.create_new_version(self.waypoint1, contributor_id)
+        self.session.flush()
+
+        self.waypoint2 = Waypoint(
+            waypoint_type='summit', elevation=4985,
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POINT(635956 5723604)'),
+            locales=[
+                WaypointLocale(
+                    lang='en', title='Mont Blanc',
+                    description='...',
+                    summary='The heighest point in Europe')
+            ])
+        self.session.add(self.waypoint2)
+        self.session.flush()
+        DocumentRest.create_new_version(self.waypoint2, contributor_id)
+        self.session.flush()
+
+        self.waypoint3 = Waypoint(
+            waypoint_type='summit', elevation=4985,
+            redirects_to=self.waypoint1.document_id,
+            geometry=DocumentGeometry(
+                geom='SRID=3857;POINT(635956 5723604)'),
+            locales=[
+                WaypointLocale(
+                    lang='en', title='Mont Blanc',
+                    description='...',
+                    summary='The heighest point in Europe')
+            ])
+        self.session.add(self.waypoint3)
+        self.session.flush()
+        DocumentRest.create_new_version(self.waypoint3, contributor_id)
+        self.session.flush()
+
+        self.route1 = Route(
+            activities=['skitouring'], elevation_max=1500, elevation_min=700,
+            main_waypoint_id=self.waypoint1.document_id,
+            locales=[
+                RouteLocale(
+                    lang='fr', title='Mont Blanc du ciel',
+                    description='...', summary='Ski')
+            ])
+        self.session.add(self.route1)
+        self.session.flush()
+        DocumentRest.create_new_version(self.route1, contributor_id)
+        self.session.flush()
+
+        version_count = self.session.query(DocumentVersion).count()
+        self.assertEqual(4, version_count)
+
+        hist_meta_count = self.session.query(HistoryMetaData).count()
+        self.assertEqual(4, hist_meta_count)
+
+    def test_get_changes(self):
+        response = self.app.get(self._prefix, status=200)
+        body = response.json
+
+        self.assertIn('total', body)
+        self.assertIn('pagination_token', body)
+        self.assertIn('feed', body)
+
+        feed = body['feed']
+        self.assertEqual(4, len(feed))
+        self.assertEqual(4, body['total'])
+
+        # check that the change for the route (latest change) is listed first
+        latest_change = feed[0]
+
+        self.assertEqual(
+            self.route1.document_id, latest_change['document']['document_id'])
+
+    def test_get_changes_paginated(self):
+        response = self.app.get(
+            self._prefix + '?limit=2', status=200)
+        body = response.json
+
+        document_ids = get_document_ids(body)
+        self.assertEqual(2, len(document_ids))
+        self.assertEqual(document_ids, [self.route1.document_id,
+                                        self.waypoint3.document_id])
+        pagination_token = body['pagination_token']
+
+        # last 2 changes
+        response = self.app.get(
+            self._prefix + '?limit=2&token=' + pagination_token, status=200)
+        body = response.json
+
+        document_ids = get_document_ids(body)
+        self.assertEqual(2, len(document_ids))
+        self.assertEqual(
+            document_ids,
+            [self.waypoint2.document_id, self.waypoint1.document_id])
+        pagination_token = body['pagination_token']
+
+        # empty response
+        response = self.app.get(
+            self._prefix + '?limit=2&token=' + pagination_token, status=200)
+        body = response.json
+
+        feed = body['feed']
+        self.assertEqual(0, len(feed))
+
+    def test_get_changes_pagination_invalid_format(self):
+        response = self.app.get(
+            self._prefix + '?token=invalid-token', status=400)
+        self.assertError(response.json['errors'], 'token', 'invalid format')
+
+    def test_get_changes_userid_invalid_format(self):
+        response = self.app.get(
+            self._prefix + '?u=invalid-user_id', status=400)
+        self.assertError(response.json['errors'], 'u', 'invalid u')

--- a/c2corg_api/views/document_changes.py
+++ b/c2corg_api/views/document_changes.py
@@ -1,0 +1,141 @@
+from c2corg_api.models import DBSession
+from c2corg_api.models.document import Document, ArchiveDocumentLocale
+from c2corg_api.models.document_history import DocumentVersion, HistoryMetaData
+from c2corg_api.models.user import User
+from c2corg_api.views import cors_policy
+from c2corg_api.views.feed import get_params
+from c2corg_api.views.validation import validate_simple_token_pagination,\
+  validate_user_id_not_required
+
+from sqlalchemy.sql.expression import desc
+
+from cornice.resource import resource, view
+from sqlalchemy.orm import joinedload, load_only
+
+
+@resource(path='/documents/changes', cors_policy=cors_policy)
+class ChangesDocumentRest(object):
+    """ Unique class for returning history of changes in documents.
+    """
+
+    def __init__(self, request):
+        self.request = request
+
+    @view(validators=[validate_simple_token_pagination,
+                      validate_user_id_not_required])
+    def get(self):
+        """Get the public document changes feed.
+
+        Request:
+            `GET` `/document/changes[&limit=...][&token=...][&u=]`
+
+        Parameters:
+
+            `limit=...` (optional)
+            How many entries should be returned (default: 30).
+            The maximum is 50.
+
+            `token=...` (optional)
+            The pagination token. When requesting a feed, the response includes
+            a `pagination_token`. This token is to be used to request the next
+            page.
+
+            `u=...` (optional)
+            Changes made by one user.
+
+            For more information about "continuation token pagination", see:
+            http://www.servicedenuages.fr/pagination-continuation-token (fr)
+        """
+        user_id = self.request.validated.get('u')
+        lang, token_id, _, limit = get_params(self.request, 30)
+
+        changes = get_changes_of_feed(token_id, limit, user_id)
+
+        doc_ids = []
+        for change in changes:
+            doc_ids.append(change.id)
+
+        return load_feed(doc_ids, limit, user_id)
+
+
+def get_changes_of_feed(token_id, limit, user_id=None):
+    query = DBSession. \
+        query(HistoryMetaData.id, HistoryMetaData.user_id). \
+        order_by(HistoryMetaData.id.desc())
+
+    # pagination filter
+    if token_id is not None:
+        query = query.filter(HistoryMetaData.id < token_id)
+
+    if user_id is not None:
+        query = query.filter(HistoryMetaData.user_id == user_id)
+
+    return query.limit(limit).all()
+
+
+def load_feed(doc_ids, limit, user_id=None):
+    if user_id:
+        doc_total = DBSession.query(HistoryMetaData.user_id)\
+            .filter(HistoryMetaData.user_id == user_id).count()
+    else:
+        doc_total = DBSession.query(HistoryMetaData.user_id).count()
+
+    doc_changes = DBSession.query(DocumentVersion) \
+        .options(load_only('history_metadata', 'lang'),
+                 joinedload('history_metadata').load_only(
+                    HistoryMetaData.id,
+                    HistoryMetaData.user_id,
+                    HistoryMetaData.comment,
+                    HistoryMetaData.written_at).
+                 joinedload('user').load_only(
+                    User.id,
+                    User.name,
+                    User.username,
+                    User.lang)) \
+        .options(load_only('document'),
+                 joinedload('document').load_only(
+                    Document.version,
+                    Document.document_id,
+                    Document.type,
+                    Document.quality)) \
+        .options(load_only('document_locales_archive'),
+                 joinedload('document_locales_archive').load_only(
+                    ArchiveDocumentLocale.title)) \
+        .order_by(desc(DocumentVersion.id)) \
+        .filter(DocumentVersion.history_metadata_id.in_(doc_ids)) \
+        .limit(limit) \
+        .all()
+
+    if not doc_changes:
+        return {'feed': [], 'total': 0}
+
+    last_change = doc_changes[-1]
+    pagination_token = '{}'.format(last_change.history_metadata_id)
+
+    return {
+        'total': doc_total,
+        'pagination_token': pagination_token,
+        'feed': [serialize_change(ch) for ch in doc_changes]
+    }
+
+
+def serialize_change(change):
+    return {
+        'written_at': change.history_metadata.written_at.isoformat(),
+        'lang': change.lang,
+        'document': {
+            'version': change.document.version,
+            'document_id': change.document.document_id,
+            'title': change.document_locales_archive.title,
+            'type': change.document.type,
+            'quality': change.document.quality
+        },
+        'user': {
+            'user_id': change.history_metadata.user_id,
+            'name': change.history_metadata.user.name,
+            'username': change.history_metadata.user.username,
+            'lang': change.history_metadata.user.lang
+        },
+        'version_id': change.id,
+        'comment': change.history_metadata.comment
+    }

--- a/c2corg_api/views/feed.py
+++ b/c2corg_api/views/feed.py
@@ -129,13 +129,13 @@ class ProfileFeedRest(object):
             raise HTTPForbidden('no permission to see the feed')
 
 
-def get_params(request):
+def get_params(request, default_page_limit=DEFAULT_PAGE_LIMIT):
     lang = request.validated.get('lang')
     token_id = request.validated.get('token_id')
     token_time = request.validated.get('token_time')
     limit = request.validated.get('limit')
     limit = min(
-        DEFAULT_PAGE_LIMIT if limit is None else limit,
+        default_page_limit if limit is None else limit,
         MAX_PAGE_LIMIT)
 
     return lang, token_id, token_time, limit

--- a/c2corg_api/views/validation.py
+++ b/c2corg_api/views/validation.py
@@ -165,11 +165,26 @@ def validate_token_pagination(request, **kwargs):
     validate_token(request)
 
 
+def validate_simple_token_pagination(request, **kwargs):
+    """
+    Validate token pagination parameters (limit and token) for changes feed.
+    """
+    check_get_for_integer_property(request, 'limit', False)
+    validate_simple_token(request)
+
+
 def validate_user_id(request, **kwargs):
     """
     Checks for a required user id parameter.
     """
     check_get_for_integer_property(request, 'u', True)
+
+
+def validate_user_id_not_required(request, **kwargs):
+    """
+    Checks for a non-required user id parameter.
+    """
+    check_get_for_integer_property(request, 'u', False)
 
 
 def parse_datetime(time_raw):
@@ -213,6 +228,18 @@ def validate_token(request, **kwargs):
                     request.validated['token_id'] = id
                     request.validated['token_time'] = time
                     return
+        request.errors.add('querystring', 'token', 'invalid format')
+
+
+def validate_simple_token(request, **kwargs):
+    if request.GET.get('token'):
+        token = request.GET.get('token')
+
+        # the token should have the format '{id}'
+        id = parse_int_safe(token)
+        if id is not None:
+            request.validated['token_id'] = id
+            return
         request.errors.add('querystring', 'token', 'invalid format')
 
 


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_api/issues/605

Right now I use http://localhost:6548/document/changes to access this data which are used to render a table of latest changes...

~~TODO - I should add:~~
~~- pagination to load batches of data on UI~~
~~- maybe cache, authentication for moderators or possibility to search by document type.~~

```javascript
{
    documents: [{
        user: {
            username: "dkocich",
            lang: "en",
            user_id: 811849,
            name: "dkocich",
            forum_username: "dkocich"
        },
        written_at: "2017-01-24T15:00:57.852404+01:00",
        version_id: 1302526,
        lang: "en",
        document: {
            document_id: 826224,
            type: "x",
            description: null,
            summary: null,
            title: "asfasfasfas"
        },
        comment: "creation"
    },
    ...
    ],
    count: 500
}
```