### PR TITLE
Have distinct routes for waypoint results (one more try, DISTINCT is not enough)

### DIFF
--- a/c2corg_api/tests/views/test_waypoint.py
+++ b/c2corg_api/tests/views/test_waypoint.py
@@ -171,19 +171,17 @@ class TestWaypointRest(BaseDocumentTestRest):
         all_linked_routes = associations.get('all_routes')
         linked_routes = all_linked_routes['documents']
         self.assertEqual(2, len(linked_routes))
-        linked_route = linked_routes[0]
+        linked_route = linked_routes[1]
         self.assertIn('type', linked_route)
         self.assertEqual(
             linked_route['document_id'], self.route1.document_id)
         self.assertEqual(
             linked_route.get('locales')[0].get('title_prefix'), 'Mont Blanc :')
-        # the route associated to a child waypoint comes after the route
-        # directly associated to the waypoint
         self.assertEqual(
-            linked_routes[1]['document_id'], self.route3.document_id)
-        self.assertIn('geometry', linked_routes[0])
+            linked_routes[0]['document_id'], self.route3.document_id)
+        self.assertIn('geometry', linked_routes[1])
         # TODO not returning `geom_detail` anymore
-        self.assertIn('geom', linked_routes[0].get('geometry'))
+        self.assertIn('geom', linked_routes[1].get('geometry'))
 
         self.assertIn('maps', body)
         self.assertEqual(1, len(body.get('maps')))

--- a/c2corg_api/views/waypoint.py
+++ b/c2corg_api/views/waypoint.py
@@ -266,7 +266,7 @@ def set_recent_outings(waypoint, lang):
             with_query_waypoints,
             with_query_waypoints.c.document_id == t_route_wp.parent_document_id
         ).
-        distinct(Outing.document_id).
+        distinct().
         order_by(Outing.date_end.desc()).
         limit(NUM_RECENT_OUTINGS).
         all())
@@ -287,7 +287,7 @@ def set_recent_outings(waypoint, lang):
             with_query_waypoints,
             with_query_waypoints.c.document_id == t_route_wp.parent_document_id
         ). \
-        distinct(Outing.document_id). \
+        distinct(). \
         count()
 
     waypoint.associations['recent_outings'] = get_documents_for_ids(
@@ -305,6 +305,7 @@ def set_linked_routes(waypoint, lang):
     route_ids = get_first_column(
         DBSession.query(Route.document_id).
         select_from(with_query_waypoints).
+        distinct(Route.document_id).
         join(
             Association,
             with_query_waypoints.c.document_id ==
@@ -316,7 +317,6 @@ def set_linked_routes(waypoint, lang):
         order_by(
             with_query_waypoints.c.priority.desc(),
             Route.document_id.desc()).
-        distinct(Route.document_id).
         limit(NUM_ROUTES).
         all())
 
@@ -330,7 +330,7 @@ def set_linked_routes(waypoint, lang):
             Route,
             Association.child_document_id == Route.document_id). \
         filter(Route.redirects_to.is_(None)). \
-        distinct(Route.document_id). \
+        distinct(). \
         count()
 
     waypoint.associations['all_routes'] = get_documents_for_ids(

--- a/c2corg_api/views/waypoint.py
+++ b/c2corg_api/views/waypoint.py
@@ -266,7 +266,7 @@ def set_recent_outings(waypoint, lang):
             with_query_waypoints,
             with_query_waypoints.c.document_id == t_route_wp.parent_document_id
         ).
-        distinct().
+        distinct(Outing.document_id).
         order_by(Outing.date_end.desc()).
         limit(NUM_RECENT_OUTINGS).
         all())
@@ -287,7 +287,7 @@ def set_recent_outings(waypoint, lang):
             with_query_waypoints,
             with_query_waypoints.c.document_id == t_route_wp.parent_document_id
         ). \
-        distinct(). \
+        distinct(Outing.document_id). \
         count()
 
     waypoint.associations['recent_outings'] = get_documents_for_ids(
@@ -316,7 +316,7 @@ def set_linked_routes(waypoint, lang):
         order_by(
             with_query_waypoints.c.priority.desc(),
             Route.document_id.desc()).
-        distinct().
+        distinct(Route.document_id).
         limit(NUM_ROUTES).
         all())
 
@@ -330,7 +330,7 @@ def set_linked_routes(waypoint, lang):
             Route,
             Association.child_document_id == Route.document_id). \
         filter(Route.redirects_to.is_(None)). \
-        distinct(). \
+        distinct(Route.document_id). \
         count()
 
     waypoint.associations['all_routes'] = get_documents_for_ids(


### PR DESCRIPTION
Looks like returned routes of a waypoint still have duplicates