### PR TITLE
Fix recently changed docs API

### DIFF
--- a/c2corg_api/tests/views/test_document_changes.py
+++ b/c2corg_api/tests/views/test_document_changes.py
@@ -123,13 +123,11 @@ class TestChangesDocumentRest(BaseTestRest):
         response = self.app.get(self._prefix + '?token=0', status=200)
         body = response.json
 
-        self.assertIn('total', body)
         self.assertNotIn('pagination_token', body)
         self.assertIn('feed', body)
 
         feed = body['feed']
         self.assertEqual(0, len(feed))
-        self.assertEqual(0, body['total'])
 
     def test_get_changes_paginated(self):
         response = self.app.get(

--- a/c2corg_api/views/document_changes.py
+++ b/c2corg_api/views/document_changes.py
@@ -105,7 +105,7 @@ def load_feed(doc_ids, limit, user_id=None):
             .all()
 
     if not doc_changes:
-        return {'feed': [], 'total': 0}
+        return {'feed': []}
 
     last_change = doc_changes[-1]
     pagination_token = '{}'.format(last_change.history_metadata_id)


### PR DESCRIPTION
still WIP

related to https://github.com/c2corg/v6_api/issues/625

It is required to rewrite `get_changes_of_feed` to filter Outings+Users earlier to get a correct list of document IDs. If document types are filtered in `load_feed`, then API don't have to return exactly 30 documents...

Other issues to fix (or planned to add)
- how to load `title_prefix` when it is available only for some doc. types? related to https://github.com/c2corg/v6_ui/pull/1466#issuecomment-280615906
- add filtering on doc. type in the future