### PR TITLE
feat: increment documents views using Redis queue and scheduled job

### DIFF
--- a/alembic_migration/versions/2d710311ac56_add_view_count_to_document.py
+++ b/alembic_migration/versions/2d710311ac56_add_view_count_to_document.py
@@ -1,0 +1,30 @@
+"""add view count to document
+
+Revision ID: 2d710311ac56
+Revises: 305b064bdf66
+Create Date: 2024-01-08 13:28:50.090334
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2d710311ac56'
+down_revision = '305b064bdf66'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column(
+        'documents',
+        sa.Column(
+            'view_count',
+            sa.Integer(),
+            nullable=False,
+            server_default='0',
+        ),
+        schema='guidebook')
+
+def downgrade():
+    op.drop_column('documents', 'view_count', schema='guidebook')

--- a/c2corg_api/__init__.py
+++ b/c2corg_api/__init__.py
@@ -6,7 +6,8 @@ from sqlalchemy import engine_from_config, exc, event
 from sqlalchemy.pool import Pool
 
 from c2corg_api.models import DBSession, Base
-from c2corg_api.search import configure_es_from_config, get_queue_config
+from c2corg_api.queues.queues_service import get_queue_config
+from c2corg_api.search import configure_es_from_config
 
 from pyramid.security import Allow, Everyone, Authenticated
 
@@ -41,7 +42,18 @@ def main(global_config, **settings):
 
     config = Configurator(settings=settings)
     config.include('cornice')
-    config.registry.queue_config = get_queue_config(settings)
+    config.registry.queue_config = get_queue_config(
+        settings,
+        settings['redis.queue_es_sync']
+    )
+
+    # Configure documents views queue
+    config.registry.documents_views_queue_config = (
+        get_queue_config(
+            settings,
+            settings['redis.queue_documents_views_sync']
+        )
+    )
 
     # FIXME? Make sure this tween is run after the JWT validation
     # Using an explicit ordering in config files might be needed.

--- a/c2corg_api/crawler/crawler_service.py
+++ b/c2corg_api/crawler/crawler_service.py
@@ -1,0 +1,42 @@
+# Based on https://github.com/monperrus/crawler-user-agents
+# and https://stackoverflow.com/a/33941034
+import re
+
+bot_pattern = (
+    r"(googlebot\/|bot|Googlebot-Mobile|Googlebot-Image|Google "
+    r"favicon|Mediapartners-Google|bingbot|slurp|java|wget|curl|"
+    r"Commons-HttpClient|Python-urllib|libwww|httpunit|nutch|phpcrawl|"
+    r"msnbot|jyxobot|FAST-WebCrawler|FAST Enterprise Crawler|biglotron|"
+    r"teoma|convera|seekbot|gigablast|exabot|ngbot|ia_archiver|"
+    r"GingerCrawler|webmon |httrack|webcrawler|grub.org|"
+    r"UsineNouvelleCrawler|antibot|netresearchserver|speedy|fluffy|"
+    r"bibnum.bnf|findlink|msrbot|panscient|yacybot|AISearchBot|IOI|"
+    r"ips-agent|tagoobot|MJ12bot|dotbot|woriobot|yanga|buzzbot|mlbot|"
+    r"yandexbot|purebot|Linguee Bot|Voyager|CyberPatrol|voilabot|"
+    r"baiduspider|citeseerxbot|spbot|twengabot|postrank|turnitinbot|"
+    r"scribdbot|page2rss|sitebot|linkdex|Adidxbot|blekkobot|ezooms|"
+    r"dotbot|Mail.RU_Bot|discobot|heritrix|findthatfile|europarchive.org|"
+    r"NerdByNature.Bot|sistrix crawler|ahrefsbot|Aboundex|domaincrawler|"
+    r"wbsearchbot|summify|ccbot|edisterbot|seznambot|ec2linkfinder|"
+    r"gslfbot|aihitbot|intelium_bot|facebookexternalhit|yeti|"
+    r"RetrevoPageAnalyzer|lb-spider|sogou|lssbot|careerbot|wotbox|wocbot|"
+    r"ichiro|DuckDuckBot|lssrocketcrawler|drupact|webcompanycrawler|"
+    r"acoonbot|openindexspider|gnam gnam spider|web-archive-net.com.bot|"
+    r"backlinkcrawler|coccoc|integromedb|content crawler spider|"
+    r"toplistbot|seokicks-robot|it2media-domain-crawler|ip-web-crawler.com|"
+    r"siteexplorer.info|elisabot|proximic|changedetection|blexbot|"
+    r"arabot|WeSEE:Search|niki-bot|CrystalSemanticsBot|rogerbot|360Spider|"
+    r"psbot|InterfaxScanBot|Lipperhey SEO Service|CC Metadata Scaper|"
+    r"g00g1e.net|GrapeshotCrawler|urlappendbot|brainobot|fr-crawler|"
+    r"binlar|SimpleCrawler|Livelapbot|Twitterbot|cXensebot|smtbot|"
+    r"bnf.fr_bot|A6-Indexer|ADmantX|Facebot|Twitterbot|OrangeBot|"
+    r"memorybot|AdvBot|MegaIndex|SemanticScholarBot|ltx71|nerdybot|"
+    r"xovibot|BUbiNG|Qwantify|archive.org_bot|Applebot|TweetmemeBot|"
+    r"crawler4j|findxbot|SemrushBot|yoozBot|lipperhey|y!j-asr|"
+    r"Domain Re-Animator Bot|AddThis)"
+)
+
+
+def is_crawler(user_agent):
+    bot_regex = re.compile(bot_pattern, re.IGNORECASE)
+    return bot_regex.search(user_agent)

--- a/c2corg_api/jobs/__init__.py
+++ b/c2corg_api/jobs/__init__.py
@@ -4,6 +4,7 @@ from apscheduler.events import EVENT_JOB_ERROR
 
 from c2corg_api.jobs.purge_non_activated_accounts import purge_account
 from c2corg_api.jobs.purge_expired_tokens import purge_token
+from c2corg_api.jobs.increment_documents_views import increment_documents_views
 
 import logging
 log = logging.getLogger(__name__)
@@ -35,6 +36,16 @@ def configure_scheduler_from_config(settings):
         trigger='cron',
         hour=0,
         minute=30
+    )
+
+    # run `increment_documents_views` job every 5 minutes
+    scheduler.add_job(
+        increment_documents_views,
+        args=[settings],
+        id='increment_documents_views',
+        name='Increment documents views',
+        trigger='interval',
+        minutes=5
     )
 
     scheduler.add_listener(exception_listener, EVENT_JOB_ERROR)

--- a/c2corg_api/jobs/increment_documents_views.py
+++ b/c2corg_api/jobs/increment_documents_views.py
@@ -1,0 +1,63 @@
+import logging
+from c2corg_api import get_queue_config
+from sqlalchemy import engine_from_config, text
+from c2corg_api.queues.queues_service import consume_all_messages
+from sqlalchemy.orm import (
+    scoped_session,
+    sessionmaker,
+)
+from collections import Counter
+import math
+import time
+
+log = logging.getLogger(__name__)
+
+# The max number of documents to update per transaction
+MAX_REQ = 4000
+
+# The number of seconds to wait between each transaction
+SLEEP_TIME = 2
+
+# Bulk update base statement
+BASE_STMT = """
+    UPDATE guidebook.documents
+    SET view_count = documents.view_count + updates.view_count
+    FROM (VALUES
+        {stmt_values}
+        ) AS updates(document_id, view_count)
+    WHERE documents.document_id = updates.document_id;
+"""
+
+
+def increment_documents_views(settings, test_session=None):
+    queue = settings['redis.queue_documents_views_sync']
+    queue_config = get_queue_config(settings, queue)
+
+    def process_task(doc_ids):
+        engine = engine_from_config(settings, 'sqlalchemy.')
+        db_session = scoped_session(sessionmaker(bind=engine))
+        session = db_session() if not test_session else test_session
+
+        if len(doc_ids) != 0:
+            doc_views = list(Counter(doc_ids).items())
+            max_iteration = math.ceil(len(doc_views) / MAX_REQ)
+            for i in range(max_iteration):
+                docs = []
+                for id, count in doc_views[i * MAX_REQ:(i + 1) * MAX_REQ]:
+                    docs.append({
+                     'document_id': id,
+                     'view_count': count
+                    })
+                stmt_values = ", ".join(
+                 f"({doc['document_id']}, {doc['view_count']})"
+                 for doc in docs
+                )
+                stmt = text(BASE_STMT.format(stmt_values=stmt_values))
+                session.execute(stmt)
+                session.commit()
+                docs.clear()
+                if max_iteration > 1 and i != max_iteration - 1:
+                    # Sleep to prevent blocking other transactions
+                    time.sleep(SLEEP_TIME)
+
+    consume_all_messages(queue_config, process_task)

--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -76,6 +76,7 @@ class Document(Base, _DocumentMixin):
     """
     __tablename__ = 'documents'
     document_id = Column(Integer, primary_key=True)
