### PR TITLE
Add locale deletion service

### DIFF
--- a/alembic_migration/versions/940bd29040d8_add_table_es_deleted_locales.py
+++ b/alembic_migration/versions/940bd29040d8_add_table_es_deleted_locales.py
@@ -1,0 +1,32 @@
+"""Add table es_deleted_locales
+
+Revision ID: 940bd29040d8
+Revises: 8cc46db2c515
+Create Date: 2017-04-06 11:53:43.889917
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '940bd29040d8'
+down_revision = '8cc46db2c515'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'es_deleted_locales',
+        sa.Column('document_id', sa.Integer(), primary_key=True),
+        sa.Column('type', sa.String(1)),
+        sa.Column('lang', sa.String(2), nullable=False),
+        sa.Column(
+            'deleted_at', sa.DateTime(timezone=True),
+            server_default=sa.text('now()'), nullable=False, index=True),
+        sa.ForeignKeyConstraint(['lang'], ['guidebook.langs.lang'], ),
+        schema='guidebook')
+
+
+def downgrade():
+    op.drop_table('es_deleted_locales', schema='guidebook')

--- a/c2corg_api/models/es_sync.py
+++ b/c2corg_api/models/es_sync.py
@@ -1,6 +1,6 @@
 from c2corg_api.models import Base, schema
 from sqlalchemy.sql.functions import func
-from sqlalchemy.sql.schema import Column, CheckConstraint
+from sqlalchemy.sql.schema import Column, CheckConstraint, ForeignKey
 from sqlalchemy.sql.sqltypes import DateTime, Integer, String
 
 
@@ -45,6 +45,25 @@ class ESDeletedDocument(Base):
     document_id = Column(Integer, primary_key=True)
 
     type = Column(String(1))
+
+    deleted_at = Column(
+        DateTime(timezone=True), default=func.now(), nullable=False,
+        index=True)
+
+
+class ESDeletedLocale(Base):
+    """A table listing locales that have been deleted and that should be
+    removed from the ES index.
+    """
+    __tablename__ = 'es_deleted_locales'
+
+    document_id = Column(Integer, primary_key=True)
+
+    type = Column(String(1))
+
+    lang = Column(
+        String(2), ForeignKey(schema + '.langs.lang'),
+        nullable=False)
 
     deleted_at = Column(
         DateTime(timezone=True), default=func.now(), nullable=False,

--- a/c2corg_api/views/document_delete.py
+++ b/c2corg_api/views/document_delete.py
@@ -7,10 +7,11 @@ from c2corg_api.models.cache_version import CacheVersion, \
     update_cache_version_full
 from c2corg_api.models.document import (
     Document, DocumentLocale, ArchiveDocumentLocale,
-    ArchiveDocument, DocumentGeometry, ArchiveDocumentGeometry)
+    ArchiveDocument, DocumentGeometry, ArchiveDocumentGeometry,
+    get_available_langs)
 from c2corg_api.models.document_history import HistoryMetaData, DocumentVersion
 from c2corg_api.models.document_topic import DocumentTopic
-from c2corg_api.models.es_sync import ESDeletedDocument
+from c2corg_api.models.es_sync import ESDeletedDocument, ESDeletedLocale
 from c2corg_api.models.feed import DocumentChange
 from c2corg_api.models.image import IMAGE_TYPE, Image, ArchiveImage
 from c2corg_api.models.outing import (
@@ -27,9 +28,9 @@ from c2corg_api.models.xreport import (
 from c2corg_api.search.notify_sync import notify_es_syncer
 from c2corg_api.views import cors_policy, restricted_json_view
 from c2corg_api.views.image import delete_all_files_for_image
-from c2corg_api.views.validation import validate_id
+from c2corg_api.views.validation import validate_id, validate_lang
 from cornice.resource import resource
-from sqlalchemy.sql.expression import or_, and_, exists
+from sqlalchemy.sql.expression import or_, and_, exists, over
 from sqlalchemy.sql.functions import func
 
 
@@ -62,6 +63,23 @@ def validate_document(request, **kwargs):
             'document_id',
             'Unsupported type when deleting document')
         return
+
+    if 'lang' in request.validated:
+        # Tests specific to a locale-only deletion
+        lang = request.validated['lang']
+        available_langs = get_available_langs(document_id)
+        if lang not in available_langs:
+            request.errors.add(
+                'querystring',
+                'lang',
+                'locale not found')
+            return
+        request.validated['is_only_locale'] = len(available_langs) == 1
+        if not request.validated['is_only_locale']:
+            # When there are other locales left, the whole document is not
+            # deleted. Following tests are then not required.
+            request.validated['document_type'] = document_type
+            return
 
     if document_type == WAYPOINT_TYPE:
         if _is_main_waypoint_of_route(document_id):
@@ -133,28 +151,12 @@ def _is_only_route_of_outing(document_id):
     return DBSession.query(only_route).scalar()
 
 
-@resource(path='/documents/delete/{id}', cors_policy=cors_policy)
-class DeleteDocumentRest(object):
+class DeleteBase(object):
 
     def __init__(self, request):
         self.request = request
 
-    @restricted_json_view(
-        permission='moderator',
-        validators=[validate_id, validate_document])
-    def delete(self):
-        """
-        Delete a document.
-
-        Request:
-            `DELETE` `/documents/delete/{id}`
-        """
-        document_id = self.request.validated['id']
-        document_type = self.request.validated['document_type']
-
-        # Note: if an error occurs while deleting, SqlAlchemy will
-        # automatically cancel all DB changes.
-
+    def _delete(self, document_id, document_type):
         if document_type == IMAGE_TYPE:
             # Files are actually removed only if the transaction succeeds
             delete_all_files_for_image(document_id, self.request)
@@ -190,7 +192,7 @@ class DeleteDocumentRest(object):
         # Order of removals depends on foreign key constraints
         if document_type == WAYPOINT_TYPE:
             _remove_waypoint_from_routes_archives_main_waypoint_id(document_id)
-        _remove_history_metadata(document_id)
+        _remove_versions(document_id)
         _remove_archive_locale(archive_clazz_locale, document_id)
         _remove_archive_geometry(document_id)
         _remove_archive(archive_clazz, document_id)
@@ -207,6 +209,68 @@ class DeleteDocumentRest(object):
             filter(ArchiveDocument.redirects_to == document_id).all()
         for merged_document_id in merged_document_ids:
             self._delete_document(merged_document_id, document_type, True)
+
+
+@resource(path='/documents/delete/{id}', cors_policy=cors_policy)
+class DeleteDocumentRest(DeleteBase):
+
+    @restricted_json_view(
+        permission='moderator',
+        validators=[validate_id, validate_document])
+    def delete(self):
+        """
+        Delete a document.
+
+        Request:
+            `DELETE` `/documents/delete/{id}`
+        """
+        document_id = self.request.validated['id']
+        document_type = self.request.validated['document_type']
+
+        # Note: if an error occurs while deleting, SqlAlchemy will
+        # automatically cancel all DB changes.
+
+        return self._delete(document_id, document_type)
+
+
+@resource(path='/documents/delete/{id}/{lang}', cors_policy=cors_policy)
+class DeleteDocumentLocaleRest(DeleteBase):
+
+    @restricted_json_view(
+        permission='moderator',
+        validators=[validate_id, validate_lang, validate_document])
+    def delete(self):
+        """
+        Delete a document locale.
+
+        Request:
+            `DELETE` `/documents/delete/{id}/{lang}`
+        """
+        document_id = self.request.validated['id']
+        document_type = self.request.validated['document_type']
+        lang = self.request.validated['lang']
+
+        # Note: if an error occurs while deleting, SqlAlchemy will
+        # automatically cancel all DB changes.
+
+        # If only one locale is available, deleting it implies to remove
+        # the whole document.
+        if self.request.validated['is_only_locale']:
+            return self._delete(document_id, document_type)
+
+        clazz, clazz_locale, archive_clazz, archive_clazz_locale = _get_models(
+            document_type)
+
+        _remove_locale_versions(document_id, lang)
+        _remove_archive_locale(archive_clazz_locale, document_id, lang)
+        _remove_locale(clazz_locale, document_id, lang)
+
+        update_cache_version_full(document_id, document_type)
+
+        _update_deleted_locales_list(document_id, document_type, lang)
+        notify_es_syncer(self.request.registry.queue_config)
+
+        return {}
 
 
 def _get_models(document_type):
@@ -232,7 +296,7 @@ def _remove_from_cache(document_id):
         filter(CacheVersion.document_id == document_id).delete()
 
 
-def _remove_history_metadata(document_id):
+def _remove_versions(document_id):
     history_metadata_ids = DBSession. \
         query(DocumentVersion.history_metadata_id). \
         filter(DocumentVersion.document_id == document_id). \
@@ -245,26 +309,58 @@ def _remove_history_metadata(document_id):
     ))
 
 
-def _remove_archive_locale(archive_clazz_locale, document_id):
+def _remove_locale_versions(document_id, lang):
+    # Only history metadata not shared with other locales should be removed.
+    # This subquery gets the list of history_metadata_id with their lang and
+    # number of associated locales:
+    t = DBSession.query(
+        DocumentVersion.history_metadata_id,
+        DocumentVersion.lang,
+        over(
+            func.count('*'),
+            partition_by=DocumentVersion.history_metadata_id).label('cnt')). \
+        filter(DocumentVersion.document_id == document_id). \
+        subquery('t')
+    # Gets the list of history_metadata_id associated only
+    # to the current locale:
+    history_metadata_ids = DBSession.query(t.c.history_metadata_id). \
+        filter(t.c.lang == lang).filter(t.c.cnt == 1).all()
+
+    DBSession.query(DocumentVersion). \
+        filter(DocumentVersion.document_id == document_id). \
+        filter(DocumentVersion.lang == lang).delete()
+
+    if len(history_metadata_ids):
+        DBSession.execute(HistoryMetaData.__table__.delete().where(
+            HistoryMetaData.id.in_(history_metadata_ids)
+        ))
+
+
+def _remove_archive_locale(archive_clazz_locale, document_id, lang=None):
     if archive_clazz_locale:
-        archive_document_locale_ids = DBSession. \
-            query(ArchiveDocumentLocale.id). \
-            filter(ArchiveDocumentLocale.document_id == document_id). \
-            subquery()
+        query = DBSession.query(ArchiveDocumentLocale.id). \
+            filter(ArchiveDocumentLocale.document_id == document_id)
+        if lang:
+            query = query.filter(ArchiveDocumentLocale.lang == lang)
+        archive_document_locale_ids = query.subquery()
         DBSession.execute(archive_clazz_locale.__table__.delete().where(
             getattr(archive_clazz_locale, 'id').in_(
                 archive_document_locale_ids)
         ))
 
-    DBSession.query(ArchiveDocumentLocale). \
-        filter(ArchiveDocumentLocale.document_id == document_id). \
-        delete()
+    query = DBSession.query(ArchiveDocumentLocale). \
+        filter(ArchiveDocumentLocale.document_id == document_id)
+    if lang:
+        query = query.filter(ArchiveDocumentLocale.lang == lang)
+    query.delete()
 
 
-def _remove_locale(clazz_locale, document_id):
-    document_locale_ids = DBSession.query(DocumentLocale.id). \
-        filter(DocumentLocale.document_id == document_id). \
-        subquery()
+def _remove_locale(clazz_locale, document_id, lang=None):
+    query = DBSession.query(DocumentLocale.id). \
+        filter(DocumentLocale.document_id == document_id)
+    if lang:
+        query = query.filter(DocumentLocale.lang == lang)
+    document_locale_ids = query.subquery()
     # Remove links to comments (comments themselves are not removed)
     DBSession.execute(DocumentTopic.__table__.delete().where(
         DocumentTopic.document_locale_id.in_(document_locale_ids)
@@ -275,9 +371,11 @@ def _remove_locale(clazz_locale, document_id):
             getattr(clazz_locale, 'id').in_(document_locale_ids)
         ))
 
-    DBSession.query(DocumentLocale). \
-        filter(DocumentLocale.document_id == document_id). \
-        delete()
+    query = DBSession.query(DocumentLocale). \
+        filter(DocumentLocale.document_id == document_id)
+    if lang:
+        query = query.filter(DocumentLocale.lang == lang)
+    query.delete()
 
 
 def _remove_archive_geometry(document_id):
@@ -375,3 +473,8 @@ def _remove_associations(document_id):
 def _update_deleted_documents_list(document_id, document_type):
     DBSession.add(ESDeletedDocument(
         document_id=document_id, type=document_type))
+
+
+def _update_deleted_locales_list(document_id, document_type, lang):
+    DBSession.add(ESDeletedLocale(
+        document_id=document_id, type=document_type, lang=lang))


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_api/issues/645

TODO
* [x] create a ``DELETE documents/delete/{document_id}/{lang}`` service similar to https://github.com/c2corg/v6_api/blob/master/c2corg_api/views/document_delete.py#L145
* [x] validate document id and lang exist and check if other locales are available
* [x] if no other locale => use the existing ``DELETE documents/delete/{document_id}`` logic (factorize code)
* if other locales exist => only remove the locale:
 * [x] _remove_history_metadata (of the locale only => add a lang filter)
 * [x] _remove_archive_locale (of the given locale only)
 * [x] _remove_locale (of the given locale only)
 * [x] update cache
 * [x] update ES index
 * [ ] ~~update feed to update the lang list~~ => not relevant until  https://github.com/c2corg/v6_api/pull/642 is actually merged
* [x] ~~remove comments related to the locale (note: when deleting the whole document, only the references to the comments are removed, not the comments themselves)~~ => already managed by ``_remove_locale``