### PR TITLE
Fix #755: multi-word search

### DIFF
--- a/c2corg_api/search/__init__.py
+++ b/c2corg_api/search/__init__.py
@@ -80,20 +80,6 @@ def create_search(document_type):
         index=elasticsearch_config['index'],
         doc_type=search_documents[document_type])
 
-
-def get_text_query(search_term, lang=None):
-    # search in all title* (title_en, title_fr, ...), summary* and
-    # description* fields. "boost" title fields and summary fields.
-    return Bool(
-        should=[
-            MultiMatch(
-                query=search_term,
-                operator='and',
-                fields=['summary*^2', 'description*'], boost=0.5),
-            get_text_query_on_title(search_term, lang)
-        ])
-
-
 def get_text_query_on_title(search_term, search_lang=None):
     # search in all title* (title_en, title_fr, ...) fields.
     if not search_lang:

--- a/c2corg_api/search/__init__.py
+++ b/c2corg_api/search/__init__.py
@@ -88,7 +88,7 @@ def get_text_query(search_term, lang=None):
         should=[
             MultiMatch(
                 query=search_term,
-                type='phrase',
+                operator='and',
                 fields=['summary*^2', 'description*'], boost=0.5),
             get_text_query_on_title(search_term, lang)
         ])
@@ -99,7 +99,7 @@ def get_text_query_on_title(search_term, search_lang=None):
     if not search_lang:
         return MultiMatch(
             query=search_term,
-            type='phrase',
+            operator='and',
             fields=['title_*.ngram', 'title_*.raw^2']
         )
     else:
@@ -113,7 +113,7 @@ def get_text_query_on_title(search_term, search_lang=None):
                 fields.append('title_{0}.ngram'.format(lang))
                 fields.append('title_{0}.raw^2'.format(lang))
 
-        return MultiMatch(query=search_term,type='phrase',fields=fields)
+        return MultiMatch(query=search_term,operator='and',fields=fields)
 
 
 search_documents = {

--- a/c2corg_api/search/__init__.py
+++ b/c2corg_api/search/__init__.py
@@ -80,6 +80,7 @@ def create_search(document_type):
         index=elasticsearch_config['index'],
         doc_type=search_documents[document_type])
 
+
 def get_text_query_on_title(search_term, search_lang=None):
     fields = []
     # search in all title* (title_en, title_fr, ...) fields.

--- a/c2corg_api/search/__init__.py
+++ b/c2corg_api/search/__init__.py
@@ -1,30 +1,30 @@
 from c2corg_api.models.area import AREA_TYPE
 from c2corg_api.models.article import ARTICLE_TYPE
 from c2corg_api.models.book import BOOK_TYPE
+from c2corg_api.models.common.attributes import default_langs
 from c2corg_api.models.image import IMAGE_TYPE
 from c2corg_api.models.outing import OUTING_TYPE
-from c2corg_api.models.xreport import XREPORT_TYPE
 from c2corg_api.models.route import ROUTE_TYPE
 from c2corg_api.models.topo_map import MAP_TYPE
 from c2corg_api.models.user_profile import USERPROFILE_TYPE
 from c2corg_api.models.waypoint import WAYPOINT_TYPE
+from c2corg_api.models.xreport import XREPORT_TYPE
 from c2corg_api.search.mappings.area_mapping import SearchArea
 from c2corg_api.search.mappings.article_mapping import SearchArticle
 from c2corg_api.search.mappings.book_mapping import SearchBook
 from c2corg_api.search.mappings.image_mapping import SearchImage
 from c2corg_api.search.mappings.outing_mapping import SearchOuting
-from c2corg_api.search.mappings.xreport_mapping import SearchXreport
 from c2corg_api.search.mappings.route_mapping import SearchRoute
 from c2corg_api.search.mappings.topo_map_mapping import SearchTopoMap
 from c2corg_api.search.mappings.user_mapping import SearchUser
 from c2corg_api.search.mappings.waypoint_mapping import SearchWaypoint
-from c2corg_api.models.common.attributes import default_langs
+from c2corg_api.search.mappings.xreport_mapping import SearchXreport
 from elasticsearch import Elasticsearch
-from elasticsearch_dsl.connections import connections
 from elasticsearch_dsl import Search
-from elasticsearch_dsl.query import MultiMatch, Bool
-from kombu.connection import Connection
+from elasticsearch_dsl.connections import connections
+from elasticsearch_dsl.query import MultiMatch
 from kombu import Exchange, Queue, pools
