### PR TITLE
Add image/area version API

### DIFF
--- a/c2corg_api/tests/views/test_area.py
+++ b/c2corg_api/tests/views/test_area.py
@@ -3,10 +3,12 @@ import json
 from c2corg_api.models.area import Area, ArchiveArea, AREA_TYPE
 from c2corg_api.models.area_association import AreaAssociation
 from c2corg_api.models.association import Association
+from c2corg_api.models.document_history import DocumentVersion
 from c2corg_api.models.image import Image
 from c2corg_api.models.route import Route
 from c2corg_api.models.waypoint import Waypoint
 from c2corg_api.tests.search import reset_search_index
+
 from c2corg_common.attributes import quality_types
 from shapely.geometry import shape, Polygon
 
@@ -85,6 +87,9 @@ class TestAreaRest(BaseDocumentTestRest):
     def test_get_info(self):
         body, locale = self.get_info(self.area1, 'en')
         self.assertEqual(locale.get('lang'), 'en')
+
+    def test_get_version(self):
+        self.get_version(self.area1, self.area1_version)
 
     def test_post_error(self):
         body = self.post_error({}, user='moderator')
@@ -449,6 +454,10 @@ class TestAreaRest(BaseDocumentTestRest):
 
         user_id = self.global_userids['contributor']
         DocumentRest.create_new_version(self.area1, user_id)
+
+        self.area1_version = self.session.query(DocumentVersion). \
+            filter(DocumentVersion.document_id == self.area1.document_id). \
+            filter(DocumentVersion.lang == 'en').first()
 
         self.area2 = Area(area_type='range')
         self.session.add(self.area2)

--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -7,6 +7,7 @@ from c2corg_api.models.article import Article
 from c2corg_api.models.book import Book
 from c2corg_api.models.association import Association
 from c2corg_api.models.cache_version import CacheVersion
+from c2corg_api.models.document_history import DocumentVersion
 from c2corg_api.models.feed import update_feed_document_create, DocumentChange
 from c2corg_api.models.outing import OutingLocale, Outing, OUTING_TYPE
 from c2corg_api.models.user_profile import USERPROFILE_TYPE
@@ -67,6 +68,10 @@ class BaseTestImage(BaseDocumentTestRest):
 
         user_id = self.global_userids['contributor']
         DocumentRest.create_new_version(self.image, user_id)
+
+        self.image_version = self.session.query(DocumentVersion). \
+            filter(DocumentVersion.document_id == self.image.document_id). \
+            filter(DocumentVersion.lang == 'en').first()
 
         self.image2 = Image(
             filename='image2.jpg',
@@ -319,6 +324,9 @@ class TestImageRest(BaseTestImage):
     def test_get_info(self):
         body, locale = self.get_info(self.image, 'en')
         self.assertEqual(locale.get('lang'), 'en')
+
+    def test_get_version(self):
+        self.get_version(self.image, self.image_version)
 
     @patch('c2corg_api.views.image.requests.post',
            return_value=Mock(status_code=200))

--- a/c2corg_api/views/area.py
+++ b/c2corg_api/views/area.py
@@ -1,12 +1,14 @@
 import functools
 
 from c2corg_api.models.area import schema_area, Area, schema_update_area, \
-    AREA_TYPE, schema_create_area
+    AREA_TYPE, schema_create_area, ArchiveArea
 from c2corg_api.models.area_association import update_area
 from c2corg_api.models.cache_version import update_cache_version_for_area
-from c2corg_api.models.document import UpdateType
+from c2corg_api.models.document import UpdateType, ArchiveDocumentLocale
 from c2corg_api.views.document_info import DocumentInfoRest
 from c2corg_api.views.document_schemas import area_documents_config
+from c2corg_api.views.document_version import DocumentVersionRest
+
 from c2corg_common.fields_area import fields_area
 from cornice.resource import resource, view
 from cornice.validators import colander_body_validator
@@ -16,7 +18,7 @@ from c2corg_api.views.document import DocumentRest, make_validator_create, \
 from c2corg_api.views import cors_policy, restricted_json_view
 from c2corg_api.views.validation import validate_id, validate_pagination, \
     validate_lang_param, validate_preferred_lang_param, validate_lang, \
-    validate_associations
+    validate_associations, validate_version_id
 from pyramid.httpexceptions import HTTPBadRequest
 
 validate_area_create = make_validator_create(fields_area.get('required'))
@@ -91,3 +93,12 @@ def update_associations(area, update_types, user_id):
 
     if UpdateType.GEOM in update_types:
         update_area(area, reset=True)
+
+
+@resource(path='/areas/{id}/{lang}/{version_id}', cors_policy=cors_policy)
+class AreaVersionRest(DocumentVersionRest):
+
+    @view(validators=[validate_id, validate_lang, validate_version_id])
+    def get(self):
+        return self._get_version(
+            ArchiveArea, ArchiveDocumentLocale, schema_area)

--- a/c2corg_api/views/image.py
+++ b/c2corg_api/views/image.py
@@ -3,6 +3,7 @@ import functools
 import requests
 
 from c2corg_api.models import DBSession
+from c2corg_api.models.document import ArchiveDocumentLocale
 from c2corg_api.models.document_history import has_been_created_by
 from c2corg_api.models.feed import update_feed_images_upload
 from c2corg_api.models.image import Image, schema_image, schema_update_image, \
@@ -10,6 +11,8 @@ from c2corg_api.models.image import Image, schema_image, schema_update_image, \
 from c2corg_api.search.notify_sync import run_on_successful_transaction
 from c2corg_api.views.document_info import DocumentInfoRest
 from c2corg_api.views.document_schemas import image_documents_config
+from c2corg_api.views.document_version import DocumentVersionRest
+
 from c2corg_common.fields_image import fields_image
 from cornice.resource import resource, view
 from cornice.validators import colander_body_validator
@@ -20,7 +23,8 @@ from c2corg_api.views import cors_policy, restricted_json_view
 from c2corg_api.views import set_creator as set_creator_on_documents
 from c2corg_api.views.validation import validate_id, validate_pagination, \
     validate_lang_param, validate_preferred_lang_param, \
-    validate_associations, validate_associations_in, validate_lang
+    validate_associations, validate_associations_in, validate_lang, \
+    validate_version_id
 
 from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound, \
     HTTPBadRequest, HTTPInternalServerError, HTTPFound
@@ -267,3 +271,12 @@ def set_creator(image):
     """Set the creator (the user who created an image) on an image.
     """
     set_creator_on_documents([image], 'creator')
+
+
+@resource(path='/images/{id}/{lang}/{version_id}', cors_policy=cors_policy)
+class ImageVersionRest(DocumentVersionRest):
+
+    @view(validators=[validate_id, validate_lang, validate_version_id])
+    def get(self):
+        return self._get_version(
+            ArchiveImage, ArchiveDocumentLocale, schema_image)


### PR DESCRIPTION
close https://github.com/c2corg/v6_ui/issues/1503 UI issue 
related to API issue https://github.com/c2corg/v6_api/issues/410

- [x] tests are missing now...

These pages now load correctly and it is possible to link version of an image from `/whatsnew` feed page:
http://localhost:6558/images/824872/fr/1302521
http://localhost:6558/areas/282678/fr/460394