### PR TITLE
Add rate limiting support for write requests

### DIFF
--- a/alembic_migration/versions/83956b269661_add_rate_limiting_structure.py
+++ b/alembic_migration/versions/83956b269661_add_rate_limiting_structure.py
@@ -21,6 +21,11 @@ def upgrade():
     op.add_column('user', sa.Column('ratelimit_reset', sa.DateTime(timezone=True)), schema='users')
     op.add_column('user', sa.Column('ratelimit_last_blocked_window', sa.DateTime(timezone=True)), schema='users')
     op.add_column('user', sa.Column('ratelimit_times', sa.Integer()), schema='users')
+    op.add_column(
+        'user',
+        sa.Column(
+            'robot', sa.Boolean(), server_default='false', nullable=False),
+        schema='users')
 
 
 def downgrade():
@@ -29,3 +34,4 @@ def downgrade():
     op.drop_column('user', 'ratelimit_reset', schema='users')
     op.drop_column('user', 'ratelimit_last_blocked_window', schema='users')
     op.drop_column('user', 'ratelimit_times', schema='users')
+    op.drop_column('user', 'robot', schema='users')

--- a/alembic_migration/versions/83956b269661_add_rate_limiting_structure.py
+++ b/alembic_migration/versions/83956b269661_add_rate_limiting_structure.py
@@ -20,7 +20,11 @@ def upgrade():
     op.add_column('user', sa.Column('ratelimit_remaining', sa.Integer()), schema='users')
     op.add_column('user', sa.Column('ratelimit_reset', sa.DateTime(timezone=True)), schema='users')
     op.add_column('user', sa.Column('ratelimit_last_blocked_window', sa.DateTime(timezone=True)), schema='users')
