### PR TITLE
Update c2-markdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ git+https://github.com/tsauerwein/ColanderAlchemy.git@c2corg
 git+https://github.com/tsauerwein/cornice.git@nested-none-2.1.0-c2corg
 
 # c2c_markdown repo...
-git+https://github.com/c2corg/c2c_markdown.git@7012ce6
+git+https://github.com/c2corg/c2c_markdown.git@4c337e2
 
 # c2corg_common project
 # for development use a local checkout


### PR DESCRIPTION
This new version of c2c-markdown: 

* Remove a bug that can give a 500 responses in cas of markdown error (instead of a JSON constructed message)
* provides `c2c:size` attributes on images (can be MI, ...)
* minor fix on non-breakable spaces detection
* security update on sanitizer
* minor issue on wikilinks with underscore in anchor
* minor bug when an external link label looks like an URL