### PR TITLE
feat: get outing views and update disable view count

### DIFF
--- a/alembic_migration/versions/2d710311ac56_add_view_count_to_document.py
+++ b/alembic_migration/versions/2d710311ac56_add_view_count_to_document.py
@@ -1,0 +1,30 @@
+"""add view count to document
+
+Revision ID: 2d710311ac56
+Revises: 305b064bdf66
+Create Date: 2024-01-08 13:28:50.090334
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2d710311ac56'
+down_revision = '305b064bdf66'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column(
+        'documents',
+        sa.Column(
+            'view_count',
+            sa.Integer(),
+            nullable=False,
+            server_default='0',
+        ),
+        schema='guidebook')
+
+def downgrade():
+    op.drop_column('documents', 'view_count', schema='guidebook')

--- a/alembic_migration/versions/abae46fab037_add_disable_view_count_to_document.py
+++ b/alembic_migration/versions/abae46fab037_add_disable_view_count_to_document.py
@@ -1,0 +1,34 @@
+"""Add disable view count to document
+
+Revision ID: abae46fab037
+Revises: 2d710311ac56
+Create Date: 2024-01-19 08:05:11.433263
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'abae46fab037'
+down_revision = '2d710311ac56'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column(
+        'documents',
+        sa.Column(
+            'disable_view_count',
+            sa.Boolean(),
+            nullable=False,
+            server_default='false',
+        ),
+        schema='guidebook')
+    query = """
+        UPDATE guidebook.documents
+        SET disable_view_count = true;"""
+    op.execute(query)
+
+def downgrade():
+    op.drop_column('documents', 'disable_view_count', schema='guidebook')

--- a/c2corg_api/__init__.py
+++ b/c2corg_api/__init__.py
@@ -6,7 +6,8 @@ from sqlalchemy import engine_from_config, exc, event
 from sqlalchemy.pool import Pool
 
 from c2corg_api.models import DBSession, Base
-from c2corg_api.search import configure_es_from_config, get_queue_config
+from c2corg_api.queues.queues_service import get_queue_config
+from c2corg_api.search import configure_es_from_config
 
 from pyramid.security import Allow, Everyone, Authenticated
 
@@ -41,7 +42,18 @@ def main(global_config, **settings):
 
     config = Configurator(settings=settings)
     config.include('cornice')
-    config.registry.queue_config = get_queue_config(settings)
+    config.registry.queue_config = get_queue_config(
+        settings,
+        settings['redis.queue_es_sync']
+    )
+
+    # Configure documents views queue
+    config.registry.documents_views_queue_config = (
+        get_queue_config(
+            settings,
+            settings['redis.queue_documents_views_sync']
+        )
+    )
 
     # FIXME? Make sure this tween is run after the JWT validation
     # Using an explicit ordering in config files might be needed.

