### PR TITLE
ci: inject {{ github.sha }}

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,4 +123,4 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           build-args: |
-            VERSION=$GITHUB_SHA
+            VERSION=${{ github.sha }}


### PR DESCRIPTION
"${GITHUB_SHA}" is ok for regular steps but in this case we need to use its variant "{{ github.sha }}" for workflow processing.

<hr>


```
$ podman run --rm -ti c2corg/v6_api:master cat common.ini | grep version
cache_version = ITHUB_SHA
cache_version_timestamp = False
$ podman run --rm -ti ghcr.io/tormath1/v6_api:tormath1-fix-version cat common.ini | grep version
cache_version = 0f0a2e61cca2899935e07ceec9ac207a93b34f3a
cache_version_timestamp = False
```

As `/health` consumes the `cache_version`:
https://github.com/c2corg/v6_api/blob/c89058da8727444ec9538fbe320c986a41c2d0ac/c2corg_api/views/health.py#L34-L36

it should now return the correct version.

Closes https://github.com/c2corg/v6_api/issues/1470