### PR TITLE
POST/PUT /outings/{id}: add validation of date_start and date_end

### DIFF
--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -363,10 +363,10 @@ class TestOutingRest(BaseDocumentTestRest):
         self.assertEqual(len(errors), 3)
 
     def test_post_date_start_is_tomorrow(self):
-        tomorrow = (datetime.date.today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')
+        later = (datetime.date.today() + datetime.timedelta(days=2)).strftime('%Y-%m-%d')
         body_post = {
             'activities': ['skitouring'],
-            'date_start': tomorrow,
+            'date_start': later,
             'date_end': '2016-01-01',
             'elevation_min': 700,
             'elevation_max': 1500,
@@ -398,11 +398,11 @@ class TestOutingRest(BaseDocumentTestRest):
         self.assertEqual(errors[0]['description'], 'can not be sometime in the future')
 
     def test_post_date_end_is_tomorrow(self):
-        tomorrow = (datetime.date.today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')
+        later = (datetime.date.today() + datetime.timedelta(days=2)).strftime('%Y-%m-%d')
         body_post = {
             'activities': ['skitouring'],
             'date_start': '2016-01-01',
-            'date_end': tomorrow,
+            'date_end': later,
             'elevation_min': 700,
             'elevation_max': 1500,
             'height_diff_up': 800,
@@ -434,7 +434,7 @@ class TestOutingRest(BaseDocumentTestRest):
 
     def test_post_end_date_is_prior_start_date(self):
         today = datetime.date.today()
-        yesterday = today - timedelta(days=1)
+        yesterday = today - datetime.timedelta(days=1)
         body_post = {
             'activities': ['skitouring'],
             'date_start': today.strftime('%Y-%m-%d'),

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -362,6 +362,112 @@ class TestOutingRest(BaseDocumentTestRest):
         errors = body.get('errors')
         self.assertEqual(len(errors), 3)
 
+    def test_post_date_start_is_tomorrow(self):
+        tomorrow = (datetime.date.today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')
+        body_post = {
+            'activities': ['skitouring'],
+            'date_start': tomorrow,
+            'date_end': '2016-01-01',
+            'elevation_min': 700,
+            'elevation_max': 1500,
+            'height_diff_up': 800,
+            'height_diff_down': 800,
+            'geometry': {
+                'id': 5678, 'version': 6789,
+                'geom_detail': '{"type": "LineString", "coordinates": ' +
+                        '[[635956, 5723604], [635966, 5723644]]}'
+            },
+            'locales': [
+                {'lang': 'en', 'title': 'Some nice loop',
+                 'weather': 'sunny'}
+            ],
+            'associations': {
+                'users': [
+                    {'document_id': self.global_userids['contributor']},
+                    {'document_id': self.global_userids['contributor2']}
+                ],
+                'routes': [{'document_id': self.route.document_id}],
+                # images are ignored
+                'images': [{'document_id': self.route.document_id}]
+            }
+        }
+        body = self.post_error(body_post)
+        errors = body.get('errors')
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]['name'], 'date_start')
+        self.assertEqual(errors[0]['description'], 'can not be sometime in the future')
+
+    def test_post_date_end_is_tomorrow(self):
+        tomorrow = (datetime.date.today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')
+        body_post = {
+            'activities': ['skitouring'],
+            'date_start': '2016-01-01',
+            'date_end': tomorrow,
+            'elevation_min': 700,
+            'elevation_max': 1500,
+            'height_diff_up': 800,
+            'height_diff_down': 800,
+            'geometry': {
+                'id': 5678, 'version': 6789,
+                'geom_detail': '{"type": "LineString", "coordinates": ' +
+                        '[[635956, 5723604], [635966, 5723644]]}'
+            },
+            'locales': [
+                {'lang': 'en', 'title': 'Some nice loop',
+                 'weather': 'sunny'}
+            ],
+            'associations': {
+                'users': [
+                    {'document_id': self.global_userids['contributor']},
+                    {'document_id': self.global_userids['contributor2']}
+                ],
+                'routes': [{'document_id': self.route.document_id}],
+                # images are ignored
+                'images': [{'document_id': self.route.document_id}]
+            }
+        }
+        body = self.post_error(body_post)
+        errors = body.get('errors')
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]['name'], 'date_end')
+        self.assertEqual(errors[0]['description'], 'can not be sometime in the future')
+
+    def test_post_end_date_is_prior_start_date(self):
+        today = datetime.date.today()
+        yesterday = today - timedelta(days=1)
+        body_post = {
+            'activities': ['skitouring'],
+            'date_start': today.strftime('%Y-%m-%d'),
+            'date_end': yesterday.strftime('%Y-%m-%d'),
+            'elevation_min': 700,
+            'elevation_max': 1500,
+            'height_diff_up': 800,
+            'height_diff_down': 800,
+            'geometry': {
+                'id': 5678, 'version': 6789,
+                'geom_detail': '{"type": "LineString", "coordinates": ' +
+                        '[[635956, 5723604], [635966, 5723644]]}'
+            },
+            'locales': [
+                {'lang': 'en', 'title': 'Some nice loop',
+                 'weather': 'sunny'}
+            ],
+            'associations': {
+                'users': [
+                    {'document_id': self.global_userids['contributor']},
+                    {'document_id': self.global_userids['contributor2']}
+                ],
+                'routes': [{'document_id': self.route.document_id}],
+                # images are ignored
+                'images': [{'document_id': self.route.document_id}]
+            }
+        }
+        body = self.post_error(body_post)
+        errors = body.get('errors')
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]['name'], 'date_end')
+        self.assertEqual(errors[0]['description'], 'can not be prior the starting date')
+
     def test_post_non_whitelisted_attribute(self):
         body = {
             'activities': ['skitouring'],

--- a/c2corg_api/tests/views/test_outing.py
+++ b/c2corg_api/tests/views/test_outing.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import date, timedelta
 import json
 
 from c2corg_api.models.article import Article
@@ -363,7 +363,7 @@ class TestOutingRest(BaseDocumentTestRest):
         self.assertEqual(len(errors), 3)
 
     def test_post_date_start_is_tomorrow(self):
-        later = (datetime.date.today() + datetime.timedelta(days=2)).strftime('%Y-%m-%d')
+        later = (date.today() + timedelta(days=2)).strftime('%Y-%m-%d')
         body_post = {
             'activities': ['skitouring'],
             'date_start': later,
@@ -395,10 +395,11 @@ class TestOutingRest(BaseDocumentTestRest):
         errors = body.get('errors')
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]['name'], 'date_start')
-        self.assertEqual(errors[0]['description'], 'can not be sometime in the future')
+        self.assertEqual(errors[0]['description'],
+                         'can not be sometime in the future')
 
     def test_post_date_end_is_tomorrow(self):
-        later = (datetime.date.today() + datetime.timedelta(days=2)).strftime('%Y-%m-%d')
+        later = (date.today() + timedelta(days=2)).strftime('%Y-%m-%d')
         body_post = {
             'activities': ['skitouring'],
             'date_start': '2016-01-01',
@@ -410,7 +411,7 @@ class TestOutingRest(BaseDocumentTestRest):
             'geometry': {
                 'id': 5678, 'version': 6789,
                 'geom_detail': '{"type": "LineString", "coordinates": ' +
-                        '[[635956, 5723604], [635966, 5723644]]}'
+                               '[[635956, 5723604], [635966, 5723644]]}'
             },
             'locales': [
                 {'lang': 'en', 'title': 'Some nice loop',
@@ -430,11 +431,12 @@ class TestOutingRest(BaseDocumentTestRest):
         errors = body.get('errors')
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]['name'], 'date_end')
-        self.assertEqual(errors[0]['description'], 'can not be sometime in the future')
+        self.assertEqual(errors[0]['description'],
+                         'can not be sometime in the future')
 
     def test_post_end_date_is_prior_start_date(self):
-        today = datetime.date.today()
-        yesterday = today - datetime.timedelta(days=1)
+        today = date.today()
+        yesterday = today - timedelta(days=1)
         body_post = {
             'activities': ['skitouring'],
             'date_start': today.strftime('%Y-%m-%d'),
@@ -446,7 +448,7 @@ class TestOutingRest(BaseDocumentTestRest):
             'geometry': {
                 'id': 5678, 'version': 6789,
                 'geom_detail': '{"type": "LineString", "coordinates": ' +
-                        '[[635956, 5723604], [635966, 5723644]]}'
+                               '[[635956, 5723604], [635966, 5723644]]}'
             },
             'locales': [
                 {'lang': 'en', 'title': 'Some nice loop',
@@ -466,7 +468,8 @@ class TestOutingRest(BaseDocumentTestRest):
         errors = body.get('errors')
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]['name'], 'date_end')
-        self.assertEqual(errors[0]['description'], 'can not be prior the starting date')
+        self.assertEqual(errors[0]['description'],
+                         'can not be prior the starting date')
 
     def test_post_non_whitelisted_attribute(self):
         body = {
@@ -606,8 +609,8 @@ class TestOutingRest(BaseDocumentTestRest):
         body, doc = self.post_success(body)
         self._assert_geometry(body)
         self._assert_default_geometry(body)
-        self.assertEqual(doc.date_start, datetime.date(2016, 1, 1))
-        self.assertEqual(doc.date_end, datetime.date(2016, 1, 2))
+        self.assertEqual(doc.date_start, date(2016, 1, 1))
+        self.assertEqual(doc.date_end, date(2016, 1, 2))
 
         version = doc.versions[0]
 
@@ -1221,8 +1224,8 @@ class TestOutingRest(BaseDocumentTestRest):
 
     def _add_test_data(self):
         self.outing = Outing(
-            activities=['skitouring'], date_start=datetime.date(2016, 1, 1),
-            date_end=datetime.date(2016, 1, 1), elevation_max=1500,
+            activities=['skitouring'], date_start=date(2016, 1, 1),
+            date_end=date(2016, 1, 1), elevation_max=1500,
             elevation_min=700, height_diff_up=800, height_diff_down=800,
             elevation_access=900, condition_rating='good'
         )
@@ -1251,8 +1254,8 @@ class TestOutingRest(BaseDocumentTestRest):
         update_feed_document_create(self.outing, user_id)
 
         self.outing2 = Outing(
-            activities=['skitouring'], date_start=datetime.date(2016, 2, 1),
-            date_end=datetime.date(2016, 2, 1),
+            activities=['skitouring'], date_start=date(2016, 2, 1),
+            date_end=date(2016, 2, 1),
             height_diff_up=600, elevation_max=1800, elevation_access=700,
             condition_rating='average',
             locales=[
@@ -1268,15 +1271,15 @@ class TestOutingRest(BaseDocumentTestRest):
         DocumentRest.create_new_version(self.outing2, user_id)
 
         self.outing3 = Outing(
-            activities=['skitouring'], date_start=datetime.date(2016, 2, 1),
-            date_end=datetime.date(2016, 2, 2),
+            activities=['skitouring'], date_start=date(2016, 2, 1),
+            date_end=date(2016, 2, 2),
             height_diff_up=200, elevation_max=1200, elevation_access=800,
             condition_rating='poor'
         )
         self.session.add(self.outing3)
         self.outing4 = Outing(
-            activities=['skitouring'], date_start=datetime.date(2016, 2, 1),
-            date_end=datetime.date(2016, 2, 3),
+            activities=['skitouring'], date_start=date(2016, 2, 1),
+            date_end=date(2016, 2, 3),
             height_diff_up=500, elevation_max=1500, elevation_access=800,
             condition_rating='excellent'
         )

--- a/c2corg_api/views/outing.py
+++ b/c2corg_api/views/outing.py
@@ -34,6 +34,9 @@ validate_associations_update = functools.partial(
 
 
 def validate_dates(request, **kwargs):
+    if request.errors:
+        return
+
     utc_now = datetime.now(timezone.utc)
     utc_now_plus_12h = (utc_now + timedelta(hours=12)).date()
 
@@ -43,9 +46,6 @@ def validate_dates(request, **kwargs):
         document = request.json_body
 
     date_start = document.get('date_start')
-    if date_start is None:
-        # sometimes, request.validated is only: {'id': 361}
-        return
     if isinstance(date_start, str):
         try:
             date_start = datetime.strptime(date_start, '%Y-%m-%d').date()
@@ -62,8 +62,6 @@ def validate_dates(request, **kwargs):
         return
 
     date_end = document.get('date_end')
-    if date_end is None:
-        return
     if isinstance(date_end, str):
         try:
             date_end = datetime.strptime(date_end, '%Y-%m-%d').date()

--- a/c2corg_api/views/outing.py
+++ b/c2corg_api/views/outing.py
@@ -130,7 +130,7 @@ class OutingRest(DocumentRest):
             validate_outing_create,
             validate_associations_create,
             validate_required_associations,
-            validate_dates,])
+            validate_dates])
     def collection_post(self):
         set_default_geom = functools.partial(
             set_default_geometry,
@@ -147,7 +147,7 @@ class OutingRest(DocumentRest):
             validate_outing_update,
             validate_associations_update,
             validate_required_associations,
-            validate_dates,])
+            validate_dates])
     def put(self):
         if not has_permission_for_outing(
                 self.request, self.request.validated['id']):