--- a/c2corg_api/crawler/crawler_service.py
+++ b/c2corg_api/crawler/crawler_service.py
@@ -1,0 +1,42 @@
+# Based on https://github.com/monperrus/crawler-user-agents
+# and https://stackoverflow.com/a/33941034
+import re
+
+bot_pattern = (
+    r"(googlebot\/|bot|Googlebot-Mobile|Googlebot-Image|Google "
+    r"favicon|Mediapartners-Google|bingbot|slurp|java|wget|curl|"
+    r"Commons-HttpClient|Python-urllib|libwww|httpunit|nutch|phpcrawl|"
+    r"msnbot|jyxobot|FAST-WebCrawler|FAST Enterprise Crawler|biglotron|"
+    r"teoma|convera|seekbot|gigablast|exabot|ngbot|ia_archiver|"
+    r"GingerCrawler|webmon |httrack|webcrawler|grub.org|"
+    r"UsineNouvelleCrawler|antibot|netresearchserver|speedy|fluffy|"
+    r"bibnum.bnf|findlink|msrbot|panscient|yacybot|AISearchBot|IOI|"
+    r"ips-agent|tagoobot|MJ12bot|dotbot|woriobot|yanga|buzzbot|mlbot|"
+    r"yandexbot|purebot|Linguee Bot|Voyager|CyberPatrol|voilabot|"
+    r"baiduspider|citeseerxbot|spbot|twengabot|postrank|turnitinbot|"
+    r"scribdbot|page2rss|sitebot|linkdex|Adidxbot|blekkobot|ezooms|"
+    r"dotbot|Mail.RU_Bot|discobot|heritrix|findthatfile|europarchive.org|"
+    r"NerdByNature.Bot|sistrix crawler|ahrefsbot|Aboundex|domaincrawler|"
+    r"wbsearchbot|summify|ccbot|edisterbot|seznambot|ec2linkfinder|"
+    r"gslfbot|aihitbot|intelium_bot|facebookexternalhit|yeti|"
+    r"RetrevoPageAnalyzer|lb-spider|sogou|lssbot|careerbot|wotbox|wocbot|"
+    r"ichiro|DuckDuckBot|lssrocketcrawler|drupact|webcompanycrawler|"
+    r"acoonbot|openindexspider|gnam gnam spider|web-archive-net.com.bot|"
+    r"backlinkcrawler|coccoc|integromedb|content crawler spider|"
+    r"toplistbot|seokicks-robot|it2media-domain-crawler|ip-web-crawler.com|"
+    r"siteexplorer.info|elisabot|proximic|changedetection|blexbot|"
+    r"arabot|WeSEE:Search|niki-bot|CrystalSemanticsBot|rogerbot|360Spider|"
+    r"psbot|InterfaxScanBot|Lipperhey SEO Service|CC Metadata Scaper|"
+    r"g00g1e.net|GrapeshotCrawler|urlappendbot|brainobot|fr-crawler|"
+    r"binlar|SimpleCrawler|Livelapbot|Twitterbot|cXensebot|smtbot|"
+    r"bnf.fr_bot|A6-Indexer|ADmantX|Facebot|Twitterbot|OrangeBot|"
+    r"memorybot|AdvBot|MegaIndex|SemanticScholarBot|ltx71|nerdybot|"
+    r"xovibot|BUbiNG|Qwantify|archive.org_bot|Applebot|TweetmemeBot|"
+    r"crawler4j|findxbot|SemrushBot|yoozBot|lipperhey|y!j-asr|"
+    r"Domain Re-Animator Bot|AddThis)"
+)
+
+
+def is_crawler(user_agent):
+    bot_regex = re.compile(bot_pattern, re.IGNORECASE)
+    return bot_regex.search(user_agent)

--- a/c2corg_api/jobs/__init__.py
+++ b/c2corg_api/jobs/__init__.py
@@ -4,6 +4,7 @@ from apscheduler.events import EVENT_JOB_ERROR
 
 from c2corg_api.jobs.purge_non_activated_accounts import purge_account
 from c2corg_api.jobs.purge_expired_tokens import purge_token
+from c2corg_api.jobs.increment_documents_views import increment_documents_views
 
 import logging
 log = logging.getLogger(__name__)
@@ -35,6 +36,16 @@ def configure_scheduler_from_config(settings):
         trigger='cron',
         hour=0,
         minute=30
+    )
+
+    # run `increment_documents_views` job every 5 minutes
+    scheduler.add_job(
+        increment_documents_views,
+        args=[settings],
+        id='increment_documents_views',
+        name='Increment documents views',
+        trigger='interval',
+        minutes=5
     )
 
     scheduler.add_listener(exception_listener, EVENT_JOB_ERROR)