+    view_count = Column(Integer, nullable=False, server_default='0')
 
     locales = relationship('DocumentLocale')
     geometry = relationship('DocumentGeometry', uselist=False)

--- a/c2corg_api/queues/queues_service.py
+++ b/c2corg_api/queues/queues_service.py
@@ -1,0 +1,89 @@
+from kombu import Exchange, Queue, pools
+from kombu.connection import Connection
+from kombu.pools import producers
+from queue import Empty
+from kombu.exceptions import TimeoutError
+import logging
+
+log = logging.getLogger('c2corg_api_queues')
+
+
+def get_queue_config(settings, queue):
+    # set the number of connections to Redis
+    pools.set_limit(int(settings['redis.queue_pool']))
+
+    class QueueConfiguration(object):
+        def __init__(self, settings):
+            self.connection = Connection(
+                settings['redis.url'],
+                virtual_host=settings['redis.db_queue']
+            )
+            self.routing_key = queue
+            self.exchange = Exchange(settings['redis.exchange'], type='direct')
+            self.queue = Queue(
+                queue,
+                self.exchange,
+                routing_key=self.routing_key
+            )
+
+    return QueueConfiguration(settings)
+
+
+def publish(queue_config, message):
+    def retry(channel):
+        """ Try to re-create the Redis queue on connection errors.
+        """
+        try:
+            # try to unbind the queue, ignore errors
+            channel.queue_unbind(
+                queue_config.queue.name,
+                exchange=queue_config.exchange.name)
+        except Exception:
+            pass
+
+        # the re-create the queue
+        channel.queue_bind(
+            queue_config.queue.name, exchange=queue_config.exchange.name)
+
+    with producers[queue_config.connection].acquire(
+            block=True, timeout=3) as producer:
+        producer.publish(
+            message,
+            exchange=queue_config.exchange,
+            declare=[queue_config.exchange, queue_config.queue],
+            retry=True,
+            retry_policy={'max_retries': 3, 'on_revive': retry},
+            routing_key=queue_config.routing_key
+        )
+
+
+def consume_all_messages(queue_config, process_task):
+    bodies = []
+    messages = []
+
+    def populate_messages(body, message):
+        bodies.append(body)
+        messages.append(message)
+
+    with queue_config.connection as connection:
+        with connection.Consumer(
+                queues=queue_config.queue,
+                callbacks=[populate_messages]
+        ):
+            try:
+                while True:
+                    connection.drain_events(timeout=1)
+            except KeyboardInterrupt:
+                pass
+            except Empty:
+                log.info('No message in the queue')
+                pass
+            except TimeoutError:
+                log.info('Queue timeout')
+                pass
+            try:
+                process_task(bodies)
+                for message in messages:
+                    message.ack()
+            except Exception as exc:
+                log.error('Queue task raised exception: %r', exc)

