### PR TITLE
Possibility to specify webp or avif format in image proxy

### DIFF
--- a/c2corg_api/tests/views/test_image.py
+++ b/c2corg_api/tests/views/test_image.py
@@ -1038,3 +1038,23 @@ class TestImageProxyRest(BaseTestRest):
                             format(self.image2.document_id),
                             status=302)
         self.assertIn('imageBI.jpg', resp.headers['Location'])
+
+    def test_bad_extension(self):
+        resp = self.app.get('/images/proxy/{}?size=BI&extension=badextension'.
+                            format(self.image.document_id),
+                            status=400)
+        errors = resp.json.get('errors')
+        self.assertEqual('invalid extension', errors[0].get('description'))
+
+    def test_format_without_size(self):
+        resp = self.app.get('/images/proxy/{}?extension=webp'.
+                            format(self.image.document_id),
+                            status=400)
+        errors = resp.json.get('errors')
+        self.assertEqual('invalid extension', errors[0].get('description'))
+
+    def test_format_with_size(self):
+        resp = self.app.get('/images/proxy/{}?size=BI&extension=avif'.
+                            format(self.image.document_id),
+                            status=302)
+        self.assertIn('imageBI.avif', resp.headers['Location'])


### PR DESCRIPTION
The proxy endpoint is used in order to get the image url from it's id.
This is especially used when including images in document via markdown.

This change is for preparing for future support of webp and avif format.