-    op.add_column('user', sa.Column('ratelimit_times', sa.Integer()), schema='users')
+    op.add_column(
+        'user',
+        sa.Column(
+            'ratelimit_times', sa.Integer(), server_default='0', nullable=False),
+        schema='users')
     op.add_column(
         'user',
         sa.Column(

--- a/alembic_migration/versions/83956b269661_add_rate_limiting_structure.py
+++ b/alembic_migration/versions/83956b269661_add_rate_limiting_structure.py
@@ -19,9 +19,13 @@ def upgrade():
     op.add_column('user', sa.Column('ratelimit_limit', sa.Integer()), schema='users')
     op.add_column('user', sa.Column('ratelimit_remaining', sa.Integer()), schema='users')
     op.add_column('user', sa.Column('ratelimit_reset', sa.DateTime(timezone=True)), schema='users')
+    op.add_column('user', sa.Column('ratelimit_last_blocked_window', sa.DateTime(timezone=True)), schema='users')
+    op.add_column('user', sa.Column('ratelimit_times', sa.Integer()), schema='users')
 
 
 def downgrade():
     op.drop_column('user', 'ratelimit_limit', schema='users')
     op.drop_column('user', 'ratelimit_remaining', schema='users')
     op.drop_column('user', 'ratelimit_reset', schema='users')
+    op.drop_column('user', 'ratelimit_last_blocked_window', schema='users')
+    op.drop_column('user', 'ratelimit_times', schema='users')

--- a/alembic_migration/versions/83956b269661_add_rate_limiting_structure.py
+++ b/alembic_migration/versions/83956b269661_add_rate_limiting_structure.py
@@ -16,7 +16,6 @@ branch_labels = None
 depends_on = None
 
 def upgrade():
-    op.add_column('user', sa.Column('ratelimit_limit', sa.Integer()), schema='users')
     op.add_column('user', sa.Column('ratelimit_remaining', sa.Integer()), schema='users')
     op.add_column('user', sa.Column('ratelimit_reset', sa.DateTime(timezone=True)), schema='users')
     op.add_column('user', sa.Column('ratelimit_last_blocked_window', sa.DateTime(timezone=True)), schema='users')
@@ -33,7 +32,6 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_column('user', 'ratelimit_limit', schema='users')
     op.drop_column('user', 'ratelimit_remaining', schema='users')
     op.drop_column('user', 'ratelimit_reset', schema='users')
     op.drop_column('user', 'ratelimit_last_blocked_window', schema='users')

--- a/alembic_migration/versions/83956b269661_add_rate_limiting_structure.py
+++ b/alembic_migration/versions/83956b269661_add_rate_limiting_structure.py
@@ -1,0 +1,27 @@
+"""Add rate limiting structure
+
+Revision ID: 83956b269661
+Revises: 24f8da659c78
+Create Date: 2018-01-12 11:54:56.294250
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '83956b269661'
+down_revision = '24f8da659c78'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('user', sa.Column('ratelimit_limit', sa.Integer()), schema='users')
+    op.add_column('user', sa.Column('ratelimit_remaining', sa.Integer()), schema='users')
+    op.add_column('user', sa.Column('ratelimit_reset', sa.DateTime(timezone=True)), schema='users')
+
+
+def downgrade():
+    op.drop_column('user', 'ratelimit_limit', schema='users')
+    op.drop_column('user', 'ratelimit_remaining', schema='users')
+    op.drop_column('user', 'ratelimit_reset', schema='users')

--- a/c2corg_api/emails/email_service.py
+++ b/c2corg_api/emails/email_service.py
@@ -89,6 +89,19 @@ class EmailService:
                 subject=self._(user.lang, 'email_change_subject'),
                 body=self._(user.lang, 'email_change_body') % link)
 
+    def send_rate_limiting_alert(self, user):
+        url = '{}/profiles/{}'.format(self.settings['ui.url'], user.id)
+        if user.blocked:
+            body = self._('fr', 'rate_limiting_blocked_alert_body') % (
+                user.name, url)
+        else:
+            body = self._('fr', 'rate_limiting_alert_body') % (
+                user.name, url, user.ratelimit_times)
+        self._send_email(
+                self.settings['rate_limiting.alert_address'],
+                subject=self._('fr', 'rate_limiting_alert_subject'),
+                body=body)
+
 
 def get_email_service(request):
     if not EmailService.instance:

--- a/c2corg_api/emails/i18n/fr/rate_limiting_alert_body
+++ b/c2corg_api/emails/i18n/fr/rate_limiting_alert_body
@@ -1,0 +1,5 @@
+Bonjour
+
+Le contributeur %s a atteint le nombre maximum autorisé de modifications via l'API camptocamp.org et a été temporairement bloqué.
+Son profil : %s
+Nombre de blocages temporaires à ce jour : %d

--- a/c2corg_api/emails/i18n/fr/rate_limiting_alert_subject
+++ b/c2corg_api/emails/i18n/fr/rate_limiting_alert_subject
@@ -1,0 +1,1 @@
+Un usage excessif de l'API a été détecté

--- a/c2corg_api/emails/i18n/fr/rate_limiting_blocked_alert_body
+++ b/c2corg_api/emails/i18n/fr/rate_limiting_blocked_alert_body
@@ -1,0 +1,5 @@
+Bonjour
+
+Le contributeur %s a atteint une nouvelle fois le nombre maximum autorisé de modifications via l'API camptocamp.org.
+Il a également dépassé le nombre maximum autorisé de blocages temporaires et a donc été définitivement bloqué.
+Son profil : %s

--- a/c2corg_api/models/user.py
+++ b/c2corg_api/models/user.py
@@ -111,6 +111,10 @@ class User(Base):
     feed_followed_only = Column(
         Boolean, server_default='FALSE', nullable=False)
 
+    ratelimit_limit = Column(Integer)
+    ratelimit_remaining = Column(Integer)
+    ratelimit_reset = Column(DateTime(timezone=True))
+
     def update_validation_nonce(self, purpose, days):
         """Generate and overwrite the nonce.
         A nonce is a random number which is used for authentication when doing

--- a/c2corg_api/models/user.py
+++ b/c2corg_api/models/user.py
@@ -117,6 +117,8 @@ class User(Base):
     ratelimit_last_blocked_window = Column(DateTime(timezone=True))
     ratelimit_times = Column(Integer)
 
+    robot = Column(Boolean, nullable=False, default=False)
+
     def update_validation_nonce(self, purpose, days):
         """Generate and overwrite the nonce.
         A nonce is a random number which is used for authentication when doing

--- a/c2corg_api/models/user.py
+++ b/c2corg_api/models/user.py
@@ -114,6 +114,8 @@ class User(Base):
     ratelimit_limit = Column(Integer)
     ratelimit_remaining = Column(Integer)
     ratelimit_reset = Column(DateTime(timezone=True))
+    ratelimit_last_blocked_window = Column(DateTime(timezone=True))
+    ratelimit_times = Column(Integer)
 
     def update_validation_nonce(self, purpose, days):
         """Generate and overwrite the nonce.

--- a/c2corg_api/models/user.py
+++ b/c2corg_api/models/user.py
@@ -111,7 +111,6 @@ class User(Base):
     feed_followed_only = Column(
         Boolean, server_default='FALSE', nullable=False)
 
-    ratelimit_limit = Column(Integer)
     ratelimit_remaining = Column(Integer)
     ratelimit_reset = Column(DateTime(timezone=True))
     ratelimit_last_blocked_window = Column(DateTime(timezone=True))

--- a/c2corg_api/models/user.py
+++ b/c2corg_api/models/user.py
@@ -115,7 +115,7 @@ class User(Base):
     ratelimit_remaining = Column(Integer)
     ratelimit_reset = Column(DateTime(timezone=True))
     ratelimit_last_blocked_window = Column(DateTime(timezone=True))
-    ratelimit_times = Column(Integer)
+    ratelimit_times = Column(Integer, nullable=False, default=0)
 
     robot = Column(Boolean, nullable=False, default=False)
 

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -69,6 +69,7 @@ def _add_global_test_data(session):
     global_passwords['contributor'] = 'super pass'
     global_passwords['contributor2'] = 'better pass'
     global_passwords['moderator'] = 'even better pass'
+    global_passwords['robot'] = 'bombproof pass'
 
     contributor_profile = UserProfile(
         categories=['amateur'],
@@ -116,7 +117,17 @@ def _add_global_test_data(session):
         moderator=True, password='even better pass',
         email_validated=True, profile=moderator_profile)
 
-    users = [moderator, contributor, contributor2, contributor3]
+    robot_profile = UserProfile(
+        locales=[DocumentLocale(title='', lang='en')])
+
+    robot = User(
+        name='Robot',
+        username='robot', email='robot@camptocamp.org',
+        forum_username='robot',
+        robot=True, password='bombproof pass',
+        email_validated=True, profile=robot_profile)
+
+    users = [robot, moderator, contributor, contributor2, contributor3]
     session.add_all(users)
     session.flush()
 
@@ -125,7 +136,7 @@ def _add_global_test_data(session):
     now = datetime.datetime.utcnow()
     exp = now + datetime.timedelta(weeks=10)
 
-    for user in [moderator, contributor, contributor2, contributor3]:
+    for user in [robot, moderator, contributor, contributor2, contributor3]:
         claims = create_claims(user, exp)
         token = jwt.encode(claims, key=key, algorithm=algorithm). \
             decode('utf-8')

--- a/c2corg_api/tests/tweens/__init__.py
+++ b/c2corg_api/tests/tweens/__init__.py
@@ -1,0 +1,1 @@
+# package

--- a/c2corg_api/tests/tweens/test_rate_limiting.py
+++ b/c2corg_api/tests/tweens/test_rate_limiting.py
@@ -1,0 +1,121 @@
+import time
+import datetime
+import pytz
+
+from c2corg_api.tests.views import BaseTestRest
+from c2corg_api.models.user import User
+
+
+class RateLimitingTest(BaseTestRest):
+
+    def setUp(self):  # noqa
+        BaseTestRest.setUp(self)
+        self._prefix = '/waypoints'
+        self.username = 'contributor'
+        user_id = self.global_userids[self.username]
+        self.user = self.session.query(User).get(user_id)
+        self.limit = int(self.settings['rate_limiting.limit'])
+        self.window_span = int(self.settings['rate_limiting.window_span'])
+
+    def test_contributor(self):
+        # Check contributor has no rate limiting data yet
+        self.assertIsNone(self.user.ratelimit_limit)
+        self.assertIsNone(self.user.ratelimit_remaining)
+        self.assertIsNone(self.user.ratelimit_reset)
+
+        self._create_document()
+
+        # Check rating limiting data are now available
+        self.session.refresh(self.user)
+        self.assertEqual(self.user.ratelimit_limit, self.limit)
+        self.assertEqual(self.user.ratelimit_remaining, self.limit - 1)
+
+        expiration_date = self.user.ratelimit_reset
+        delta = datetime.datetime.now(pytz.utc) + \
+            datetime.timedelta(seconds=self.window_span) - \
+            self.user.ratelimit_reset
+        self.assertLessEqual(delta.total_seconds(), 2)
+
+        # Make as many requests as allowed according to the settings
+        # (already 1 request as been consumed when creating the document)
+        for i in range(1, self.limit):
+            self._update_document()
+            self.session.refresh(self.user)
+            self.assertEqual(self.user.ratelimit_limit, self.limit)
+            self.assertEqual(self.user.ratelimit_remaining, self.limit - 1 - i)
+            self.assertEqual(self.user.ratelimit_reset, expiration_date)
+
+        # Counter "remaining" is now set to 0 => write requests should be
+        # refused with error code 429 ("Too many requests")
+        self.assertEqual(self.user.ratelimit_remaining, 0)
+        self._update_document(status=429)
+        self.session.refresh(self.user)
+        self.assertEqual(self.user.ratelimit_remaining, 0)
+
+        # GET requests are still allowed
+        self.app.get(
+            self._prefix + '/' + str(self.document['document_id']), status=200)
+
+        # Test write requests are accepted again after window is expired
+        waiting_time = self.window_span + 5
+        print('Waiting %d secs the rate limiting window expires...'
+              % waiting_time)
+        time.sleep(waiting_time)
+        self._update_document()
+        self.session.refresh(self.user)
+        self.assertEqual(self.user.ratelimit_remaining, self.limit - 1)
+
+        # Deleting the document is also considered by rate limiting
+        # TODO test for moderators
+        # self._delete_document()
+        # self.session.refresh(self.user)
+        # self.assertEqual(self.user.ratelimit_remaining, self.limit - 2)
+
+    def _create_document(self):
+        body = {
+            'waypoint_type': 'summit',
+            'elevation': 2203,
+            'geometry': {
+                'geom': '{"type": "Point", "coordinates": [635956, 5723604]}'
+            },
+            'locales': [{
+                'lang': 'en', 'title': 'Mont Granier'
+            }]
+        }
+        headers = self.add_authorization_header(username=self.username)
+        response = self.app_post_json(self._prefix, body,
+                                      headers=headers, status=200)
+        document_id = response.json.get('document_id')
+        self._set_document(document_id)
+
+    def _update_document(self, status=200):
+        document_id = self.document['document_id']
+        body = {
+            'message': 'Update',
+            'document': {
+                'document_id': document_id,
+                'version': self.document['version'],
+                'waypoint_type': 'summit',
+                'elevation': self.document['elevation'] + 1,
+                'locales': [{
+                    'version': self.document['locales'][0]['version'],
+                    'lang': 'en', 'title': 'Mont Granier'
+                }]
+            }
+        }
+        headers = self.add_authorization_header(username=self.username)
+        self.app_put_json(
+            self._prefix + '/' + str(document_id),
+            body, headers=headers, status=status)
+        self._set_document(document_id)
+
+    def _set_document(self, document_id):
+        response = self.app.get(
+            self._prefix + '/' + str(document_id), status=200)
+        self.document = response.json
+
+    def _delete_document(self):
+        headers = self.add_authorization_header(username=self.username)
+        self.app.delete_json(
+            '/documents/delete/' + str(self.document['document_id']),
+            headers=headers, status=200)

--- a/c2corg_api/tests/tweens/test_rate_limiting.py
+++ b/c2corg_api/tests/tweens/test_rate_limiting.py
@@ -36,7 +36,6 @@ class RateLimitingTest(BaseTestRest):
                 self.limit_moderator if self.user.moderator else self.limit
 
         # Check contributor has no rate limiting data yet
-        self.assertIsNone(self.user.ratelimit_limit)
         self.assertIsNone(self.user.ratelimit_remaining)
         self.assertIsNone(self.user.ratelimit_reset)
 
@@ -44,7 +43,6 @@ class RateLimitingTest(BaseTestRest):
 
         # Check rating limiting data are now available
         self.session.refresh(self.user)
-        self.assertEqual(self.user.ratelimit_limit, limit)
         self.assertEqual(self.user.ratelimit_remaining, limit - 1)
 
         expiration_date = self.user.ratelimit_reset
@@ -58,7 +56,6 @@ class RateLimitingTest(BaseTestRest):
         for i in range(1, limit):
             self._update_document()
             self.session.refresh(self.user)
-            self.assertEqual(self.user.ratelimit_limit, limit)
             self.assertEqual(self.user.ratelimit_remaining, limit - 1 - i)
             self.assertEqual(self.user.ratelimit_reset, expiration_date)
 

--- a/c2corg_api/tests/tweens/test_rate_limiting.py
+++ b/c2corg_api/tests/tweens/test_rate_limiting.py
@@ -18,6 +18,8 @@ class RateLimitingTest(BaseTestRest):
         self.limit = int(self.settings['rate_limiting.limit'])
         self.limit_moderator = int(
             self.settings['rate_limiting.limit_moderator'])
+        self.limit_robot = int(
+            self.settings['rate_limiting.limit_robot'])
         self.window_span = int(self.settings['rate_limiting.window_span'])
         self.max_times = int(self.settings['rate_limiting.max_times'])
 
@@ -30,7 +32,8 @@ class RateLimitingTest(BaseTestRest):
         self._test_requests()
 
     def _test_requests(self):
-        limit = self.limit_moderator if self.user.moderator else self.limit
+        limit = self.limit_robot if self.user.robot else \
+                self.limit_moderator if self.user.moderator else self.limit
 
         # Check contributor has no rate limiting data yet
         self.assertIsNone(self.user.ratelimit_limit)

--- a/c2corg_api/tests/views/test_forum.py
+++ b/c2corg_api/tests/views/test_forum.py
@@ -170,6 +170,8 @@ class TestForumTopicRest(BaseTestRest):
                 'lang': 'en'
             },
             status=200)
