### PR TITLE
Add support for slacklining

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test: .build/venv/bin/nosetests template .build/dev-requirements.timestamp .buil
 
 .PHONY: lint
 lint: .build/venv/bin/flake8
-	.build/venv/bin/flake8 c2corg_api
+	.build/venv/bin/flake8 c2corg_api es_migration
 
 .PHONY: install
 install: .build/requirements.timestamp template

--- a/alembic_migration/versions/bacd59c5806a_add_slacklining.py
+++ b/alembic_migration/versions/bacd59c5806a_add_slacklining.py
@@ -1,0 +1,202 @@
+"""Add slacklining
+
+Revision ID: bacd59c5806a
+Revises: 91b1beed9a1c
+Create Date: 2017-01-08 10:01:56.428713
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from c2corg_api.models import utils
+from alembic_migration.extensions import drop_enum
+from sqlalchemy.sql.sqltypes import Enum
+
+# revision identifiers, used by Alembic.
+revision = 'bacd59c5806a'
+down_revision = '91b1beed9a1c'
+branch_labels = None
+depends_on = None
+
+# activity enum
+activities_old = [
+    'skitouring', 'snow_ice_mixed', 'mountain_climbing', 'rock_climbing',
+    'ice_climbing', 'hiking', 'snowshoeing', 'paragliding',
+    'mountain_biking', 'via_ferrata']
+activities_new = activities_old + ['slacklining', ]
+
+activity_enum_old = Enum(
+    *activities_old,
+    name='activity_type', schema='guidebook')
+activity_enum_new = Enum(
+    *activities_new,
+    name='activity_type', schema='guidebook')
+activity_enum_tmp = Enum(
+    *activities_new,
+    name='_activity_type', schema='guidebook')
+
+tables_with_activity_column = [
+    ('guidebook', 'articles', 'activities', False),
+    ('guidebook', 'books', 'activities', False),
+    ('guidebook', 'images', 'activities', False),
+    ('guidebook', 'outings', 'activities', False),
+    ('guidebook', 'routes', 'activities', False),
+    ('guidebook', 'user_profiles', 'activities', False),
+    ('guidebook', 'xreports', 'activities', False),
+    ('guidebook', 'articles_archives', 'activities', False),
+    ('guidebook', 'books_archives', 'activities', False),
+    ('guidebook', 'images_archives', 'activities', False),
+    ('guidebook', 'outings_archives', 'activities', False),
+    ('guidebook', 'routes_archives', 'activities', False),
+    ('guidebook', 'user_profiles_archives', 'activities', False),
+    ('guidebook', 'xreports_archives', 'activities', False),
+    ('guidebook', 'feed_document_changes', 'activities', True),
+    ('users', 'user', 'feed_filter_activities', True),
+]
+
+# waypoint_type enum
+waypoint_types_old = [
+    'summit', 'pass', 'lake', 'waterfall', 'locality', 'bisse', 'canyon', 'access',
+    'climbing_outdoor', 'climbing_indoor', 'hut', 'gite', 'shelter', 'bivouac',
+    'camp_site', 'base_camp', 'local_product', 'paragliding_takeoff', 'paragliding_landing',
+    'cave', 'waterpoint', 'weather_station', 'webcam', 'virtual', 'misc']
+waypoint_types_new = waypoint_types_old + ['slackline_spot', ]
+
+waypoint_enum_old = Enum(
+    *waypoint_types_old,
+    name='waypoint_type', schema='guidebook')
+waypoint_enum_new = Enum(
+    *waypoint_types_new,
+    name='waypoint_type', schema='guidebook')
+waypoint_enum_tmp = Enum(
+    *waypoint_types_new,
+    name='_waypoint_type', schema='guidebook')
+
+tables_with_waypoint_type_column = [
+    ('guidebook', 'waypoints', 'waypoint_type', False),
+    ('guidebook', 'waypoints_archives', 'waypoint_type', False),
+]
+
+
+def replace_enum(old_enum, new_enum, tmp_enum, tables_to_update, array_column):
+    """ Function to replace an old enum with a new enum, e.g. to add a new
+     value to an enum.
+     See: http://stackoverflow.com/a/14845740/119937
+    """
+    # Create a temporary type, convert and drop the "old" type
+    tmp_enum.create(op.get_bind(), checkfirst=False)
+
+    for schema, table, column, update_default in tables_to_update:
+        if array_column and update_default:
+            op.execute(
+                'ALTER TABLE {0}.{1} ALTER COLUMN {2} DROP DEFAULT'.format(
+                    schema, table, column))
+
+        op.execute(
+            'ALTER TABLE {0}.{1} ALTER COLUMN {2} TYPE {3}.{4}{5}'
+            ' USING {2}::text{5}::{3}.{4}{5}'.format(
+                schema, table, column, tmp_enum.schema, tmp_enum.name,
+                '[]' if array_column else ''))
+
+    old_enum.drop(op.get_bind(), checkfirst=False)
+
+    # Create and convert to the "new" type
+    new_enum.create(op.get_bind(), checkfirst=False)
+
+    for schema, table, column, update_default in tables_to_update:
+        op.execute(
+            'ALTER TABLE {0}.{1} ALTER COLUMN {2} TYPE {3}.{4}{5}'
+            ' USING {2}::text{5}::{3}.{4}{5}'.format(
+                schema, table, column, new_enum.schema, new_enum.name,
+                '[]' if array_column else ''))
+
+        if array_column and update_default:
+            op.execute(
+                'ALTER TABLE {0}.{1} ALTER COLUMN {2} '
+                'SET DEFAULT \'{{}}\'::{3}.{4}[]'.format(
+                    schema, table, column, new_enum.schema, new_enum.name))
+
+    tmp_enum.drop(op.get_bind(), checkfirst=False)
+
+
+def upgrade():
+    # add new value 'slackline_spot' to enum 'waypoint_type'
+    replace_enum(
+        waypoint_enum_old, waypoint_enum_new, waypoint_enum_tmp,
+        tables_with_waypoint_type_column, array_column=False)
+
+    # add new value 'slacklining' to enum 'activity_type'
+    replace_enum(
+        activity_enum_old, activity_enum_new, activity_enum_tmp,
+        tables_with_activity_column, array_column=True)
+
+    # new enum 'slackline_type'
+    slackline_type_enum = sa.Enum(
+        'slackline', 'highline', 'waterline',
+        name='slackline_type', schema='guidebook')
+
+    op.execute("""
+        CREATE TYPE guidebook.slackline_type
+        AS ENUM('slackline', 'highline', 'waterline');
+        """)
+
+    for table in ['routes', 'routes_archives']:
+        op.add_column(
+            table,
+            sa.Column('slackline_type', slackline_type_enum),
+            schema='guidebook')
+        op.add_column(
+            table,
+            sa.Column('slackline_height', sa.SmallInteger),
+            schema='guidebook')
+
+    for table in ['routes_locales', 'routes_locales_archives']:
+        op.add_column(
+            table,
+            sa.Column('slackline_anchor1', sa.String),
+            schema='guidebook')
+        op.add_column(
+            table,
+            sa.Column('slackline_anchor2', sa.String),
+            schema='guidebook')
+
+    for table in ['waypoints', 'waypoints_archives']:
+        op.add_column(
+            table,
+            sa.Column(
+                'slackline_types', utils.ArrayOfEnum(slackline_type_enum)),
+            schema='guidebook')
+        op.add_column(
+            table,
+            sa.Column('slackline_length_min', sa.SmallInteger),
+            schema='guidebook')
+        op.add_column(
+            table,
+            sa.Column('slackline_length_max', sa.SmallInteger),
+            schema='guidebook')
+
+
+def downgrade():
+    # remove value 'slacklining' from enum 'activity_type' and 'slackline_spot'
+    # from 'waypoint_type'
+    # note that this operation will fail if the value is still used somewhere.
+    replace_enum(
+        activity_enum_new, activity_enum_old, activity_enum_tmp,
+        tables_with_activity_column, array_column=True)
+    replace_enum(
+        waypoint_enum_new, waypoint_enum_old, waypoint_enum_tmp,
+        tables_with_waypoint_type_column, array_column=False)
+
+    for table in ['routes', 'routes_archives']:
+        op.drop_column(table, 'slackline_type', schema='guidebook')
+        op.drop_column(table, 'slackline_height', schema='guidebook')
+
+    for table in ['routes_locales', 'routes_locales_archives']:
+        op.drop_column(table, 'slackline_anchor1', schema='guidebook')
+        op.drop_column(table, 'slackline_anchor2', schema='guidebook')
+
+    for table in ['waypoints', 'waypoints_archives']:
+        op.drop_column(table, 'slackline_types', schema='guidebook')
+        op.drop_column(table, 'slackline_length_min', schema='guidebook')
+        op.drop_column(table, 'slackline_length_max', schema='guidebook')
+
+    drop_enum('slackline_type', schema='guidebook')

--- a/c2corg_api/__init__.py
+++ b/c2corg_api/__init__.py
@@ -96,6 +96,7 @@ def main(global_config, **settings):
         log.warning('Bypassing authorization')
 
     configure_caches(settings)
+    configure_feed(settings, config)
 
     # Scan MUST be the last call otherwise ACLs will not be set
     # and the permissions would be bypassed
@@ -114,3 +115,11 @@ def ping_connection(dbapi_connection, connection_record, connection_proxy):
         # connecting again up to three times before raising.
         raise exc.DisconnectionError()
     cursor.close()
+
+
+def configure_feed(settings, config):
+    account_id = None
+
+    if settings.get('feed.admin_user_account'):
+        account_id = int(settings.get('feed.admin_user_account'))
+    config.registry.feed_admin_user_account_id = account_id

--- a/c2corg_api/models/enums.py
+++ b/c2corg_api/models/enums.py
@@ -146,3 +146,5 @@ avalanche_level = enum(
     'avalanche_level', attributes.avalanche_levels)
 avalanche_slope = enum(
     'avalanche_slope', attributes.avalanche_slopes)
+slackline_type = enum(
+    'slackline_type', attributes.slackline_types)

--- a/c2corg_api/models/route.py
+++ b/c2corg_api/models/route.py
@@ -149,6 +149,10 @@ class _RouteMixin(object):
     # type de voie
     climbing_outdoor_type = Column(enums.climbing_outdoor_type)
 
+    slackline_type = Column(enums.slackline_type)
+
+    slackline_height = Column(SmallInteger)
+
 
 attributes = [
     'main_waypoint_id', 'activities', 'elevation_min', 'elevation_max',
@@ -162,7 +166,8 @@ attributes = [
     'aid_rating', 'via_ferrata_rating', 'hiking_rating',
     'hiking_mtb_exposition', 'snowshoe_rating', 'mtb_up_rating',
     'mtb_down_rating', 'mtb_length_asphalt', 'mtb_length_trail',
-    'mtb_height_diff_portages', 'rock_types', 'climbing_outdoor_type']
+    'mtb_height_diff_portages', 'rock_types', 'climbing_outdoor_type',
+    'slackline_type', 'slackline_height']
 
 
 class Route(_RouteMixin, Document):
@@ -236,9 +241,13 @@ class _RouteLocaleMixin(object):
     # historique de l'itineraire
     route_history = Column(String)
 
+    slackline_anchor1 = Column(String)
+
+    slackline_anchor2 = Column(String)
 
 attributes_locales = [
-    'slope', 'remarks', 'gear', 'external_resources', 'route_history'
+    'slope', 'remarks', 'gear', 'external_resources', 'route_history',
+    'slackline_anchor1', 'slackline_anchor2'
 ]
 
 

--- a/c2corg_api/models/waypoint.py
+++ b/c2corg_api/models/waypoint.py
@@ -164,6 +164,12 @@ class _WaypointMixin(object):
     # nb places en gardiennage (gite, camping refuge)
     capacity_staffed = Column(SmallInteger)
 
+    slackline_types = Column(ArrayOfEnum(enums.slackline_type))
+
+    slackline_length_min = Column(SmallInteger)
+
+    slackline_length_max = Column(SmallInteger)
+
 
 attributes = [
     'waypoint_type', 'elevation', 'prominence', 'length', 'height_median',
@@ -178,7 +184,8 @@ attributes = [
     'blanket_unstaffed', 'gas_unstaffed', 'heating_unstaffed',
     'climbing_styles', 'access_time', 'climbing_rating_max',
     'climbing_rating_min', 'climbing_rating_median', 'height_min',
-    'equipment_ratings'
+    'equipment_ratings', 'slackline_types', 'slackline_length_min',
+    'slackline_length_max'
 ]
 
 

--- a/c2corg_api/search/mappings/route_mapping.py
+++ b/c2corg_api/search/mappings/route_mapping.py
@@ -121,6 +121,8 @@ class SearchRoute(SearchDocument):
          'rock', model_field=Route.rock_types)
     climbing_outdoor_type = QEnumArray(
          'crtyp', model_field=Route.climbing_outdoor_type)
+    slackline_type = QEnum(
+         'sltyp', model_field=Route.slackline_type)
 
     FIELDS = [
         'activities', 'elevation_min', 'elevation_max', 'height_diff_up',
@@ -128,7 +130,8 @@ class SearchRoute(SearchDocument):
         'height_diff_access', 'height_diff_difficulties', 'route_types',
         'orientations', 'glacier_gear', 'configuration',
         'mtb_length_asphalt', 'mtb_length_trail',
-        'mtb_height_diff_portages', 'rock_types', 'climbing_outdoor_type'
+        'mtb_height_diff_portages', 'rock_types', 'climbing_outdoor_type',
+        'slackline_type'
     ]
 
     ENUM_RANGE_FIELDS = [

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -231,6 +231,7 @@ class BaseTestCase(unittest.TestCase, AssertionsMixin):
         self.queue_config = registry.queue_config
         reset_queue(self.queue_config)
         reset_cache_key()
+        registry.feed_admin_user_account_id = None
 
     def tearDown(self):  # noqa
         # rollback - everything that happened with the Session above

--- a/common.ini.in
+++ b/common.ini.in
@@ -52,6 +52,9 @@ redis.cache_status_refresh_period = {redis_cache_status_refresh_period}
 cache_version = {version}
 cache_version_timestamp = False
 
+# if given, changes of this user account will not be returned in the feed
+feed.admin_user_account = {feed_admin_user_account}
+
 logging.level = {logging_level}
 
 jwtauth.find_groups = c2corg_api.security.roles:groupfinder

--- a/config/default
+++ b/config/default
@@ -86,4 +86,7 @@ export image_backend_secret_key = test
 export skip_captcha_validation = False
 export recaptcha_secret_key = 6LfWUwoUAAAAABDo4_HRfru4HfLxOKmcqBRBObGj
 
+# if given, changes of this user account will not be returned in the feed
+export feed_admin_user_account = 2
+
 export show_debugger_for_errors = false

--- a/es_migration/2017-03-29_slackline.py
+++ b/es_migration/2017-03-29_slackline.py
@@ -1,0 +1,73 @@
+import sys
+
+import os
+from c2corg_api.search import configure_es_from_config, elasticsearch_config
+from c2corg_api.search.mappings.route_mapping import SearchRoute
+from elasticsearch_dsl import Index
+from pyramid.paster import (
+    get_appsettings,
+    setup_logging,
+    )
+from pyramid.scripts.common import parse_vars
+
+
+def usage(argv):
+    cmd = os.path.basename(argv[0])
+    print('usage: %s <config_uri> [var=value]\n'
+          '(example: "%s development.ini")' % (cmd, cmd))
+    sys.exit(1)
+
+
+def main(argv=sys.argv):
+    if len(argv) < 2:
+        usage(argv)
+    config_uri = argv[1]
+    options = parse_vars(argv[2:])
+    setup_logging(config_uri)
+    settings = get_appsettings(config_uri, options=options)
+    configure_es_from_config(settings)
+    migrate()
+
+
+def migrate():
+    """ Add the field "slackline_type" to the route mapping.
+    """
+    client = elasticsearch_config['client']
+    index_name = elasticsearch_config['index']
+    mapping_name = SearchRoute._doc_type.name
+    field_name = 'slackline_type'
+
+    info = client.info()
+    print('ElasticSearch version: {0}'.format(info['version']['number']))
+
+    if not client.indices.exists(index_name):
+        print('Index "{0}" does not exists!'.format(index_name))
+        sys.exit(0)
+
+    index = Index(index_name)
+    field_mapping = index.connection.indices.get_field_mapping(
+        index=index_name,
+        doc_type=mapping_name,
+        fields=field_name
+        )
+
+    if field_mapping:
+        print('Field "{0}" already exists'.format(field_name))
+        sys.exit(0)
+
+    # see:
+    # https://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-put-mapping.html
+    index.connection.indices.put_mapping(
+        index=index_name,
+        doc_type=mapping_name,
+        body={
+            'properties': {
+                field_name: SearchRoute.queryable_fields['sltyp'].to_dict()
+            }
+        }
+    )
+
+    print('Field "{0}" created'.format(field_name))
+
+if __name__ == "__main__":
+    main()

--- a/es_migration/Readme.md
+++ b/es_migration/Readme.md
@@ -1,0 +1,6 @@
+This directory contains scripts to update the mapping configuration of
+the ElaticSearch index.
+
+To apply a migration, run the script with e.g.:
+
+    .build/venv/bin/python es_migration/2017-03-29_slackline.py development.ini

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ git+https://github.com/tsauerwein/cornice.git@nested-none-2.1.0-c2corg
 # c2corg_common project
 # for development use a local checkout
 # -e ../v6_common
-git+https://github.com/c2corg/v6_common.git@cab298e
+git+https://github.com/c2corg/v6_common.git@d8ce59a
 
 # Discourse API client
 git+https://github.com/c2corg/pydiscourse.git@188cdf8

--- a/test.ini.in
+++ b/test.ini.in
@@ -18,3 +18,4 @@ discourse.url = {tests_discourse_url}
 discourse.api_key = {discourse_api_key}
 discourse.sso_secret = {discourse_sso_secret}
 skip.captcha.validation = True
+feed.admin_user_account =


### PR DESCRIPTION
See https://github.com/c2corg/v6_ui/issues/1543

This PR adapts the API to support slacklining:
- Adds `slacklining` as new activity
- Adds `slackline_spot` as new waypoint type
- Adds new fields to the routes model (`slackline_type`, `slackline_height`)
- Adds new fields to the routes_local model (`slackline_anchor1`, `slackline_anchor2`)
- Adds new fields to the waypoints model (`slackline_types`, `slackline_length_min`, `slackline_length_max`)

To make it possible to filter routes on the slackline type, I had to adapt the ES mapping. When applying this PR, a script has to be run to change the mapping, see https://github.com/c2corg/v6_api/tree/highline/es_migration

Still todo:

* [x] For the import, ignore changes of the [C2C account](https://www.camptocamp.org/profiles/2/fr) user in the feed.