### PR DESCRIPTION
3 new validators to ensure that:
 * date_start <= today + 12h (for users connected in UTC+12)
 * date_end <= today + 12h
 * date_start <= date_end

Fixes #833

### Validation

I was able to test the change in the API manually by running a hacked version of the frontend that allows me to specify invalid dates when editing outings:

```diff
diff --git a/src/js/constants/fieldsProperties.json b/src/js/constants/fieldsProperties.json
index dbb80b75..e55a3640 100644
--- a/src/js/constants/fieldsProperties.json
+++ b/src/js/constants/fieldsProperties.json
@@ -247,7 +247,7 @@
     },
     "date_start":
     {
-        "type": "date",
+        "type": "text",
         "required": true,
         "queryMode": "dates"
     },
```

This pull-request also adds 2 new unit-tests to test the validators but I was not able to execute them on my workstation. When executing `docker-compose exec api make -f config/docker-dev test`, I experience this issue with most of the tests (not only the 2 new tests):

```
Traceback (most recent call last):
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/pool.py", line 1122, in _do_get
    return self._pool.get(wait, self._timeout)
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/util/queue.py", line 145, in get
    raise Empty
sqlalchemy.util.queue.Empty

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/engine/base.py", line 2141, in _wrap_pool_connect
    return fn()
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/pool.py", line 328, in unique_connection
    return _ConnectionFairy._checkout(self)
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/pool.py", line 766, in _checkout
    fairy = _ConnectionRecord.checkout(pool)
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/pool.py", line 516, in checkout
    rec = pool._do_get()
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/pool.py", line 1138, in _do_get
    self._dec_overflow()
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/util/langhelpers.py", line 60, in __exit__
    compat.reraise(exc_type, exc_value, exc_tb)
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/util/compat.py", line 186, in reraise
    raise value
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/pool.py", line 1135, in _do_get
    return self._create_connection()
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/pool.py", line 333, in _create_connection
    return _ConnectionRecord(self)
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/pool.py", line 461, in __init__
    self.__connect(first_connect_check=True)
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/pool.py", line 651, in __connect
    connection = pool._invoke_creator(self)
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/engine/strategies.py", line 105, in connect
    return dialect.connect(*cargs, **cparams)
  File "/var/www/.build/venv/lib/python3.4/site-packages/sqlalchemy/engine/default.py", line 385, in connect
    return self.dbapi.connect(*cargs, **cparams)
  File "/var/www/.build/venv/lib/python3.4/site-packages/psycopg2/__init__.py", line 130, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
psycopg2.OperationalError: FATAL:  remaining connection slots are reserved for non-replication superuser connections
```

I will try again later.