--- a/c2corg_api/jobs/increment_documents_views.py
+++ b/c2corg_api/jobs/increment_documents_views.py
@@ -1,0 +1,63 @@
+import logging
+from c2corg_api import get_queue_config
+from sqlalchemy import engine_from_config, text
+from c2corg_api.queues.queues_service import consume_all_messages
+from sqlalchemy.orm import (
+    scoped_session,
+    sessionmaker,
+)
+from collections import Counter
+import math
+import time
+
+log = logging.getLogger(__name__)
+
+# The max number of documents to update per transaction
+MAX_REQ = 4000
+
+# The number of seconds to wait between each transaction
+SLEEP_TIME = 2
+
+# Bulk update base statement
+BASE_STMT = """
+    UPDATE guidebook.documents
+    SET view_count = documents.view_count + updates.view_count
+    FROM (VALUES
+        {stmt_values}
+        ) AS updates(document_id, view_count)
+    WHERE documents.document_id = updates.document_id;
+"""
+
+
+def increment_documents_views(settings, test_session=None):
+    queue = settings['redis.queue_documents_views_sync']
+    queue_config = get_queue_config(settings, queue)
+
+    def process_task(doc_ids):
+        engine = engine_from_config(settings, 'sqlalchemy.')
+        db_session = scoped_session(sessionmaker(bind=engine))
+        session = db_session() if not test_session else test_session
+
+        if len(doc_ids) != 0:
+            doc_views = list(Counter(doc_ids).items())
+            max_iteration = math.ceil(len(doc_views) / MAX_REQ)
+            for i in range(max_iteration):
+                docs = []
+                for id, count in doc_views[i * MAX_REQ:(i + 1) * MAX_REQ]:
+                    docs.append({
+                     'document_id': id,
+                     'view_count': count
+                    })
+                stmt_values = ", ".join(
+                 f"({doc['document_id']}, {doc['view_count']})"
+                 for doc in docs
+                )
+                stmt = text(BASE_STMT.format(stmt_values=stmt_values))
+                session.execute(stmt)
+                session.commit()
+                docs.clear()
+                if max_iteration > 1 and i != max_iteration - 1:
+                    # Sleep to prevent blocking other transactions
+                    time.sleep(SLEEP_TIME)
+
+    consume_all_messages(queue_config, process_task)

--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -76,6 +76,7 @@ class Document(Base, _DocumentMixin):
     """
     __tablename__ = 'documents'
     document_id = Column(Integer, primary_key=True)
+    view_count = Column(Integer, nullable=False, server_default='0')
 
     locales = relationship('DocumentLocale')
     geometry = relationship('DocumentGeometry', uselist=False)

--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -77,6 +77,10 @@ class Document(Base, _DocumentMixin):
     __tablename__ = 'documents'
     document_id = Column(Integer, primary_key=True)
     view_count = Column(Integer, nullable=False, server_default='0')
+    disable_view_count = Column(
+        Boolean,
+        nullable=False,
+        server_default='false')
 
     locales = relationship('DocumentLocale')
     geometry = relationship('DocumentGeometry', uselist=False)

--- a/c2corg_api/models/document.py
+++ b/c2corg_api/models/document.py
@@ -27,7 +27,7 @@ from sqlalchemy.orm import relationship, column_property
 from sqlalchemy.sql.schema import UniqueConstraint
 
 UpdateType = enum.Enum(
-    'UpdateType', 'FIGURES LANG GEOM')
+    'UpdateType', 'FIGURES LANG GEOM DISABLE_VIEW_COUNT')
 
 DOCUMENT_TYPE = document_types.DOCUMENT_TYPE
 
@@ -147,7 +147,8 @@ class Document(Base, _DocumentMixin):
             'locales': {
                 locale.lang: locale.version for locale in self.locales
             },
-            'geometry': self.geometry.version if self.geometry else None
+            'geometry': self.geometry.version if self.geometry else None,
+            'disable_view_count': self.disable_view_count
         }
 
     def get_update_type(self, old_versions):
@@ -162,7 +163,8 @@ class Document(Base, _DocumentMixin):
         figures_equal = self.version == old_versions['document']
         geom_equal = self.geometry.version == old_versions['geometry'] if \
             self.geometry else old_versions['geometry'] is None
-
+        disable_view_count_equal = \
+            self.disable_view_count == old_versions['disable_view_count']
         changed_langs = []
         locale_versions = old_versions['locales']
         for locale in self.locales:
@@ -179,6 +181,8 @@ class Document(Base, _DocumentMixin):
             update_types.append(UpdateType.GEOM)
         if changed_langs:
             update_types.append(UpdateType.LANG)
+        if disable_view_count_equal:
+            update_types.append(UpdateType.DISABLE_VIEW_COUNT)
 
         return (update_types, changed_langs)
 

--- a/c2corg_api/models/outing.py
+++ b/c2corg_api/models/outing.py
@@ -119,6 +119,8 @@ attributes = [
     'via_ferrata_rating', 'mtb_up_rating', 'mtb_down_rating'
     ]
 
+document_outing_attribute = ['view_count', 'disable_view_count']
+
 
 class Outing(_OutingMixin, Document):
     """