-        _post_mock.assert_has_calls([
-            call('/t/10/invite.json', user='contributor'),
-            call('/t/10/invite.json', user='contributor2')])
+        _post_mock.assert_has_calls(
+            [
+                call('/t/10/invite.json', user='contributor'),
+                call('/t/10/invite.json', user='contributor2')],
+            any_order=True)

--- a/c2corg_api/tests/views/test_user_block.py
+++ b/c2corg_api/tests/views/test_user_block.py
@@ -19,6 +19,7 @@ class BaseBlockTest(BaseTestRest):
             self.global_userids['moderator'])
 
         self.contributor2.blocked = True
+        self.contributor2.ratelimit_times = 2
 
         self.session.flush()
         self.set_discourse_up()
@@ -133,11 +134,13 @@ class TestUserUnblockRest(BaseBlockTest):
             'user_id': self.contributor2.id
         }
         self.assertTrue(self.is_blocked(self.contributor2.id))
+        self.assertNotEqual(self.contributor2.ratelimit_times, 0)
 
         headers = self.add_authorization_header(username='moderator')
         self.app_post_json(
             self._prefix, request_body, status=200, headers=headers)
         self.assertFalse(self.is_blocked(self.contributor2.id))
+        self.assertEqual(self.contributor2.ratelimit_times, 0)
 
     def test_unblock_not_blocked_user(self):
         """ Test that unblocking a not blocked user does not raise an error.

--- a/c2corg_api/tests/views/test_user_profile.py
+++ b/c2corg_api/tests/views/test_user_profile.py
@@ -41,21 +41,21 @@ class TestUserProfileRest(BaseDocumentTestRest):
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 0, 'limit': 0}, user='contributor'),
-            [], 6)
+            [], 7)
 
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 0, 'limit': 1}, user='contributor'),
-            [self.profile4.document_id], 6)
+            [self.profile4.document_id], 7)
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 0, 'limit': 2}, user='contributor'),
-            [self.profile4.document_id, self.profile2.document_id], 6)
+            [self.profile4.document_id, self.profile2.document_id], 7)
         self.assertResultsEqual(
             self.get_collection(
                 {'offset': 1, 'limit': 3}, user='contributor'),
             [self.profile2.document_id, self.global_userids['contributor3'],
-             self.global_userids['contributor2']], 6)
+             self.global_userids['contributor2']], 7)
 
     def test_get_collection_lang(self):
         self.get_collection_lang(user='contributor')
@@ -67,7 +67,8 @@ class TestUserProfileRest(BaseDocumentTestRest):
             self.get_collection_search({'l': 'en'}, user='contributor'),
             [self.profile4.document_id, self.global_userids['contributor3'],
              self.global_userids['contributor2'], self.profile1.document_id,
-             self.global_userids['moderator']], 5)
+             self.global_userids['moderator'], self.global_userids['robot']],
+            6)
 
     def test_get_unauthenticated_private_profile(self):
         """Tests that only the user name is returned when requesting a private

