### PR TITLE
Adapt sso_login for ajax POST

### DIFF
--- a/common.ini.in
+++ b/common.ini.in
@@ -72,6 +72,8 @@ discourse.api_key = {discourse_api_key}
 discourse.sso_secret = {discourse_sso_secret}
 discourse.category = {discourse_category}
 
+ui.url = {ui_url}
+
 mail.validate_register_url_template = {mail_validate_register_url_template}
 mail.request_password_change_url_template = {mail_request_password_change_url_template}
 mail.validate_change_email_url_template = {mail_validate_change_email_url_template}


### PR DESCRIPTION
As authentication is stored as JWT token in local storage, we need to pass through UI authCtrl.
This PR adapt API side sso_login for UI authCtrl and auth service.

SSO will works : 

remote service send a request to sso_sync and get an URL to UI sso_login with token.

UI server return as simple view with call to `authCtrl.ssoLogin()`.

Browser send a ajax post request to API sso_login and get a JWT token and follow normal authentication workflow, except that it does not redirect user to home page because of no_redirect in query params.

TODO after merge : Update the wiki page