### PR TITLE
Add associated images counter in outings lists

### DIFF
--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -46,6 +46,13 @@ class TestOutingRest(BaseDocumentTestRest):
         self.assertEqual(author['name'], 'Contributor')
         self.assertEqual(author['user_id'], self.global_userids['contributor'])
 
+        for doc in body['documents']:
+            # number of associated images
+            self.assertIn('img_count', doc)
+            self.assertEqual(
+                doc['img_count'],
+                1 if doc['document_id'] == self.outing.document_id else 0)
+
     def test_get_collection_for_route(self):
         reset_search_index(self.session)
         response = self.app.get(

--- a/c2corg_api/views/__init__.py
+++ b/c2corg_api/views/__init__.py
@@ -110,7 +110,7 @@ def to_json_dict(obj, schema, with_special_locales_attrs=False):
     # it because it's not a real column)
     special_attributes = [
         'available_langs', 'associations', 'maps', 'areas', 'author',
-        'protected', 'type', 'name', 'forum_username', 'creator'
+        'protected', 'type', 'name', 'forum_username', 'creator', 'img_count'
     ]
     for attr in special_attributes:
         if hasattr(obj, attr):

--- a/c2corg_api/views/document_schemas.py
+++ b/c2corg_api/views/document_schemas.py
@@ -34,13 +34,14 @@ class GetDocumentsConfig:
     def __init__(
             self, document_type, clazz, schema, clazz_locale=None, fields=None,
             listing_fields=None, adapt_schema=None, include_areas=True,
-            set_custom_fields=None):
+            include_img_count=False, set_custom_fields=None):
         self.document_type = document_type
         self.clazz = clazz
         self.schema = schema
         self.clazz_locale = clazz_locale
         self.adapt_schema = adapt_schema
         self.include_areas = include_areas
+        self.include_img_count = include_img_count
         self.set_custom_fields = set_custom_fields
 
         self._set_load_only_fields(fields, listing_fields)
@@ -166,7 +167,8 @@ outing_listing_schema_adaptor = make_schema_adaptor(
 
 outing_documents_config = GetDocumentsConfig(
     OUTING_TYPE, Outing, schema_outing, fields=fields_outing,
-    adapt_schema=outing_listing_schema_adaptor, set_custom_fields=set_author)
+    adapt_schema=outing_listing_schema_adaptor, set_custom_fields=set_author,
+    include_img_count=True)
 
 
 # xreports


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_api/issues/684

The chosen solution is to make an extra DB query to count the number of images associated to the listed documents (eg. in the advanced search pages or in associations section of document pages). The counts are then added to the listed documents objects before being returned by the API.

As for now, **the ``img_count`` attribute is available only in outings lists** but could be added for other document types if needed (currently disabled for those types since not asked by #684 and to avoid the additional DB query if not required).

Please note that ``img_count`` is available also for outings in the feed service, even though it is not really needed since the feed already returns a subset of associated images if any.
It would be possible to remove the ``img_count`` attribute in the feed (for instance to make sure the extra DB request is not done) by adding
```
document_config.include_img_count = False
```
after https://github.com/c2corg/v6_api/blob/master/c2corg_api/views/feed.py#L381
The problem is that listed items are cached and reused both in the standard documents lists and in the feed items. Which mean that an outing document might have or not have the ``img_count`` attribute whether called first in the feed or in the standard lists. I have then preferred to keep the attribute in both cases.