--- a/c2corg_api/tweens/jwt_database_validation.py
+++ b/c2corg_api/tweens/jwt_database_validation.py
@@ -1,0 +1,41 @@
+import logging
+
+from pyramid.httpexceptions import HTTPUnauthorized, HTTPError
+from c2corg_api.security.roles import is_valid_token, extract_token
+from c2corg_api.views import http_error_handler, catch_all_error_handler
+
+log = logging.getLogger(__name__)
+
+
+def jwt_database_validation_tween_factory(handler, registry):
+    """ Check validity of the JWT token.
+    """
+
+    def tween(request):
+
+        log.debug('JWT VALIDATION')
+
+        # forward requests without authorization
+        if request.authorization is None:
+            # Skipping validation if there is no authorization object.
+            # This is dangerous since a bad ordering of this tween and the
+            # cookie tween would bypass security
+            return handler(request)
+
+        # Finally, check database validation
+        try:
+            token = extract_token(request)
+            valid = token and is_valid_token(token)
+        except Exception as exc:
+            if isinstance(exc, HTTPError):
+                return http_error_handler(exc, request)
+            else:
+                return catch_all_error_handler(exc, request)
+
+        if valid:
+            return handler(request)
+        else:
+            return http_error_handler(
+                HTTPUnauthorized('Invalid token'), request)
+
+    return tween

