### PR TITLE
Allow Xrep. editing to all Xrep. associated users on API

### DIFF
--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -94,6 +94,17 @@ def _add_global_test_data(session):
         password='better pass', email_validated=True,
         profile=contributor2_profile)
 
+    contributor3_profile = UserProfile(
+        categories=['amateur'],
+        locales=[DocumentLocale(title='...', lang='en')])
+
+    contributor3 = User(
+        name='Contributor 3',
+        username='contributor3', email='contributor3@camptocamp.org',
+        forum_username='contributor3',
+        password='poor pass', email_validated=True,
+        profile=contributor3_profile)
+
     moderator_profile = UserProfile(
         categories=['mountain_guide'],
         locales=[DocumentLocale(title='', lang='en')])
@@ -105,7 +116,7 @@ def _add_global_test_data(session):
         moderator=True, password='even better pass',
         email_validated=True, profile=moderator_profile)
 
-    users = [moderator, contributor, contributor2]
+    users = [moderator, contributor, contributor2, contributor3]
     session.add_all(users)
     session.flush()
 
@@ -114,7 +125,7 @@ def _add_global_test_data(session):
     now = datetime.datetime.utcnow()
     exp = now + datetime.timedelta(weeks=10)
 
-    for user in [moderator, contributor, contributor2]:
+    for user in [moderator, contributor, contributor2, contributor3]:
         claims = create_claims(user, exp)
         token = jwt.encode(claims, key=key, algorithm=algorithm). \
             decode('utf-8')

--- a/c2corg_api/tests/views/test_user_profile.py
+++ b/c2corg_api/tests/views/test_user_profile.py
@@ -41,21 +41,21 @@ class TestUserProfileRest(BaseDocumentTestRest):
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 0, 'limit': 0}, user='contributor'),
-            [], 5)
+            [], 6)
 
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 0, 'limit': 1}, user='contributor'),
-            [self.profile4.document_id], 5)
+            [self.profile4.document_id], 6)
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 0, 'limit': 2}, user='contributor'),
-            [self.profile4.document_id, self.profile2.document_id], 5)
+            [self.profile4.document_id, self.profile2.document_id], 6)
         self.assertResultsEqual(
             self.get_collection(
-                {'offset': 1, 'limit': 2}, user='contributor'),
-            [self.profile2.document_id, self.global_userids['contributor2']],
-            5)
+                {'offset': 1, 'limit': 3}, user='contributor'),
+            [self.profile2.document_id, self.global_userids['contributor3'],
+             self.global_userids['contributor2']], 6)
 
     def test_get_collection_lang(self):
         self.get_collection_lang(user='contributor')
@@ -65,8 +65,9 @@ class TestUserProfileRest(BaseDocumentTestRest):
 
         self.assertResultsEqual(
             self.get_collection_search({'l': 'en'}, user='contributor'),
-            [self.profile4.document_id, self.global_userids['contributor2'],
-             self.profile1.document_id, self.global_userids['moderator']], 4)
+            [self.profile4.document_id, self.global_userids['contributor3'],
+             self.global_userids['contributor2'], self.profile1.document_id,
+             self.global_userids['moderator']], 5)
 
     def test_get_unauthenticated_private_profile(self):
         """Tests that only the user name is returned when requesting a private


### PR DESCRIPTION
related to https://github.com/c2corg/v6_ui/issues/1472
Required by UI part https://github.com/c2corg/v6_ui/pull/1480

An associated user can edit attributes of Xreport or XreportLocale...

TODO:
- [x] Removing of other associated documents by the associated user don't work correctly on UI now. I receive  these messages:

**On the detail view page**

_**Adding of assoc.**_
  - Failed to associate document: no rights to modify associations with xreport 826204 : associations.xreports 

_**Removing of assoc**_
  - Failed to unassociate document: no rights to modify associations between document r (226446) and x (826204) : Bad Request
`{"status": "error", "errors": [{"name": "Bad Request", "location": "body", "description": "no rights
 to modify associations between document r (50746) and x (826204)"}]}`

**On the edit page** 
No permission to change this xreport : Forbidden