--- a/c2corg_api/scripts/es/syncer.py
+++ b/c2corg_api/scripts/es/syncer.py
@@ -1,8 +1,9 @@
 import logging
 import sys
 import os
+from c2corg_api.queues.queues_service import get_queue_config
 from c2corg_api.scripts.es.sync import sync_es
-from c2corg_api.search import configure_es_from_config, get_queue_config
+from c2corg_api.search import configure_es_from_config
 from pyramid.scripts.common import parse_vars
 from pyramid.paster import get_appsettings, setup_logging
 from sqlalchemy import engine_from_config
@@ -79,7 +80,7 @@ def main(argv=sys.argv):
     Session = sessionmaker()  # noqa
     Session.configure(bind=engine)
     configure_es_from_config(settings)
-    queue_config = get_queue_config(settings)
+    queue_config = get_queue_config(settings, settings['redis.queue_es_sync'])
     batch_size = int(settings.get('elasticsearch.batch_size.syncer', 1000))
 
     with queue_config.connection:

--- a/c2corg_api/search/__init__.py
+++ b/c2corg_api/search/__init__.py
@@ -23,8 +23,6 @@ from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.connections import connections
 from elasticsearch_dsl.query import MultiMatch
-from kombu import Exchange, Queue, pools
-from kombu.connection import Connection
 
 # the maximum number of documents that can be returned for each document type
 SEARCH_LIMIT_MAX = 50
