### PR TITLE
Upgrade psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ geomet==0.1.1
 kombu==4.0.0
 # phpserialize is only required during the migration
 phpserialize==1.3.0
-psycopg2==2.6.2
+psycopg2==2.7.3.2
 pyproj==1.9.5.1
 pyramid-jwtauth==0.1.3
 pyramid==1.7.3


### PR DESCRIPTION
Avoid error when intalling psycopg2:
Error: could not determine PostgreSQL version from '10.1'