### PR TITLE
Skip query if no values for `in()`

### DIFF
--- a/c2corg_api/views/document_changes.py
+++ b/c2corg_api/views/document_changes.py
@@ -77,31 +77,34 @@ def load_feed(doc_ids, limit, user_id=None):
     else:
         doc_total = DBSession.query(HistoryMetaData.user_id).count()
 
-    doc_changes = DBSession.query(DocumentVersion) \
-        .options(load_only('history_metadata', 'lang'),
-                 joinedload('history_metadata').load_only(
-                    HistoryMetaData.id,
-                    HistoryMetaData.user_id,
-                    HistoryMetaData.comment,
-                    HistoryMetaData.written_at).
-                 joinedload('user').load_only(
-                    User.id,
-                    User.name,
-                    User.username,
-                    User.lang)) \
-        .options(load_only('document'),
-                 joinedload('document').load_only(
-                    Document.version,
-                    Document.document_id,
-                    Document.type,
-                    Document.quality)) \
-        .options(load_only('document_locales_archive'),
-                 joinedload('document_locales_archive').load_only(
-                    ArchiveDocumentLocale.title)) \
-        .order_by(desc(DocumentVersion.id)) \
-        .filter(DocumentVersion.history_metadata_id.in_(doc_ids)) \
-        .limit(limit) \
-        .all()
+    if not doc_ids:
+        doc_changes = []
+    else:
+        doc_changes = DBSession.query(DocumentVersion) \
+            .options(load_only('history_metadata', 'lang'),
+                     joinedload('history_metadata').load_only(
+                        HistoryMetaData.id,
+                        HistoryMetaData.user_id,
+                        HistoryMetaData.comment,
+                        HistoryMetaData.written_at).
+                     joinedload('user').load_only(
+                        User.id,
+                        User.name,
+                        User.username,
+                        User.lang)) \
+            .options(load_only('document'),
+                     joinedload('document').load_only(
+                        Document.version,
+                        Document.document_id,
+                        Document.type,
+                        Document.quality)) \
+            .options(load_only('document_locales_archive'),
+                     joinedload('document_locales_archive').load_only(
+                        ArchiveDocumentLocale.title)) \
+            .order_by(desc(DocumentVersion.id)) \
+            .filter(DocumentVersion.history_metadata_id.in_(doc_ids)) \
+            .limit(limit) \
+            .all()
 
     if not doc_changes:
         return {'feed': [], 'total': 0}

--- a/c2corg_api/views/document_changes.py
+++ b/c2corg_api/views/document_changes.py
@@ -50,10 +50,7 @@ class ChangesDocumentRest(object):
         lang, token_id, _, limit = get_params(self.request, 30)
 
         changes = get_changes_of_feed(token_id, limit, user_id)
-
-        doc_ids = []
-        for change in changes:
-            doc_ids.append(change.id)
+        doc_ids = [change.id for change in changes]
 
         return load_feed(doc_ids, limit, user_id)
 


### PR DESCRIPTION
When running the tests of current master, a warning was shown:

```
/home/tsauerwein/projects/c2corg/v6_api/.build/venv/lib/python3.4/site-packages/sqlalchemy/sql/default_comparator.py:161: 
SAWarning: The IN-predicate on "documents_versions.history_metadata_id" was invoked with an empty sequence. This results in a contradiction, which nonetheless can be expensive to evaluate.  Consider alternative strategies for improved performance.
  'strategies for improved performance.' % expr)
```