@@ -56,22 +54,6 @@ def configure_es_from_config(settings):
     elasticsearch_config['index'] = settings['elasticsearch.index']
     elasticsearch_config['host'] = settings['elasticsearch.host']
     elasticsearch_config['port'] = int(settings['elasticsearch.port'])
-
-
-def get_queue_config(settings):
-    # set the number of connections to Redis
-    pools.set_limit(int(settings['redis.queue_pool']))
-
-    class QueueConfiguration(object):
-        def __init__(self, settings):
-            self.connection = Connection(
-                settings['redis.url'],
-                virtual_host=settings['redis.db_queue']
-            )
-            self.exchange = Exchange(settings['redis.exchange'], type='direct')
-            self.queue = Queue(settings['redis.queue_es_sync'], self.exchange)
-
-    return QueueConfiguration(settings)
 
 
 def create_search(document_type):

--- a/c2corg_api/security/roles.py
+++ b/c2corg_api/security/roles.py
@@ -72,7 +72,8 @@ def create_claims(user, exp):
     return {
         'sub': user.id,
         'username': user.username,
-        'exp': int((exp - datetime.datetime(1970, 1, 1)).total_seconds())
+        'robot': user.robot,
+        'exp': int((exp - datetime.datetime(1970, 1, 1)).total_seconds()),
     }
 
 

--- a/common.ini.in
+++ b/common.ini.in
@@ -32,6 +32,7 @@ redis.db_cache = {redis_db_cache}
 # queue configuration
 redis.exchange = {redis_exchange}
 redis.queue_es_sync = {redis_queue_es}
+redis.queue_documents_views_sync = {redis_queue_documents_views}
 redis.queue_pool = 20
 
 # cache configuration

--- a/config/default
+++ b/config/default
@@ -25,6 +25,7 @@ export redis_db_queue = 4
 export redis_db_cache = 5
 export redis_exchange = c2corg_$(instanceid)
 export redis_queue_es = c2corg_$(instanceid)_es_sync
+export redis_queue_documents_views = c2corg_$(instanceid)_documents_views_sync
 export redis_cache_key_prefix = c2corg_$(instanceid)
 export redis_cache_status_refresh_period = 30
 


### PR DESCRIPTION
The beginning of a potential solution for https://github.com/c2corg/c2c_ui/issues/2648.

~~I've taken some chunk of code written by @jaweherCherif here https://github.com/c2corg/v6_api/pull/1502 for the moment.~~

## In a nutshell

Taking into account @cbeauchesne 's [comment](https://github.com/c2corg/v6_api/pull/1502#issuecomment-1413555114)  + the [specs](https://forum.camptocamp.org/t/cahier-des-charges-compteur-de-vues-pour-les-sorties/305151/18?u=loic_p) from the forum I've used a Redis queue (created similarly to the one used by the syncer) to buffer all the documents viewed and created a job (similar to the 2 background jobs) that update the documents views every 5 minutes (<-- interval chosen randomly for now). The counter of each document viewed is increase only if the client is not a c2c bot or a crawler.  

## Bulk update

For the moment each bulk update query will update 4000 documents max by default. So if we have to update an amount of docs > 4000 it will be divided into several bulk update query that will update 4000 documents max each.

## Performance

Here is a small project to have an idea of how much time it gets to perform the bulk updates using this approach:
https://github.com/florentcadot/c2c-update-view-counter-benchmark/tree/master.
The idea is just to push some documents ids to a Redis Queue, perform the bulk update and measure the amount of time required to perform this update thanks to sqlalchemy [profiling](https://docs.sqlalchemy.org/en/13/faq/performance.html#query-profiling). It uses the same dev database and same libs versions than this project.
It is possible to change the number of docs to update and the bulk update amount (4000 by default from now) to try to find a sweet spot.

Here are some results:
- For 100 documents to update:  **0.001287s**   
- For 1000 documents to update: **0.011257s**
- For 10000 documents to update:  **0.076611s** (bulk update of 4000 docs n°1) **0.040134s** (bulk update of 4000 docs n°2)  **0.015170s** (bulk update of 2000 docs n°3) 

## In another PR:

See https://github.com/c2corg/v6_api/pull/1731

- [x] Update API route to allow authorized users (ACL management) to update ~~`enable_view_count`~~ `disable_view_count state` 
- [x] Get API route to allow authorized users (ACL management) to read the counter of a document if ~~`enable_view_count`~~ `disable_view_count` is ~~True~~ False       

Feel free to give a feedback anytime :smile:   

EDIT: use `disable_view_count` instead of `enable_view_count` to be consistent with `disable_comments` outing column and add other PR link 