--- a/c2corg_api/tweens/rate_limiting.py
+++ b/c2corg_api/tweens/rate_limiting.py
@@ -41,7 +41,6 @@ def rate_limiting_tween_factory(handler, registry):
                 'rate_limiting.limit_moderator' if user.moderator else
                 'rate_limiting.limit'))
             user.ratelimit_reset = now + datetime.timedelta(seconds=span)
-            user.ratelimit_limit = limit
             user.ratelimit_remaining = limit - 1
         elif user.ratelimit_remaining:
             user.ratelimit_remaining -= 1

--- a/c2corg_api/tweens/rate_limiting.py
+++ b/c2corg_api/tweens/rate_limiting.py
@@ -36,7 +36,7 @@ def rate_limiting_tween_factory(handler, registry):
             # No window exists or it is expired: create a new one.
             span = int(registry.settings.get('rate_limiting.window_span'))
             limit = int(registry.settings.get('rate_limiting.limit'))
-            user.ratelimit_reset = now + datetime.timedelta(minutes=span)
+            user.ratelimit_reset = now + datetime.timedelta(seconds=span)
             user.ratelimit_limit = limit
             user.ratelimit_remaining = limit - 1
         elif user.ratelimit_remaining:

--- a/c2corg_api/tweens/rate_limiting.py
+++ b/c2corg_api/tweens/rate_limiting.py
@@ -52,8 +52,7 @@ def rate_limiting_tween_factory(handler, registry):
             current_window = user.ratelimit_reset
             if user.ratelimit_last_blocked_window != current_window:
                 user.ratelimit_last_blocked_window = current_window
