### PR TITLE
Fix transfer encoding of sent emails

### DIFF
--- a/c2corg_api/emails/email_service.py
+++ b/c2corg_api/emails/email_service.py
@@ -1,7 +1,7 @@
 import transaction  # NOQA
 
 from pyramid_mailer import get_mailer
-from pyramid_mailer.message import Message
+from pyramid_mailer.message import Message, Attachment
 from functools import lru_cache
 from c2corg_common.attributes import default_langs
 
@@ -54,6 +54,16 @@ class EmailService:
         """Send an email. This method may throw."""
         log.debug('Sending email to %s through %s' % (
             to_address, self.mail_server))
+        if body:
+            # Convert body text to attachment instance
+            # in order to force the transfer encoding to base64
+            # instead of quoted-printable because of problems
+            # with email services such as hotmail.
+            body = Attachment(
+                data=body,
+                content_type='text/plain',
+                transfer_encoding='base64',
+                disposition='inline')
         msg = Message(
                 subject=subject,
                 sender=self.mail_from,

--- a/c2corg_api/tests/emails/test_emails.py
+++ b/c2corg_api/tests/emails/test_emails.py
@@ -12,7 +12,7 @@ class EmailTests(BaseTestCase):
         self.email_service._send_email('toto@localhost', subject='s', body='b')
         self.assertEqual(self.get_email_box_length(), outbox_count + 1)
         self.assertEqual(self.get_last_email().subject, "s")
-        self.assertEqual(self.get_last_email().body, "b")
+        self.assertEqual(self.get_last_email().body.data, "b")
 
     def test_registration_confirmation(self):
         user = User(email='me@localhost', lang='en')
@@ -21,8 +21,8 @@ class EmailTests(BaseTestCase):
         self.email_service.send_registration_confirmation(user, link)
         self.assertEqual(self.get_email_box_length(), outbox_count + 1)
         self.assertIn("Registration", self.get_last_email().subject)
-        self.assertIn("To activate", self.get_last_email().body)
-        self.assertIn(link, self.get_last_email().body)
+        self.assertIn("To activate", self.get_last_email().body.data)
+        self.assertIn(link, self.get_last_email().body.data)
 
     def test_localization(self):
         localizator = EmailLocalizator()

--- a/c2corg_api/tests/views/test_user.py
+++ b/c2corg_api/tests/views/test_user.py
@@ -77,7 +77,7 @@ class BaseUserTestRest(BaseTestRest):
         return re.findall('http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@#.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+[0-9a-zA-Z]', data)  # noqa
 
     def extract_nonce(self, key):
-        match = self.extract_urls(self.get_last_email().body)
+        match = self.extract_urls(self.get_last_email().body.data)
         validation_url = match[0]
         fragment = urlparse(validation_url).fragment
         nonce = fragment.replace(key + '=',  '')


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_ui/issues/1730

I have not figured out how to easily set the message encoding when defining the ``Message`` at https://github.com/c2corg/v6_api/blob/de9e3a730f299b5fcc98183edaee04de7027e1a5/c2corg_api/emails/email_service.py#L55-L60

but I have noticed it seems possible to do so for ``Attachment`` and that message bodies could be defined directly as ``Attachment`` (and are converted to ``Attachment`` anyway if not already the case):
https://github.com/Pylons/pyramid_mailer/blob/master/pyramid_mailer/message.py#L201-L216

This PR explicitely uses an ``Attachment`` object as body of the message and set the charset when creating this object.

@gberaudo I know it's been a while since you have written the email service code, but does this change make sense to you?