@@ -238,11 +240,7 @@ schema_outing_locale = SQLAlchemySchemaNode(
         }
     })
 
-schema_outing = SQLAlchemySchemaNode(
-    Outing,
-    # whitelisted attributes
-    includes=schema_attributes + attributes,
-    overrides={
+schema_outing_overrides = {
         'document_id': {
             'missing': None
         },
@@ -257,7 +255,21 @@ schema_outing = SQLAlchemySchemaNode(
         },
         'geometry': get_geometry_schema_overrides(
             ['LINESTRING', 'MULTILINESTRING'])
-    })
+    }
+
+schema_outing = SQLAlchemySchemaNode(
+    Outing,
+    # whitelisted attributes
+    includes=schema_attributes + attributes + document_outing_attribute,
+    overrides=schema_outing_overrides
+)
+
+schema_outing_collection = SQLAlchemySchemaNode(
+    Outing,
+    # whitelisted attributes
+    includes=schema_attributes + attributes,
+    overrides=schema_outing_overrides
+)
 
 schema_create_outing = get_create_schema(schema_outing)
 schema_update_outing = get_update_schema(schema_outing)

--- a/c2corg_api/models/schema_utils.py
+++ b/c2corg_api/models/schema_utils.py
@@ -1,6 +1,12 @@
 from colander import MappingSchema, SchemaNode, String, Integer, Sequence
 
-default_fields_doc = ['document_id', 'version', 'waypoint_type']
+default_fields_doc = [
+    'document_id',
+    'version',
+    'waypoint_type',
+    'disable_view_count',
+    'view_count'
+]
 default_fields_locale = ['version', 'lang']
 default_fields_geometry = ['version']
 

