### PR TITLE
Add SSO rest service

### DIFF
--- a/alembic_migration/versions/9739938498a8_add_sso_tables.py
+++ b/alembic_migration/versions/9739938498a8_add_sso_tables.py
@@ -1,0 +1,38 @@
+"""Add SSO tables
+
+Revision ID: 9739938498a8
+Revises: 8c230a4a0284
+Create Date: 2017-08-17 15:25:46.868974
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '9739938498a8'
+down_revision = '8c230a4a0284'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table('sso_key',
+                    sa.Column('domain', sa.String(), nullable=False),
+                    sa.Column('key', sa.String(), nullable=False),
+                    sa.PrimaryKeyConstraint('domain'),
+                    sa.UniqueConstraint('key'),
+                    schema='users')
+    op.create_table('sso_external_id',
+                    sa.Column('domain', sa.String(), nullable=False),
+                    sa.Column('external_id', sa.Integer(), nullable=False),
+                    sa.Column('user_id', sa.Integer(), nullable=False),
+                    sa.Column('token', sa.String()),
+                    sa.Column('expire', sa.DateTime(timezone=True)),
+                    sa.ForeignKeyConstraint(['domain'], ['users.sso_key.domain'], ),
+                    sa.ForeignKeyConstraint(['user_id'], ['users.user.id'], ),
+                    sa.PrimaryKeyConstraint('domain', 'external_id'),
+                    schema='users')
+
+def downgrade():
+    op.drop_table('sso_external_id', schema='users')
+    op.drop_table('sso_key', schema='users')

--- a/c2corg_api/models/__init__.py
+++ b/c2corg_api/models/__init__.py
@@ -43,6 +43,7 @@ from c2corg_api.models import article  # noqa
 from c2corg_api.models import book  # noqa
 from c2corg_api.models import feed  # noqa
 from c2corg_api.models import mailinglist  # noqa
+from c2corg_api.models import sso  # noqa
 
 document_types = {
     xreport.XREPORT_TYPE: xreport.Xreport,

--- a/c2corg_api/models/sso.py
+++ b/c2corg_api/models/sso.py
@@ -1,0 +1,40 @@
+from sqlalchemy import (
+    Column,
+    Integer,
+    ForeignKey,
+    DateTime,
+    String
+    )
+from sqlalchemy.orm import relationship
+
+from c2corg_api.models import Base, users_schema
+from c2corg_api.models.user import User
+
+
+class SsoKey(Base):
+    """
+    Class containing API keys.
+    """
+    __tablename__ = 'sso_key'
+    __table_args__ = {"schema": users_schema}
+
+    domain = Column(String(), nullable=False, primary_key=True)
+    key = Column(String(), nullable=False, unique=True)
+
+
+class SsoExternalId(Base):
+    """
+    Class containing User's SSO external identifiers.
+    """
+    __tablename__ = 'sso_external_id'
+    __table_args__ = {"schema": users_schema}
+
+    domain = Column(String(), ForeignKey(users_schema + '.sso_key.domain'),
+                    nullable=False, primary_key=True)
+    external_id = Column(Integer, nullable=False, primary_key=True)
+    user_id = Column(Integer, ForeignKey(users_schema + '.user.id'),
+                     nullable=False)
+    token = Column(String())
+    expire = Column(DateTime(timezone=True))
+
+    user = relationship(User)

--- a/c2corg_api/tests/views/test_sso.py
+++ b/c2corg_api/tests/views/test_sso.py
@@ -1,0 +1,389 @@
+# -*- coding: utf-8 -*-
+
+from unittest.mock import patch, Mock
+from urllib.parse import urlparse, parse_qs
+
+from pydiscourse.exceptions import DiscourseClientError
+
+from c2corg_api.models.user import User
+from c2corg_api.models.sso import SsoKey, SsoExternalId
+from c2corg_api.security.discourse_client import set_discourse_client
+from c2corg_api.tests.views import BaseTestRest
+from c2corg_api.views.sso import localized_now, sso_expire_from_now
+
+sso_domain = 'external.domain.net'
+sso_key = 'sso_test_key'
+
+
+class TestSsoSyncRest(BaseTestRest):
+
+    def setUp(self):
+        super().setUp()
+        self._url = "/sso_sync"
+
+        self.contributor = self.session.query(User). \
+            filter(User.username == 'contributor'). \
+            one()
+
+        self.session.add(SsoKey(
+            domain=sso_domain,
+            key=sso_key,
+        ))
+        self.contributor_external_id = SsoExternalId(
+            domain=sso_domain,
+            external_id='1',
+            user=self.contributor,
+        )
+        self.session.add(self.contributor_external_id)
+        self.session.flush()
+
+        set_discourse_client(None)
+
+    def test_no_sso_key(self):
+        request_body = {
+            'external_id': '999',
+            'email': 'newuser@external.domain.net'
+        }
+        body = self.app_post_json(self._url, request_body, status=400).json
+        errors = body.get('errors')
+        self.assertEqual('sso_key', errors[0].get('name'))
+        self.assertEqual('Required', errors[0].get('description'))
+
+    def test_bad_sso_key(self):
+        request_body = {
+            'sso_key': 'bad_sso_key',
+            'external_id': '999',
+            'email': 'newuser@external.domain.net'
+        }
+        body = self.app_post_json(self._url, request_body, status=403).json
+        errors = body.get('errors')
+        self.assertEqual('sso_key', errors[0].get('name'))
+        self.assertEqual('Invalid', errors[0].get('description'))
+
+    def test_no_external_id(self):
+        request_body = {
+            'sso_key': sso_key
+        }
+        body = self.app_post_json(self._url, request_body, status=400).json
+        errors = body.get('errors')
+        self.assertEqual('external_id', errors[0].get('name'))
+        self.assertEqual('Required', errors[0].get('description'))
+
+    def test_new_user_no_email(self):
+        request_body = {
+            'sso_key': sso_key,
+            'external_id': '999',
+        }
+        body = self.app_post_json(self._url, request_body, status=400).json
+        errors = body.get('errors')
+        self.assertEqual('email', errors[0].get('name'))
+        self.assertEqual('Required', errors[0].get('description'))
+
+    def test_new_user_existing_username(self):
+        request_body = {
+            'sso_key': sso_key,
+            'external_id': '999',
+            'email': 'newuser@external.domain.net',
+            'username': self.contributor.username,
+            'lang': 'fr',
+            'groups': 'group1,group2'
+        }
+        body = self.app_post_json(self._url, request_body, status=400).json
+        errors = body.get('errors')
+        self.assertEqual('already used username', errors[0].get('description'))
+
+    def test_new_user_existing_forum_username(self):
+        request_body = {
+            'sso_key': sso_key,
+            'external_id': '999',
+            'email': 'newuser@external.domain.net',
+            'username': 'newuser',
+            'forum_username': self.contributor.forum_username,
+            'lang': 'fr',
+            'groups': 'group1,group2'
+        }
+        body = self.app_post_json(self._url, request_body, status=400).json
+        errors = body.get('errors')
+        self.assertEqual('already used forum_username',
+                         errors[0].get('description'))
+
+    @patch(
+        'c2corg_api.security.discourse_client.DiscourseClient',
+        return_value=Mock(
+            by_external_id=Mock(
+                side_effect=DiscourseClientError(
+                    response=Mock(status_code=404)
+                )
+            ),
+            sync_sso=Mock(return_value={
+                'id': 555
+            })
+        )
+    )
+    def test_new_user_success(self, discourse_mock):
+        request_body = {
+            'sso_key': sso_key,
+            'external_id': '999',
+            'email': 'newuser@external.domain.net',
+            'username': 'newuser',
+            'name': 'New User',
+            'forum_username': 'NewUser',
+            'lang': 'fr',
+        }
+        body = self.app_post_json(self._url, request_body, status=200).json
+
+        sso_external_id = self.session.query(SsoExternalId). \
+            filter(SsoExternalId.domain == sso_domain). \
+            filter(SsoExternalId.external_id == '999'). \
+            one_or_none()
+        self.assertIsNotNone(sso_external_id)
+        sso_user = sso_external_id.user
+        self.assertEqual('newuser', sso_user.username)
+        self.assertEqual('New User', sso_user.name)
+        self.assertEqual('NewUser', sso_user.forum_username)
+
+        self.assertEqual(sso_external_id.token,
+                         self.token_from_url(body.get('url')))
+
+        client = discourse_mock.return_value
+        client.by_external_id.assert_called_with(sso_external_id.user.id)
+        client.sync_sso.assert_called_once_with(
+            sso_secret=self.settings.get('discourse.sso_secret'),
+            name='New User',
+            username='NewUser',
+            email='newuser@external.domain.net',
+            external_id=sso_user.id
+        )
+
+    def token_from_url(self, url):
+        qs = parse_qs(urlparse(url).query)
+        return qs.get('token')[0]
+
+    @patch(
+        'c2corg_api.security.discourse_client.DiscourseClient',
+        return_value=Mock(
+            by_external_id=Mock(return_value={
+                'id': 1,
+                'username': 'contributor'
+            })
+        )
+    )
+    def test_success_by_email(self, discourse_mock):
+        request_body = {
+            'sso_key': sso_key,
+            'external_id': '1',
+            'email': self.contributor.email
+        }
+        body = self.app_post_json(self._url, request_body, status=200).json
+
+        sso_external_id = self.session.query(SsoExternalId). \
+            filter(SsoExternalId.domain == sso_domain). \
+            filter(SsoExternalId.external_id == '1'). \
+            one_or_none()
+        self.assertIsNotNone(sso_external_id)
+        self.assertEqual('contributor', sso_external_id.user.username)
+
+        self.assertEqual(sso_external_id.token,
+                         self.token_from_url(body.get('url')))
+
+    @patch(
+        'c2corg_api.security.discourse_client.DiscourseClient',
+        return_value=Mock(
+            by_external_id=Mock(return_value={
+                'id': 1,
+                'username': 'contributor'
+            })
+        )
+    )
+    def test_success_by_external_id(self, discourse_mock):
+        request_body = {
+            'sso_key': sso_key,
+            'external_id': '1',
+            'email': 'email@external.domain.net',
+            'username': self.contributor.username,
+            'name': self.contributor.name,
+            'forum_username': self.contributor.forum_username,
+            'lang': 'fr',
+        }
+        body = self.app_post_json(self._url, request_body, status=200).json
+
+        self.session.expire(self.contributor_external_id)
+        self.assertEqual(self.contributor_external_id.token,
+                         self.token_from_url(body.get('url')))
+
+        client = discourse_mock.return_value
+        client.by_external_id.assert_called_once_with(self.contributor.id)
+
+    @patch(
+        'c2corg_api.security.discourse_client.DiscourseClient',
+        return_value=Mock(
+            by_external_id=Mock(side_effect=ConnectionError())
+        )
+    )
+    def test_discourse_down(self, discourse_mock):
+        request_body = {
+            'sso_key': sso_key,
+            'external_id': '999',
+            'email': 'newuser@external.domain.net',
+            'username': 'newuser',
+            'name': 'New User',
+            'forum_username': 'NewUser',
+            'lang': 'fr',
+        }
+        body = self.app_post_json(self._url, request_body, status=500).json
+        errors = body.get('errors')
+        self.assertEqual('Error with Discourse', errors[0].get('description'))
+
+    @patch(
+        'c2corg_api.security.discourse_client.DiscourseClient',
+        return_value=Mock(
+            by_external_id=Mock(
+                side_effect=DiscourseClientError(
+                    response=Mock(status_code=404)
+                )
+            ),
+            sync_sso=Mock(return_value={
+                'id': 555
+            })
+        )
+    )
+    def test_new_user_no_name(self, discourse_mock):
+        """name and forum_username should default to username"""
+        request_body = {
+            'sso_key': sso_key,
+            'external_id': '999',
+            'email': 'newuser@external.domain.net',
+            'username': 'newuser',
+            'lang': 'fr',
+        }
+        self.app_post_json(self._url, request_body, status=200).json
+
+        sso_external_id = self.session.query(SsoExternalId). \
+            filter(SsoExternalId.domain == sso_domain). \
+            filter(SsoExternalId.external_id == '999'). \
+            one_or_none()
+        self.assertIsNotNone(sso_external_id)
+        sso_user = sso_external_id.user
+        self.assertEqual('newuser', sso_user.username)
+        self.assertEqual('newuser', sso_user.name)
+        self.assertEqual('newuser', sso_user.forum_username)
+
+    @patch(
+        'c2corg_api.security.discourse_client.DiscourseClient',
+        return_value=Mock(
+            by_external_id=Mock(return_value={
+                'id': 1,
+                'username': 'contributor'
+            }),
+            sync_sso=Mock(return_value={
+                'id': 1
+            }),
+            groups=Mock(return_value=[]),
+        )
+    )
+    def test_not_found_group(self, discourse_mock):
+        request_body = {
+            'sso_key': sso_key,
+            'external_id': '1',
+            'group': 'group_1',
+        }
+        self.app_post_json(self._url, request_body, status=200).json
+
+    @patch(
+        'c2corg_api.security.discourse_client.DiscourseClient',
+        return_value=Mock(
+            by_external_id=Mock(return_value={
+                'id': 1,
+                'username': 'contributor'}),
+            groups=Mock(return_value=[{
+                'id': 222,
+                'name': 'group_1'
+            }]),
+            add_user_to_group=Mock()
+        )
+    )
+    def test_existing_group(self, discourse_mock):
+        request_body = {
+            'sso_key': sso_key,
+            'external_id': '1',
+            'groups': 'group_1'
+        }
+        self.app_post_json(self._url, request_body, status=200).json
+
+        client = discourse_mock.return_value
+        client.add_user_to_group.assert_called_once_with(222, 1)
+
+
+class TestSsoLoginRest(BaseTestRest):
+
+    def setUp(self):
+        super().setUp()
+        self._url = "/sso_login"
+
+        self.contributor = self.session.query(User). \
+            filter(User.username == 'contributor'). \
+            one()
+
+        self.session.add(SsoKey(
+            domain=sso_domain,
+            key=sso_key,
+        ))
+
+        self.sso_external_id = SsoExternalId(
+            domain=sso_domain,
+            external_id='1',
+            user=self.contributor,
+        )
+        self.sso_external_id.token = 'good_token'
+        self.session.add(self.sso_external_id)
+
+        self.session.flush()
+
+    def test_no_token(self):
+        self.app.get(self._url, status=403)
+
+    def test_invalid_token(self):
+        self.app.get(self._url,
+                     params={'token': 'bad_token'},
+                     status=403)
+
+    def test_expired_token(self):
+        self.sso_external_id.expire = localized_now()
+        self.session.flush()
+
+        self.app.get(self._url,
+                     params={'token': 'good_token'},
+                     status=403)
+
+    @patch(
+        'c2corg_api.views.sso.get_discourse_client',
+        return_value=Mock(
+            redirect_without_nonce=Mock(
+                return_value='https://discourse_redirect'
+            )
+        )
+    )
+    def test_success_discourse_up(self, discourse_mock):
+        self.sso_external_id.expire = sso_expire_from_now()
+        self.session.flush()
+
+        r = self.app.get(self._url,
+                         params={'token': 'good_token'},
+                         status=302)
+
+        self.assertEqual('https://discourse_redirect', r.location)
+
+    @patch(
+        'c2corg_api.views.sso.get_discourse_client',
+        return_value=Mock(
+            redirect_without_nonce=Mock(side_effect=Exception)
+        )
+    )
+    def test_success_discourse_down(self, discourse_mock):
+        # SSO login allowed even if Discourse is down.
+        self.sso_external_id.expire = sso_expire_from_now()
+        self.session.flush()
+
+        self.app.get(self._url,
+                     params={'token': 'good_token'},
+                     status=200)

--- a/c2corg_api/views/sso.py
+++ b/c2corg_api/views/sso.py
@@ -1,0 +1,281 @@
+from base64 import b64encode
+from datetime import datetime, timedelta
+from os import urandom
+from pytz import utc
+from urllib.parse import urlencode
+import logging
+
+import colander
+from cornice.resource import resource, view
+from cornice.validators import colander_body_validator
+from pydiscourse.exceptions import DiscourseClientError
+from pyramid.httpexceptions import (
+    HTTPForbidden,
+    HTTPFound,
+    HTTPInternalServerError,
+)
+
+from c2corg_common.attributes import default_langs
+
+from c2corg_api.models import DBSession
+from c2corg_api.models.document import DocumentLocale
+from c2corg_api.models.sso import (
+    SsoKey,
+    SsoExternalId,
+)
+from c2corg_api.models.user import User
+from c2corg_api.models.user_profile import UserProfile
+from c2corg_api.security.discourse_client import get_discourse_client
+from c2corg_api.security.roles import log_validated_user_i_know_what_i_do
+from c2corg_api.views import (
+    cors_policy,
+    json_view,
+)
+from c2corg_api.views.user import (
+    validate_unique_attribute,
+    validate_forum_username,
+)
+
+CONST_EXPIRE_AFTER_MINUTES = 10
+
+log = logging.getLogger(__name__)
+
+
+class SsoSyncSchema(colander.MappingSchema):
+    sso_key = colander.SchemaNode(colander.String())
+    external_id = colander.SchemaNode(colander.String())
+    email = colander.SchemaNode(colander.String(),
+                                missing=None)
+    username = colander.SchemaNode(colander.String(),
+                                   missing=None)
+    name = colander.SchemaNode(colander.String(),
+                               missing=None)
+    forum_username = colander.SchemaNode(colander.String(),
+                                         missing=None)
+    lang = colander.SchemaNode(colander.String(),
+                               validator=colander.OneOf(default_langs),
+                               missing=None)
+    groups = colander.SchemaNode(colander.String(),
+                                 missing=None)
+
+sso_sync_schema = SsoSyncSchema()
+
+
+def sso_sync_validator(request, **kwargs):
+    if 'sso_key' not in request.validated:
+        return  # validated by colander schema
+    sso_key = DBSession.query(SsoKey). \
+        filter(SsoKey.key == request.validated['sso_key']). \
+        one_or_none()
+    if sso_key is None:
+        log.warning('Attempt to use sso_sync with bad key from {}'
+                    .format(request.client_addr))
+        request.errors.status = 403
+        request.errors.add('body', 'sso_key', 'Invalid')
+        return
+
+    user = None
+
+    # search user by external_id
+    if 'external_id' not in request.validated:
+        return  # validated by colander schema
+    sso_external_id = DBSession.query(SsoExternalId). \
+        filter(SsoExternalId.domain == sso_key.domain). \
+        filter(SsoExternalId.external_id ==
+               request.validated['external_id']). \
+        one_or_none()
+    if sso_external_id is not None:
+        user = sso_external_id.user
+
+    if user is None:
+        # search user by email
+        if request.validated['email'] is None:
+            request.errors.add('body', 'email', 'Required')
+            return
+        user = DBSession.query(User). \
+            filter(User.email == request.validated['email']). \
+            one_or_none()
+
+    if user is None:
+        username = request.validated['username']
+        if username is None:
+            request.errors.add('body', 'username', 'Required')
+        request.validated['name'] = request.validated['name'] or username
+        request.validated['forum_username'] = \
+            request.validated['forum_username'] or username
+        if request.validated['lang'] is None:
+            request.errors.add('body', 'lang', 'Required')
+        validate_unique_attribute('email', request, **kwargs)
+        validate_unique_attribute('username', request, **kwargs)
+        validate_forum_username(request, **kwargs)
+        validate_unique_attribute(
+            'forum_username', request, lowercase=True, **kwargs)
+
+    request.validated['sso_key'] = sso_key
+    request.validated['sso_external_id'] = sso_external_id
+    request.validated['sso_user'] = user
+
+
+@resource(path='/sso_sync', cors_policy=cors_policy)
+class SsoSyncRest(object):
+    def __init__(self, request):
+        self.request = request
+
+    @json_view(
+        schema=sso_sync_schema,
+        validators=[
+            colander_body_validator,
+            sso_sync_validator,
+        ])
+    def post(self):
+        """
+        Synchronize user details and return authentication url.
+        Important: Email addresses need to be validated by external site.
+        """
+        request = self.request
+        sso_key = request.validated['sso_key']
+        sso_external_id = request.validated['sso_external_id']
+        user = request.validated['sso_user']
+
+        if user is None:
+            # create new user
+            user = User(
+                username=request.validated['username'],
+                name=request.validated['name'],
+                forum_username=request.validated['forum_username'],
+                email=request.validated['email'],
+                email_validated=True,  # MUST be validated by external site
+                lang=request.validated['lang'],
+                password=generate_token()  # random password
+            )
+            # directly create the user profile, the document id of the profile
+            # is the user id
+            lang = user.lang
+            user.profile = UserProfile(
+                categories=['amateur'],
+                locales=[DocumentLocale(lang=lang, title='')],
+            )
+            DBSession.add(user)
+            DBSession.flush()
+
+        if sso_external_id is None:
+            sso_external_id = SsoExternalId(
+                domain=sso_key.domain,
+                external_id=request.validated['external_id'],
+                user=user,
+            )
+            DBSession.add(sso_external_id)
+
+        sso_external_id.token = generate_token()
+        sso_external_id.expire = sso_expire_from_now()
+
+        client = get_discourse_client(request.registry.settings)
+        discourse_userid = call_discourse(
+            get_discourse_userid, client, user.id)
+        if discourse_userid is None:
+            call_discourse(client.sync_sso, user)
+            discourse_userid = client.get_userid(user.id)  # From cache
+
+        # Groups are added to discourse, not removed
+        group_ids = []
+        discourse_groups = None
+        groups = request.validated['groups'] or ''
+        for group_name in groups.split(','):
+            if group_name == '':
+                continue
+            group_id = None
+            if discourse_groups is None:
+                discourse_groups = call_discourse(client.client.groups)
+
+            group_id = None
+            for discourse_group in discourse_groups:
+                if discourse_group['name'] == group_name:
+                    group_id = discourse_group['id']
+
+            if group_id is None:
+                # If group is not found, we ignore it as we want to return
+                # a valid token for user authentication
+                pass
+            else:
+                group_ids.append(group_id)
+
+        for group_id in group_ids:
+            call_discourse(client.client.add_user_to_group,
+                           group_id, discourse_userid)
+
+        return {
+            'url': '{}?{}'.format(request.route_url('ssologinrest'),
+                                  urlencode({'token': sso_external_id.token}))
+        }
+
+
+def get_discourse_userid(client, userid):
+    """ Get discourse user id with 404 handling"""
+    try:
+        return client.get_userid(userid)
+    except DiscourseClientError as e:
+        if e.response.status_code == 404:
+            return None
+        raise
+
+
+def call_discourse(method, *args, **kwargs):
+    try:
+        return method.__call__(*args, **kwargs)
+    except Exception as e:
+        log.error('Error with Discourse: {}'.format(str(e)), exc_info=True)
+        raise HTTPInternalServerError('Error with Discourse')
+
+
+def generate_token():
+    return b64encode(urandom(64)).decode('utf-8')
+
+
+def localized_now():
+    return utc.localize(datetime.utcnow())
+
+
+def sso_expire_from_now():
+    return (localized_now() + timedelta(minutes=CONST_EXPIRE_AFTER_MINUTES))
+
+
+def validate_token(request, **kwargs):
+    token = request.params.get('token', None)
+    if token is None:
+        log.warning('Attempt to use sso_login without token from {}'
+                    .format(request.client_addr))
+        raise HTTPForbidden('Invalid token')
+
+    sso_external_id = DBSession.query(SsoExternalId). \
+        filter(SsoExternalId.token == token). \
+        filter(SsoExternalId.expire > localized_now()). \
+        one_or_none()
+    if sso_external_id is None:
+        log.warning('Attempt to use sso_login with bad token from {}'
+                    .format(request.client_addr))
+        raise HTTPForbidden('Invalid token')
+    request.validated['sso_user'] = sso_external_id.user
+
+
+@resource(path='/sso_login', cors_policy=cors_policy)
+class SsoLoginRest(object):
+    def __init__(self, request):
+        self.request = request
+
+    @view(validators=[validate_token])
+    def get(self):
+        user = self.request.validated['sso_user']
+        log_validated_user_i_know_what_i_do(user, self.request)
+        client = get_discourse_client(self.request.registry.settings)
+        try:
+            r = client.redirect_without_nonce(user)
+        except:
+            # Any error with discourse should not prevent login
+            log.warning(
+                'Error logging into discourse for %d', user.id,
+                exc_info=True)
+        else:
+            return HTTPFound(r)
+        return {
+            'success': True
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,6 +51,6 @@ git+https://github.com/tsauerwein/cornice.git@nested-none-2.1.0-c2corg
 git+https://github.com/c2corg/v6_common.git@35db96a
 
 # Discourse API client
-git+https://github.com/c2corg/pydiscourse.git@188cdf8
+https://github.com/c2corg/pydiscourse/archive/ea03a3a.zip
 
 -e .


### PR DESCRIPTION
How does it works :

There id graphical interface to add new SSO keys, connect directly to the postgresql server , example:
```
psql -d c2corg -c "INSERT INTO users.sso_key("domain", "key") VALUES ('pro-montagne', 'mykey');"
```

Some external service, with an SSO key to create/authenticate users in c2c domain.

Some external service named *example.com* send a POST request to `/sso_sync` with:
- sso_key: the_example_dot_com_sso_key
- external_id: 999
- email: newuser@external.domain.net
- username: newuser (mandatory only for not existing users)
- name: New User (defaults to username)
- forum_username: NewUser (defaults to username)
- lang: fr  (mandatory only for not existing users)

The C2C API server checks the SSO key and the source domain of the request (using DNS request).
It the server is authorized, it will search for the user by `external domain` and `external_id`.
If not found, it will search for it by `email`.
If not found, it will create it, returning an error for already used `username` or `forum_username`.
If everything go fine, the C2C server returns an authentication url with a token valid for only this user and for the next 10 minutes.

The external service server insert, in response to the browser, an iframe to that url.

So the browser will send a GET request to `/sso_login`.

The C2C api server will check the token and authenticate the user, returning a redirection the forum.

The browser send a request to the forum.

The browser is now authenticated everywhere.

Remaining TODO:
* Put the documentation somewhere ? I suppose in the wiki.
* check that the sso_login request has the sso_key.domain as referer ?