### PR TITLE
Publish new image version

### DIFF
--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -839,9 +839,6 @@ class TestOutingRest(BaseDocumentTestRest):
                 ],
                 'geometry': {
                     'version': self.outing.geometry.version,
-                    'geom_detail':
-                        '{"type": "LineString", "coordinates": ' +
-                        '[[635956, 5723604], [635976, 5723654]]}',
                     'geom':
                         '{"type": "Point", "coordinates": [635000, 5723000]}'
                 },
@@ -856,44 +853,6 @@ class TestOutingRest(BaseDocumentTestRest):
         (body, route) = self.put_success_figures_only(
             body, self.outing, user='moderator')
         self._assert_default_geometry(body, x=635000, y=5723000)
-
-    def test_put_update_default_geom_from_linked_routes(self):
-        """Tests that the default geometry is updated from linked routes.
-        """
-        body = {
-            'message': 'Changing figures',
-            'document': {
-                'document_id': self.outing2.document_id,
-                'version': self.outing2.version,
-                'quality': quality_types[1],
-                'activities': ['skitouring'],
-                'date_start': '2016-01-01',
-                'date_end': '2016-01-01',
-                'elevation_min': 700,
-                'elevation_max': 1600,
-                'height_diff_up': 800,
-                'height_diff_down': 800,
-                'locales': [
-                    {'lang': 'en', 'title': 'Mont Blanc from the air',
-                     'description': '...', 'weather': 'sunny',
-                     'version': self.locale_en.version}
-                ],
-                'associations': {
-                    'users': [{
-                        'document_id': self.global_userids['contributor']
-                    }],
-                    'routes': [{'document_id': self.route.document_id}]
-                }
-            }
-        }
-        headers = self.add_authorization_header(username='moderator')
-        self.app_put_json(
-            self._prefix + '/' + str(self.outing2.document_id), body,
-            headers=headers, status=200)
-        response = self.app.get(
-            self._prefix + '/' + str(self.outing2.document_id), status=200)
-        body = response.json
-        self._assert_default_geometry(body, x=635961, y=5723624)
 
     def test_put_success_lang_only(self):
         body = {

--- a/c2corg_api/tests/views/test_route.py
+++ b/c2corg_api/tests/views/test_route.py
@@ -802,7 +802,7 @@ class TestRouteRest(BaseDocumentTestRest):
             }
         }
         (body, route) = self.put_success_all(body, self.route)
-        self._assert_default_geometry(body, x=635966, y=5723629)
+        self._assert_default_geometry(body, x=635961, y=5723624)
 
         self.assertEquals(route.elevation_max, 1600)
         locale_en = route.get_locale('en')
@@ -896,103 +896,6 @@ class TestRouteRest(BaseDocumentTestRest):
         }
         (body, route) = self.put_success_figures_only(body, self.route)
         self._assert_default_geometry(body, x=635000, y=5723000)