-                user.ratelimit_times = user.ratelimit_times + 1 \
-                    if user.ratelimit_times else 1
+                user.ratelimit_times += 1
                 max_times = int(
                     registry.settings.get('rate_limiting.max_times'))
                 if user.ratelimit_times > max_times:

--- a/c2corg_api/tweens/rate_limiting.py
+++ b/c2corg_api/tweens/rate_limiting.py
@@ -1,0 +1,50 @@
+import logging
+import datetime
+import pytz
+
+from pyramid.httpexceptions import HTTPBadRequest, HTTPTooManyRequests
+from c2corg_api.views import http_error_handler
+from c2corg_api.models import DBSession
+from c2corg_api.models.user import User
+
+log = logging.getLogger(__name__)
+
+
+def rate_limiting_tween_factory(handler, registry):
+    """ Add a rate limiting protection on write requests.
+    """
+
+    def tween(request):
+
+        log.debug('RATE LIMITING FOR METHOD ' + request.method)
+
+        # Only write requests are considered for rate limiting.
+        if request.method not in ['POST', 'PUT', 'DELETE']:
+            return handler(request)
+
+        if request.authorization is None:
+            # See comment of similar block in jwt_database_validation tween
+            return handler(request)
+
+        user = DBSession.query(User).get(request.authenticated_userid)
+        if user is None:
+            return http_error_handler(
+                HTTPBadRequest('Unknown user'), request)
+
+        now = datetime.datetime.now(pytz.utc)
+        if user.ratelimit_reset is None or user.ratelimit_reset < now:
+            # No window exists or it is expired: create a new one.
+            span = int(registry.settings.get('rate_limiting.window_span'))
+            limit = int(registry.settings.get('rate_limiting.limit'))
+            user.ratelimit_reset = now + datetime.timedelta(minutes=span)
+            user.ratelimit_limit = limit
+            user.ratelimit_remaining = limit - 1
+        elif user.ratelimit_remaining:
+            user.ratelimit_remaining -= 1
+        else:
+            return http_error_handler(
+                HTTPTooManyRequests('Rate limit reached'), request)
+
+        return handler(request)
+
+    return tween

