### PR TITLE
Use larger limit for retrieved routes associated to waypoint 

### DIFF
--- a/c2corg_api/views/waypoint.py
+++ b/c2corg_api/views/waypoint.py
@@ -35,7 +35,7 @@ from sqlalchemy.sql.elements import literal_column
 from sqlalchemy.sql.expression import and_, union
 
 # the number of routes that are included for waypoints
-NUM_ROUTES = 30
+NUM_ROUTES = 400
 
 validate_waypoint_create = make_validator_create(
     fields_waypoint, 'waypoint_type', waypoint_types)


### PR DESCRIPTION
30 > 400. This should cover the worst case scenarii described in https://github.com/c2corg/c2c_ui/issues/754 and allow to solve this issue from the frontend side.