+from kombu.connection import Connection
 
 # the maximum number of documents that can be returned for each document type
 SEARCH_LIMIT_MAX = 50
@@ -99,7 +99,11 @@ def get_text_query_on_title(search_term, search_lang=None):
                 fields.append('title_{0}.ngram'.format(lang))
                 fields.append('title_{0}.raw^2'.format(lang))
 
-        return MultiMatch(query=search_term,operator='and',fields=fields)
+        return MultiMatch(
+            query=search_term,
+            operator='and',
+            fields=fields
+        )
 
 
 search_documents = {

--- a/c2corg_api/search/__init__.py
+++ b/c2corg_api/search/__init__.py
@@ -81,16 +81,13 @@ def create_search(document_type):
         doc_type=search_documents[document_type])
 
 def get_text_query_on_title(search_term, search_lang=None):
+    fields = []
     # search in all title* (title_en, title_fr, ...) fields.
     if not search_lang:
-        return MultiMatch(
-            query=search_term,
-            operator='and',
-            fields=['title_*.ngram', 'title_*.raw^2']
-        )
+        fields.append('title_*.ngram')
+        fields.append('title_*.raw^2')
     else:
         # if a language is given, boost the fields for the language
-        fields = []
         for lang in default_langs:
             if lang == search_lang:
                 fields.append('title_{0}.ngram^2'.format(lang))
@@ -99,11 +96,11 @@ def get_text_query_on_title(search_term, search_lang=None):
                 fields.append('title_{0}.ngram'.format(lang))
                 fields.append('title_{0}.raw^2'.format(lang))
 
-        return MultiMatch(
-            query=search_term,
-            operator='and',
-            fields=fields
-        )
+    return MultiMatch(
+        query=search_term,
+        operator='and',
+        fields=fields
+    )
 
 
 search_documents = {

--- a/c2corg_api/search/__init__.py
+++ b/c2corg_api/search/__init__.py
@@ -88,6 +88,7 @@ def get_text_query(search_term, lang=None):
         should=[
             MultiMatch(
                 query=search_term,
+                type='phrase',
                 fields=['summary*^2', 'description*'], boost=0.5),
             get_text_query_on_title(search_term, lang)
         ])
@@ -98,6 +99,7 @@ def get_text_query_on_title(search_term, search_lang=None):
     if not search_lang:
         return MultiMatch(
             query=search_term,
+            type='phrase',
             fields=['title_*.ngram', 'title_*.raw^2']
         )
     else:
@@ -111,7 +113,7 @@ def get_text_query_on_title(search_term, search_lang=None):
                 fields.append('title_{0}.ngram'.format(lang))
                 fields.append('title_{0}.raw^2'.format(lang))
 
-        return MultiMatch(query=search_term, fields=fields)
+        return MultiMatch(query=search_term,type='phrase',fields=fields)
 
 
 search_documents = {

--- a/c2corg_api/search/__init__.py
+++ b/c2corg_api/search/__init__.py
@@ -98,6 +98,7 @@ def get_text_query_on_title(search_term, search_lang=None):
 
     return MultiMatch(
         query=search_term,
+        fuzziness='auto',
         operator='and',
         fields=fields
     )


### PR DESCRIPTION
Hello,

This PR fixes #755 and #557.

The bug was due to a bad multi-match request. Here, we want to search for the whole phrase instead of a list of separate words. By adding `operator="and"` (see [doc](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-multi-match-query.html#operator-min)), the issue is solved.

I also added the `fuzziness=auto` parameter (see [doc](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-match-query.html#query-dsl-match-query-fuzziness)) to allow misspellings.

At this point, it looks OK but there is still a minor point:
<img width="1262" alt="Capture d’écran 2022-09-28 à 23 59 45" src="https://user-images.githubusercontent.com/22117220/192896401-78bbdd1e-3816-446e-94a2-a7f7bbb6150a.png">

We want the 5th result to be the 1st want as we typed `traversée des calanques`. Due to fuzziness, the first 6 results are "equivalent". It looks like the 5th result is after because it has only one available locale `fr` (but I can't find the real cause as multi_match is using `type=best_field` which keeps only the best field score for each document: only `score(title_fr)` and not `score(title_fr) + score(title_en)`)
Ideally, we would use `fuzziness=auto` and `type=phrase` in order to keep the words order into account. But this is not working.

**Possible next steps**:
- We say it's OK like that
- We investigate [span queries ](https://stackoverflow.com/questions/53652765/elastic-search-match-phrase-fuzziness)