--- a/c2corg_api/tweens/rate_limiting.py
+++ b/c2corg_api/tweens/rate_limiting.py
@@ -35,7 +35,9 @@ def rate_limiting_tween_factory(handler, registry):
         if user.ratelimit_reset is None or user.ratelimit_reset < now:
             # No window exists or it is expired: create a new one.
             span = int(registry.settings.get('rate_limiting.window_span'))
-            limit = int(registry.settings.get('rate_limiting.limit'))
+            limit = int(registry.settings.get(
+                'rate_limiting.limit_moderator' if user.moderator else
+                'rate_limiting.limit'))
             user.ratelimit_reset = now + datetime.timedelta(seconds=span)
             user.ratelimit_limit = limit
             user.ratelimit_remaining = limit - 1

--- a/c2corg_api/tweens/rate_limiting.py
+++ b/c2corg_api/tweens/rate_limiting.py
@@ -36,6 +36,7 @@ def rate_limiting_tween_factory(handler, registry):
             # No window exists or it is expired: create a new one.
             span = int(registry.settings.get('rate_limiting.window_span'))
             limit = int(registry.settings.get(
+                'rate_limiting.limit_robot' if user.robot else
                 'rate_limiting.limit_moderator' if user.moderator else
                 'rate_limiting.limit'))
             user.ratelimit_reset = now + datetime.timedelta(seconds=span)

