### PR TITLE
Replace nosetest by pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: Continuous integration
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.4'
+      - run: pip install -r dev-requirements.txt
+      - run: flake8 c2corg_api es_migration

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,9 @@ cleanall: clean
 	rm -rf .build
 
 .PHONY: test
-test: .build/venv/bin/nosetests template .build/dev-requirements.timestamp .build/requirements.timestamp
+test: .build/venv/bin/pytest template .build/dev-requirements.timestamp .build/requirements.timestamp
 	# All tests must be run with authentication/authorization enabled
-	.build/venv/bin/nosetests
+	.build/venv/bin/pytest --cov=c2corg_api
 
 .PHONY: lint
 lint: .build/venv/bin/flake8
@@ -99,7 +99,7 @@ upgrade-dev: .build/venv/bin/pip
 
 .build/venv/bin/flake8: .build/dev-requirements.timestamp
 
-.build/venv/bin/nosetests: .build/dev-requirements.timestamp
+.build/venv/bin/pytest: .build/dev-requirements.timestamp
 
 .build/dev-requirements.timestamp: .build/venv/bin/pip dev-requirements.txt
 	.build/venv/bin/pip install -r dev-requirements.txt

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Press CTRL+C to terminate it.
 In another terminal (`docker-compose up` must be running) :
 
 ```sh
-docker-compose exec api make -f config/docker-dev lint
+./scripts/lint.sh
 ```
 
 ### Run test suite 
@@ -40,10 +40,10 @@ In another terminal (`docker-compose up` must be running) :
 
 ```sh
 # First, inititate test database, must be done once
-docker-compose exec postgresql /v6_api/scripts/create_user_db_test.sh
+./scripts/init_test.sh
 
 # Then
-docker-compose exec api make -f config/docker-dev test
+./scripts/test.sh
 ```
 
 ## Useful links in [wiki](https://github.com/c2corg/v6_api/wiki)

--- a/c2corg_api/tests/__init__.py
+++ b/c2corg_api/tests/__init__.py
@@ -165,6 +165,7 @@ def _add_global_test_data(session):
 
 
 def setup_package():
+
     # set up database
     engine = get_engine()
     DBSession.configure(bind=engine)
@@ -309,3 +310,6 @@ def reset_cache_key():
     caching.CACHE_VERSION = '{0}-{1}-{2}'.format(
         cache_version, int(time.time()), randint(0, 10**9))
     caching_common.cache_status = caching_common.CacheStatus()
+
+
+setup_package()

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 flake8==3.0.4
 pep8-naming==0.4.1
-nose==1.3.7
 WebTest==2.0.20
 ipdb==0.10.1
 httmock==1.2.5
+pytest==4.6.11
+pytest-cov==2.8.1

--- a/dev_api.Dockerfile
+++ b/dev_api.Dockerfile
@@ -41,8 +41,8 @@ COPY ./ /var/www/
 WORKDIR /var/www/
 
 RUN set -x \
- && make -f config/docker-dev install \ 
- && py3compile -f -X '^.*gevent/_util_py2.py$' .build/venv/
+ && make -f config/docker-dev install \
+ && py3compile -f -X '^.*gevent/_util_py2.py$' -X '^.*attr/_next_gen.py$' .build/venv/
 
 ENV version="{version}" \
     PATH=/var/www/.build/venv/bin/:$PATH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,6 @@ services:
     volumes:
       - ./docker-compose/pgsql-settings.d/:/c2corg_anon/pgsql-settings.d/
       - .:/v6_api
-    ports:
-      - 5432:5432
 
   elasticsearch:
     image: 'docker.io/c2corg/c2corg_es:anon-2018-11-02'

--- a/scripts/init_test.sh
+++ b/scripts/init_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose exec -T postgresql /v6_api/scripts/create_user_db_test.sh

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose exec api make -f config/docker-dev lint

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose exec api make -f config/docker-dev test


### PR DESCRIPTION
nosetest is EOL : https://nose.readthedocs.io/en/latest/ 

> Nose has been in maintenance mode for the past several years and will likely cease without a new person/team to take over maintainership. New projects should consider using Nose2, py.test, or just plain unittest/unittest2.

I've choosen pytest as it's the most widely used. 

I've added coverage in std output.

Also added a github action as a try for new CI executor.

A lot of warnings are shown on test output (they were ignored by nosetest), I'll make another PR to clean them.