### PR TITLE
Add username in the password change email body

### DIFF
--- a/c2corg_api/emails/email_service.py
+++ b/c2corg_api/emails/email_service.py
@@ -71,17 +71,19 @@ class EmailService:
                 body=body)
         self.mailer.send(msg)
 
-    def _send_email_with_link(self, user, key, link):
+    def send_registration_confirmation(self, user, link):
         self._send_email(
                 user.email,
-                subject=self._(user.lang, key + '_subject'),
-                body=self._(user.lang, key + '_body') % link)
-
-    def send_registration_confirmation(self, user, link):
-        self._send_email_with_link(user, 'registration', link)
+                subject=self._(user.lang, 'registration_subject'),
+                body=self._(user.lang, 'registration_body') % link)
 
     def send_request_change_password(self, user, link):
-        self._send_email_with_link(user, 'password_change', link)
+        body = self._(user.lang, 'password_change_body') % (
+            link, user.username)
+        self._send_email(
+                user.email,
+                subject=self._(user.lang, 'password_change_subject'),
+                body=body)
 
     def send_change_email_confirmation(self, user, link):
         self._send_email(

--- a/c2corg_api/emails/i18n/ca/password_change_body
+++ b/c2corg_api/emails/i18n/ca/password_change_body
@@ -2,5 +2,7 @@ Hola
 
 Per canviar la vostra contrasenya, cliqueu a %s
 
+El vostre nom d'usuari és "%s"
+
 Moltes gràcies
 L'equip de Camptocamp.org

--- a/c2corg_api/emails/i18n/de/password_change_body
+++ b/c2corg_api/emails/i18n/de/password_change_body
@@ -2,5 +2,7 @@ Guten Tag,
 
 um Ihr Kennwort zu ändern, klicken Sie bitte auf folgenden Link: %s
 
+Ihr Benutzername ist "%s"
+
 Vielen Dank
 Das Camptocamp.org Team

--- a/c2corg_api/emails/i18n/en/password_change_body
+++ b/c2corg_api/emails/i18n/en/password_change_body
@@ -2,5 +2,8 @@ Hello
 
 To change your password click on %s
 
+Your username is "%s"
+Please note the username is case-sensitive.
+
 Thank you very much
 The Camptocamp.org team

--- a/c2corg_api/emails/i18n/es/password_change_body
+++ b/c2corg_api/emails/i18n/es/password_change_body
@@ -2,5 +2,7 @@ Hola
 
 Para cambiar su contraseña, haga clic en %s
 
+Tu nombre de usuario está "%s"
+
 Muchas gracias
 El equipo Camptocamp.org

--- a/c2corg_api/emails/i18n/eu/password_change_body
+++ b/c2corg_api/emails/i18n/eu/password_change_body
@@ -2,5 +2,7 @@ Kaixo
 
 Zure pasahitza aldatzeko klikatu %s
 
+Zure erabiltzaile izena da "%s"
+
 Eskerrik asko
 Taldea Camptocamp.org The

--- a/c2corg_api/emails/i18n/fr/password_change_body
+++ b/c2corg_api/emails/i18n/fr/password_change_body
@@ -2,5 +2,8 @@ Bonjour
 
 Pour changer votre mot de passe cliquez sur %s
 
+Votre identifiant est "%s"
+Attention les majuscules et minuscules sont importantes.
+
 Merci beaucoup
 L'équipe Camptocamp.org

--- a/c2corg_api/emails/i18n/it/password_change_body
+++ b/c2corg_api/emails/i18n/it/password_change_body
@@ -2,5 +2,7 @@ Ciao
 
 Per cambiare la vostra password cliccare su %s
 
+Il vostro nome utente è "%s"
+
 Grazie mille
 L'equipe Camptocamp.org


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_api/issues/717

Not tested because I have no way to send emails in my instance. The branch could be tested on the demo instance.