--- a/c2corg_api/views/user_block.py
+++ b/c2corg_api/views/user_block.py
@@ -90,6 +90,9 @@ class UserUnblockRest(object):
         """
         user = _get_user(self.request.validated['user_id'])
         user.blocked = False
+        # Make sure the rate limiting counter is reset
+        # (it might be the reason the user was blocked):
+        user.ratelimit_times = 0
 
         # unsuspend account in Discourse
         try:

--- a/common.ini.in
+++ b/common.ini.in
@@ -112,5 +112,6 @@ rate_limiting.window_span = 900
 # Max number of actions allowed during a single window:
 rate_limiting.limit = 50
 rate_limiting.limit_moderator = 100
+rate_limiting.limit_robot = 1000
 # Max number of times a user can be rate limited before being blocked:
 rate_limiting.max_times = 3

--- a/common.ini.in
+++ b/common.ini.in
@@ -111,5 +111,6 @@ image_url = {image_url}
 rate_limiting.window_span = 900
 # Max number of actions allowed during a single window:
 rate_limiting.limit = 50
+rate_limiting.limit_moderator = 100
 # Max number of times a user can be rate limited before being blocked:
 rate_limiting.max_times = 3

--- a/common.ini.in
+++ b/common.ini.in
@@ -105,3 +105,9 @@ skip.captcha.validation = {skip_captcha_validation}
 image_backend.url = {image_backend_url}
 image_backend.secret_key = {image_backend_secret_key}
 image_url = {image_url}
+
+# Rate limiting settings
+# Window timespan in minutes:
+rate_limiting.window_span = 15
+# Max number of actions allowed during a single window:
+rate_limiting.limit = 50

--- a/common.ini.in
+++ b/common.ini.in
@@ -107,13 +107,13 @@ image_backend.secret_key = {image_backend_secret_key}
 image_url = {image_url}
 
 # Rate limiting settings
-# Window timespan in seconds (15min):
-rate_limiting.window_span = 900
+# Window timespan in seconds:
+rate_limiting.window_span = {rate_limiting_window_span}
 # Max number of actions allowed during a single window:
-rate_limiting.limit = 50
-rate_limiting.limit_moderator = 100
-rate_limiting.limit_robot = 1000
+rate_limiting.limit = {rate_limiting_limit}
+rate_limiting.limit_moderator = {rate_limiting_limit_moderator}
+rate_limiting.limit_robot = {rate_limiting_limit_robot}
 # Max number of times a user can be rate limited before being blocked:
-rate_limiting.max_times = 3
+rate_limiting.max_times = {rate_limiting_max_times}
 # Email address rate limiting alert messages are sent to
 rate_limiting.alert_address = {rate_limiting_alert_address}

--- a/common.ini.in
+++ b/common.ini.in
@@ -111,3 +111,5 @@ image_url = {image_url}
 rate_limiting.window_span = 900
 # Max number of actions allowed during a single window:
 rate_limiting.limit = 50
+# Max number of times a user can be rate limited before being blocked:
+rate_limiting.max_times = 3

--- a/common.ini.in
+++ b/common.ini.in
@@ -115,3 +115,5 @@ rate_limiting.limit_moderator = 100
 rate_limiting.limit_robot = 1000
 # Max number of times a user can be rate limited before being blocked:
 rate_limiting.max_times = 3
+# Email address rate limiting alert messages are sent to
+rate_limiting.alert_address = {rate_limiting_alert_address}

--- a/common.ini.in
+++ b/common.ini.in
@@ -107,7 +107,7 @@ image_backend.secret_key = {image_backend_secret_key}
 image_url = {image_url}
 
 # Rate limiting settings
-# Window timespan in minutes:
-rate_limiting.window_span = 15
+# Window timespan in seconds (15min):
+rate_limiting.window_span = 900
 # Max number of actions allowed during a single window:
 rate_limiting.limit = 50

--- a/config/default
+++ b/config/default
@@ -92,3 +92,5 @@ export feed_admin_user_account = 2
 export guidebook_anonymous_user_account = 2
 
 export show_debugger_for_errors = false
+
+export rate_limiting_alert_address = fixme@camptocamp.org

--- a/config/default
+++ b/config/default
@@ -93,4 +93,13 @@ export guidebook_anonymous_user_account = 2
 
 export show_debugger_for_errors = false
 
+# Rate limiting settings
 export rate_limiting_alert_address = fixme@camptocamp.org
+# Window timespan in seconds:
+export rate_limiting_window_span = 900
+# Max number of actions allowed during a single window:
+export rate_limiting_limit = 50
+export rate_limiting_limit_moderator = 100
+export rate_limiting_limit_robot = 1000
+# Max number of times a user can be rate limited before being blocked:
+export rate_limiting_max_times = 3

--- a/test.ini.in
+++ b/test.ini.in
@@ -21,5 +21,6 @@ skip.captcha.validation = True
 feed.admin_user_account =
 guidebook.anonymous_user_account =
 rate_limiting.window_span = 5
-rate_limiting.limit = 15
+rate_limiting.limit = 12
+rate_limiting.limit_moderator = 15
 rate_limiting.max_times = 2

--- a/test.ini.in
+++ b/test.ini.in
@@ -22,3 +22,4 @@ feed.admin_user_account =
 guidebook.anonymous_user_account =
 rate_limiting.window_span = 5
 rate_limiting.limit = 15
+rate_limiting.max_times = 2

--- a/test.ini.in
+++ b/test.ini.in
@@ -20,3 +20,5 @@ discourse.sso_secret = {discourse_sso_secret}
 skip.captcha.validation = True
 feed.admin_user_account =
 guidebook.anonymous_user_account =
+rate_limiting.window_span = 5
+rate_limiting.limit = 15


### PR DESCRIPTION
* [x] Move existing tween (JWT validation) to a dedicated dir
* [x] Create a rate limiting tween that intercepts write requests (POST, PUT, DELETE) only
* [x] Alembic script
* [x] Unit tests

Ordered evolutions:
* [x] Send an email to moderators when a user is rate limited
* [x] Block user after x (in a row?) rate limited statuses
* [x] Have special settings depending on user categories (eg. moderators)
* [x] Add robot to user categories