-
-    def test_put_success_update_default_geom_main_wp_changed(self):
-        """Test that the default geom is updated when the main waypoint changes
-        and no track exists.
-        """
-        body = {
-            'message': 'Changing figures',
-            'document': {
-                'document_id': self.route2.document_id,
-                'version': self.route2.version,
-                'quality': quality_types[1],
-                'main_waypoint_id': self.waypoint.document_id,
-                'activities': ['skitouring'],
-                'glacier_gear': 'no',
-                'elevation_min': 700,
-                'elevation_max': 1600,
-                'height_diff_up': 800,
-                'height_diff_down': 800,
-                'durations': ['1'],
-                'locales': [
-                    {'lang': 'en', 'title': 'Mont Blanc from the air',
-                     'description': '...', 'gear': 'paraglider',
-                     'version': self.route2.locales[0].version}
-                ],
-                'associations': {
-                    'waypoints': [
-                        {'document_id': self.waypoint.document_id}
-                    ]
-                }
-            }
-        }
-        (body, route) = self.put_success_figures_only(body, self.route2)
-        self._assert_default_geometry(body, x=635956, y=5723604)
-
-    def test_put_success_update_default_geom_from_wps_new(self):
-        """Test that the default geom is updated with associated waypoints if
-        no track exists (and no default geom was set yet).
-        """
-        body = {
-            'message': 'Changing figures',
-            'document': {
-                'document_id': self.route2.document_id,
-                'version': self.route2.version,
-                'quality': quality_types[1],
-                'activities': ['skitouring'],
-                'glacier_gear': 'no',
-                'elevation_min': 700,
-                'elevation_max': 1600,
-                'height_diff_up': 800,
-                'height_diff_down': 800,
-                'durations': ['1'],
-                'locales': [
-                    {'lang': 'en', 'title': 'Mont Blanc from the air',
-                     'description': '...', 'gear': 'paraglider',
-                     'version': self.route2.locales[0].version}
-                ],
-                'associations': {
-                    'waypoints': [
-                        {'document_id': self.waypoint.document_id}
-                    ]
-                }
-            }
-        }
-        (body, route) = self.put_success_figures_only(body, self.route2)
-        self._assert_default_geometry(body, x=635956, y=5723604)
-
-    def test_put_success_update_default_geom_from_wps(self):
-        """Test that the default geom is updated with associated waypoints if
-        no track exists.
-        """
-        body = {
-            'message': 'Changing figures',
-            'document': {
-                'document_id': self.route3.document_id,
-                'version': self.route3.version,
-                'quality': quality_types[1],
-                'activities': ['skitouring'],
-                'glacier_gear': 'no',
-                'elevation_min': 700,
-                'elevation_max': 1600,
-                'height_diff_up': 800,
-                'height_diff_down': 800,
-                'durations': ['1'],
-                'locales': [
-                    {'lang': 'en', 'title': 'Mont Blanc from the air',
-                     'description': '...', 'gear': 'paraglider',
-                     'version': self.route3.locales[0].version}
-                ],
-                'associations': {
-                    'waypoints': [
-                        {'document_id': self.waypoint.document_id}
-                    ]
-                }
-            }
-        }
-        (body, route) = self.put_success_figures_only(body, self.route3)
-        self._assert_default_geometry(body, x=635956, y=5723604)
 
     def test_put_success_main_wp_changed(self):
         body = {

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -373,11 +373,11 @@ class DocumentRest(object):
         # remember the current version numbers of the document
         old_versions = document.get_versions()
 
+        if before_update:
+            before_update(document, document_in)
+
         # update the document with the input document
         document.update(document_in)
-
-        if before_update:
-            before_update(document, document_in, user_id=user_id)
 
         if manage_versions:
             manage_versions(document, old_versions)


### PR DESCRIPTION
PR for #746, itself for c2corg/c2c_ui#388

The idea is, if document.filename is updated on image, then send `publish` request to image backend : [diff](https://github.com/c2corg/v6_api/compare/publish-new-image-version?expand=1#diff-0ed2cf87a7823395be03efb0711e74beR119)

I've made some revamp to achieve this. The best place for this feature is `before_update()` callback : it's called before any update : [link](https://github.com/c2corg/v6_api/compare/publish-new-image-version?expand=1#diff-b906af94797c5db6c394971ac60bf7a4L379). But, surprisingly, even if its arguments are `actual_doc` and `new_doc`, it was called **after** update in memory.

So, I fixed that : 

* move `before_update()` call before `document.update(document_input)`
* remove useless `user_id` argument from `before_update` signature
* <del>then, it appears that `route.before_update` is now useless. It's pupose was to update geometry based on linked waypoints. New UI **always** send geometry (means that it's handled by users)</del>
* <add>`route.before_update()`purpose was to always recompute localisation from GPS trace, or associated waypoints. This behaviour is now obsolete, as we let contributor handle geolocalisation point. But, as @saunier noticed it (see below), other UI may send empty geometry. In this cas, we set this point from the old version, as we always need it. Btw, I didn't set GPS trace from old version, because we may want to offer the possibility to remove GPS trace</add>
* same on `outing.before_update`, at this small exception : i keep it to keep update on localisation base on GPS trace.
* And at the end, remove useless unittest.


