### PR TITLE
Remove duplicates in recent outings

### DIFF
--- a/c2corg_api/views/route.py
+++ b/c2corg_api/views/route.py
@@ -140,7 +140,7 @@ class RouteRest(DocumentRest):
                 Association,
                 Outing.document_id == Association.child_document_id).
             filter(Association.parent_document_id == route.document_id).
-            group_by(Outing.document_id).
+            distinct().
             order_by(Outing.date_end.desc()).
             limit(NUM_RECENT_OUTINGS).
             all())
@@ -151,7 +151,7 @@ class RouteRest(DocumentRest):
                 Association,
                 Outing.document_id == Association.child_document_id). \
             filter(Association.parent_document_id == route.document_id). \
-            group_by(Outing.document_id). \
+            distinct(). \
             count()
 
         route.associations['recent_outings'] = get_documents_for_ids(

--- a/c2corg_api/views/route.py
+++ b/c2corg_api/views/route.py
@@ -140,6 +140,7 @@ class RouteRest(DocumentRest):
                 Association,
                 Outing.document_id == Association.child_document_id).
             filter(Association.parent_document_id == route.document_id).
+            group_by(Outing.document_id).
             order_by(Outing.date_end.desc()).
             limit(NUM_RECENT_OUTINGS).
             all())
@@ -150,6 +151,7 @@ class RouteRest(DocumentRest):
                 Association,
                 Outing.document_id == Association.child_document_id). \
             filter(Association.parent_document_id == route.document_id). \
+            group_by(Outing.document_id). \
             count()
 
         route.associations['recent_outings'] = get_documents_for_ids(

--- a/c2corg_api/views/waypoint.py
+++ b/c2corg_api/views/waypoint.py
@@ -266,6 +266,7 @@ def set_recent_outings(waypoint, lang):
             with_query_waypoints,
             with_query_waypoints.c.document_id == t_route_wp.parent_document_id
         ).
+        distinct().
         order_by(Outing.date_end.desc()).
         limit(NUM_RECENT_OUTINGS).
         all())
@@ -286,6 +287,7 @@ def set_recent_outings(waypoint, lang):
             with_query_waypoints,
             with_query_waypoints.c.document_id == t_route_wp.parent_document_id
         ). \
+        distinct(). \
         count()
 
     waypoint.associations['recent_outings'] = get_documents_for_ids(


### PR DESCRIPTION
As usual, I do not know python and the pyramid framework, nor am I testing this.
But we know the request can return duplicates (see e.g. Meij waypoint with says it has >2000 outings, but really only ~800), I assume this could fix this.
As a consequence we could enhance UI a little bit and remove some useless code on the frontend part.