### PR TITLE
Send emails using smtplib directly (without pyramid mailer).

### DIFF
--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -14,7 +14,6 @@ from c2corg_api.models.user_profile import UserProfile
 from c2corg_api.scripts.es.fill_index import fill_index
 from sqlalchemy import engine_from_config
 from pyramid.paster import get_appsettings
-from pyramid_mailer import get_mailer
 from pyramid import testing
 from alembic.config import Config
 
@@ -220,8 +219,7 @@ class BaseTestCase(unittest.TestCase, AssertionsMixin):
     def setUp(self):  # noqa
         self.app = TestApp(self.app)
         registry = self.app.app.registry
-        self.mailer = get_mailer(registry)
-        self.email_service = EmailService(self.mailer, settings)
+        self.email_service = EmailService(settings)
         EmailService.instance = None
 
         self.config = testing.setUp()

--- a/c2corg_api/tests/emails/test_emails.py
+++ b/c2corg_api/tests/emails/test_emails.py
@@ -4,25 +4,47 @@ from c2corg_api.models.user import User
 from c2corg_api.emails.email_service import EmailLocalizator
 from c2corg_common.attributes import default_langs
 
+from unittest.mock import patch, ANY
+from base64 import b64encode
+
 
 class EmailTests(BaseTestCase):
 
-    def test_send_email(self):
-        outbox_count = self.get_email_box_length()
+    @patch('c2corg_api.emails.email_service.smtplib.SMTP')
+    def test_send_email(self, smtp):
         self.email_service._send_email('toto@localhost', subject='s', body='b')
-        self.assertEqual(self.get_email_box_length(), outbox_count + 1)
-        self.assertEqual(self.get_last_email().subject, "s")
-        self.assertEqual(self.get_last_email().body.data, "b")
 
-    def test_registration_confirmation(self):
+        smtp.assert_called_once_with(self.settings['mail.host'],
+                                     port=self.settings['mail.port'])
+
+        smtp.return_value.sendmail.assert_called_once_with(
+            self.settings['mail.from'],
+            'toto@localhost',
+            ANY)
+
+        msg = smtp.return_value.sendmail.call_args_list[0][0][2]
+        self.assertIn('From: noreply@camptocamp.org', msg)
+        self.assertIn('To: toto@localhost', msg)
+        self.assertIn('Subject: s', msg)
+        self.assertIn('Content-Type: text/plain; charset="utf-8"', msg)
+        self.assertIn('Content-Transfer-Encoding: base64', msg)
+        self.assertIn(b64encode('b'.encode('utf8')).decode('utf8'), msg)
+
+    @patch('c2corg_api.emails.email_service.EmailService._send_email')
+    def test_registration_confirmation(self, _send_email):
         user = User(email='me@localhost', lang='en')
         link = 'http://somelink'
-        outbox_count = self.get_email_box_length()
         self.email_service.send_registration_confirmation(user, link)
-        self.assertEqual(self.get_email_box_length(), outbox_count + 1)
-        self.assertIn("Registration", self.get_last_email().subject)
-        self.assertIn("To activate", self.get_last_email().body.data)
-        self.assertIn(link, self.get_last_email().body.data)
+
+        _send_email.assert_called_once_with(
+            'me@localhost',
+            subject='Registration on Camptocamp.org',
+            body='''Hello
+
+To activate your account click on http://somelink
+
+Thank you very much
+The Camptocamp.org team''')
 
     def test_localization(self):
         localizator = EmailLocalizator()


### PR DESCRIPTION
Also note the email template files openned using universal newline support.

This fix error 550 "Bare LF found" with free.fr.

Relate #700