--- a/c2corg_api/queues/queues_service.py
+++ b/c2corg_api/queues/queues_service.py
@@ -1,0 +1,89 @@
+from kombu import Exchange, Queue, pools
+from kombu.connection import Connection
+from kombu.pools import producers
+from queue import Empty
+from kombu.exceptions import TimeoutError
+import logging
+
+log = logging.getLogger('c2corg_api_queues')
+
+
+def get_queue_config(settings, queue):
+    # set the number of connections to Redis
+    pools.set_limit(int(settings['redis.queue_pool']))
+
+    class QueueConfiguration(object):
+        def __init__(self, settings):
+            self.connection = Connection(
+                settings['redis.url'],
+                virtual_host=settings['redis.db_queue']
+            )
+            self.routing_key = queue
+            self.exchange = Exchange(settings['redis.exchange'], type='direct')
+            self.queue = Queue(
+                queue,
+                self.exchange,
+                routing_key=self.routing_key
+            )
+
+    return QueueConfiguration(settings)
+
+
+def publish(queue_config, message):
+    def retry(channel):
+        """ Try to re-create the Redis queue on connection errors.
+        """
+        try:
+            # try to unbind the queue, ignore errors
+            channel.queue_unbind(
+                queue_config.queue.name,
+                exchange=queue_config.exchange.name)
+        except Exception:
+            pass
+
+        # the re-create the queue
+        channel.queue_bind(
+            queue_config.queue.name, exchange=queue_config.exchange.name)
+
+    with producers[queue_config.connection].acquire(
+            block=True, timeout=3) as producer:
+        producer.publish(
+            message,
+            exchange=queue_config.exchange,
+            declare=[queue_config.exchange, queue_config.queue],
+            retry=True,
+            retry_policy={'max_retries': 3, 'on_revive': retry},
+            routing_key=queue_config.routing_key
+        )
+
+
+def consume_all_messages(queue_config, process_task):
+    bodies = []
+    messages = []
+
+    def populate_messages(body, message):
+        bodies.append(body)
+        messages.append(message)
+
+    with queue_config.connection as connection:
+        with connection.Consumer(
+                queues=queue_config.queue,
+                callbacks=[populate_messages]
+        ):
+            try:
+                while True:
+                    connection.drain_events(timeout=1)
+            except KeyboardInterrupt:
+                pass
+            except Empty:
+                log.info('No message in the queue')
+                pass
+            except TimeoutError:
+                log.info('Queue timeout')
+                pass
+            try:
+                process_task(bodies)
+                for message in messages:
+                    message.ack()
+            except Exception as exc:
+                log.error('Queue task raised exception: %r', exc)

--- a/c2corg_api/scripts/es/syncer.py
+++ b/c2corg_api/scripts/es/syncer.py
@@ -1,8 +1,9 @@
 import logging
 import sys
 import os
+from c2corg_api.queues.queues_service import get_queue_config
 from c2corg_api.scripts.es.sync import sync_es
-from c2corg_api.search import configure_es_from_config, get_queue_config
+from c2corg_api.search import configure_es_from_config
 from pyramid.scripts.common import parse_vars
 from pyramid.paster import get_appsettings, setup_logging
 from sqlalchemy import engine_from_config
@@ -79,7 +80,7 @@ def main(argv=sys.argv):
     Session = sessionmaker()  # noqa
     Session.configure(bind=engine)
     configure_es_from_config(settings)
-    queue_config = get_queue_config(settings)
+    queue_config = get_queue_config(settings, settings['redis.queue_es_sync'])
     batch_size = int(settings.get('elasticsearch.batch_size.syncer', 1000))
 
     with queue_config.connection:

--- a/c2corg_api/search/__init__.py
+++ b/c2corg_api/search/__init__.py
@@ -23,8 +23,6 @@ from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.connections import connections
 from elasticsearch_dsl.query import MultiMatch
-from kombu import Exchange, Queue, pools
-from kombu.connection import Connection
 
 # the maximum number of documents that can be returned for each document type
 SEARCH_LIMIT_MAX = 50
@@ -56,22 +54,6 @@ def configure_es_from_config(settings):
     elasticsearch_config['index'] = settings['elasticsearch.index']
     elasticsearch_config['host'] = settings['elasticsearch.host']
     elasticsearch_config['port'] = int(settings['elasticsearch.port'])
-
-
-def get_queue_config(settings):
-    # set the number of connections to Redis
-    pools.set_limit(int(settings['redis.queue_pool']))
-
-    class QueueConfiguration(object):
-        def __init__(self, settings):
-            self.connection = Connection(
-                settings['redis.url'],
-                virtual_host=settings['redis.db_queue']
-            )
-            self.exchange = Exchange(settings['redis.exchange'], type='direct')
-            self.queue = Queue(settings['redis.queue_es_sync'], self.exchange)
-
-    return QueueConfiguration(settings)
 
 
 def create_search(document_type):

