### PR TITLE
Rename document merging route

### DIFF
--- a/c2corg_api/tests/views/test_document_merge.py
+++ b/c2corg_api/tests/views/test_document_merge.py
@@ -16,7 +16,7 @@ class TestDocumentMergeRest(BaseTestRest):
 
     def setUp(self):  # noqa
         super(TestDocumentMergeRest, self).setUp()
-        self._prefix = '/document/merge'
+        self._prefix = '/documents/merge'
 
         contributor_id = self.global_userids['contributor']
 

--- a/c2corg_api/views/document_merge.py
+++ b/c2corg_api/views/document_merge.py
@@ -92,7 +92,7 @@ def validate_documents(request, **kwargs):
                 'body', 'types', 'merging user accounts is not supported')
 
 
-@resource(path='/document/merge', cors_policy=cors_policy)
+@resource(path='/documents/merge', cors_policy=cors_policy)
 class MergeDocumentRest(object):
 
     def __init__(self, request):
@@ -119,7 +119,7 @@ class MergeDocumentRest(object):
 
 
         Request:
-            `POST` `/document/merge`
+            `POST` `/documents/merge`
 
         Request body:
             {


### PR DESCRIPTION
Use ``documents/merge`` instead of ``document/merge`` (plural) to be consistent with specific document type routes (eg. ``waypoints/add``) and document deletion (``documents/delete``).