### PR TITLE
Fix incorrect query when testing for <24h creation date

### DIFF
--- a/c2corg_api/models/document_history.py
+++ b/c2corg_api/models/document_history.py
@@ -8,7 +8,7 @@ from sqlalchemy import (
     ForeignKey
     )
 from sqlalchemy.orm import relationship, backref
-from sqlalchemy.sql.expression import over, and_
+from sqlalchemy.sql.expression import over, and_, asc
 from sqlalchemy.sql.functions import func
 
 from c2corg_api.models import Base, DBSession, schema, users_schema
@@ -122,13 +122,9 @@ def is_less_than_24h_old(document_id):
     """
     written_at = DBSession.query(
         HistoryMetaData.written_at.label('written_at')). \
-        select_from(ArchiveDocument). \
-        join(
-            DocumentVersion,
-            and_(
-                ArchiveDocument.document_id == DocumentVersion.document_id,
-                ArchiveDocument.version == 1)). \
-        join(HistoryMetaData,
+        select_from(HistoryMetaData). \
+        join(DocumentVersion,
              DocumentVersion.history_metadata_id == HistoryMetaData.id). \
-        filter(ArchiveDocument.document_id == document_id).scalar()
+        filter(DocumentVersion.document_id == document_id). \
+        order_by(asc(HistoryMetaData.written_at)).limit(1).scalar()
     return datetime.now(timezone.utc) - written_at <= timedelta(hours=24)

--- a/c2corg_api/tests/views/test_document_delete.py
+++ b/c2corg_api/tests/views/test_document_delete.py
@@ -233,6 +233,16 @@ class TestDocumentDeleteRest(BaseTestRest):
 
         DocumentRest.create_new_version(self.article1, user_id)
         update_feed_document_create(self.article1, user_id)
+        self.session.flush()
+
+        self.article1.locales[0].title = 'Some other article title'
+        article1_lang = self.article1.locales[0].lang
+        self.session.flush()
+        DocumentRest.update_version(
+            self.article1, user_id,
+            'new title', [UpdateType.LANG], [article1_lang])
+        self.session.flush()
+
         self._add_association(self.route2, self.article1)
         self._add_association(self.outing2, self.article1)
         self.session.flush()


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1556#issuecomment-298595959

The former test to figure out if a document had been created less than 24h ago failed when several versions of the document had been created in the meantime => several history metadata were then returned despite the "version == 1" filter:
```
File \"/var/www/c2corg_api/models/document_history.py\", line 133, in is_less_than_24h_old\n    filter(ArchiveDocument.document_id == document_id).scalar()\n 
File \"/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/orm/query.py\", line 2783, in scalar\n    ret = self.one()\n
File \"/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/orm/query.py\", line 2757, in one\n
\"Multiple rows were found for one()\")\nsqlalchemy.orm.exc.MultipleResultsFound: Multiple rows were found for one()"}
```

The current PR simply gets the oldest history_metadata available for the document. 