--- a/c2corg_api/security/roles.py
+++ b/c2corg_api/security/roles.py
@@ -72,7 +72,8 @@ def create_claims(user, exp):
     return {
         'sub': user.id,
         'username': user.username,
-        'exp': int((exp - datetime.datetime(1970, 1, 1)).total_seconds())
+        'robot': user.robot,
+        'exp': int((exp - datetime.datetime(1970, 1, 1)).total_seconds()),
     }
 
 

--- a/c2corg_api/views/document.py
+++ b/c2corg_api/views/document.py
@@ -132,6 +132,12 @@ class DocumentRest(object):
 
         cache = cache_document_cooked if cook else cache_document_detail
 
+        claims = self.request.environ.get('jwtauth.claims', {})
+        is_bot = claims.get('robot', False)
+        user_agent = self.request.headers.get('User-Agent', '')
+        if not (is_bot or is_crawler(user_agent)):
+            publish(self.request.registry.documents_views_queue_config, id)
+
         def create_response():
             return self._get_in_lang(
                 id, lang, document_config.clazz, schema, editing_view,

--- a/c2corg_api/views/outing.py
+++ b/c2corg_api/views/outing.py
@@ -11,7 +11,8 @@ from c2corg_api.views.document import DocumentRest, make_validator_create, \
     make_validator_update
 from c2corg_api.views.document_info import DocumentInfoRest
 from c2corg_api.views.document_schemas import outing_documents_config, \
-    outing_schema_adaptor
+    outing_schema_adaptor, adapt_get_outing_response, \
+    outing_documents_collection_config
 from c2corg_api.views.document_version import DocumentVersionRest
 from c2corg_api.views.validation import validate_id, validate_pagination, \
     validate_lang, validate_version_id, validate_lang_param, \
@@ -130,14 +131,19 @@ class OutingRest(DocumentRest):
     @view(validators=[
         validate_pagination, validate_preferred_lang_param])
     def collection_get(self):
-        return self._collection_get(OUTING_TYPE, outing_documents_config)
+        return self._collection_get(
+            OUTING_TYPE,
+            outing_documents_collection_config,
+        )
 
     @view(validators=[validate_id, validate_lang_param, validate_cook_param])
     def get(self):
         return self._get(
             outing_documents_config,
             schema_outing,
-            adapt_schema=outing_schema_adaptor)
+            adapt_schema=outing_schema_adaptor,
+            adapt_response=adapt_get_outing_response
+        )
 
     @restricted_json_view(
         schema=schema_create_outing,

--- a/common.ini.in
+++ b/common.ini.in
@@ -32,6 +32,7 @@ redis.db_cache = {redis_db_cache}
 # queue configuration
 redis.exchange = {redis_exchange}
 redis.queue_es_sync = {redis_queue_es}
+redis.queue_documents_views_sync = {redis_queue_documents_views}
 redis.queue_pool = 20
 
 # cache configuration

--- a/config/default
+++ b/config/default
@@ -25,6 +25,7 @@ export redis_db_queue = 4
 export redis_db_cache = 5
 export redis_exchange = c2corg_$(instanceid)
 export redis_queue_es = c2corg_$(instanceid)_es_sync
+export redis_queue_documents_views = c2corg_$(instanceid)_documents_views_sync
 export redis_cache_key_prefix = c2corg_$(instanceid)
 export redis_cache_status_refresh_period = 30
 


### PR DESCRIPTION
The missing blocks to solve https://github.com/c2corg/c2c_ui/issues/2648, see https://github.com/c2corg/v6_api/pull/1726 description for more details.

## Important
This branch is based on what have been done in https://github.com/c2corg/v6_api/pull/1726. The code should not be reviewed and converted to a real PR until https://github.com/c2corg/v6_api/pull/1726 have been merged.

## What have been done
- [x] Update API route to allow authorized users (ACL management) to update disable_view_count state
- [x] Get API route to allow authorized users (ACL management) to read the counter of a document if disable_view_count is False