### PR TITLE
feat: add external_resources column to waypoints

### DIFF
--- a/alembic_migration/versions/626354ffcda0_add_column_external_resources_to_waypoints.py
+++ b/alembic_migration/versions/626354ffcda0_add_column_external_resources_to_waypoints.py
@@ -1,0 +1,37 @@
+"""add_column_external_resources_to_waypoints
+
+Revision ID: 626354ffcda0
+Revises: 305b064bdf66
+Create Date: 2024-02-18 08:36:44.714268
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '626354ffcda0'
+down_revision = '305b064bdf66'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column(
+        'waypoints_locales',
+        sa.Column(
+            'external_resources',
+            sa.String(),
+            nullable=True),
+        schema='guidebook')
+    op.add_column(
+        'waypoints_locales_archives',
+        sa.Column(
+            'external_resources',
+            sa.String(),
+            nullable=True),
+        schema='guidebook')
+
+
+def downgrade():
+    op.drop_column('waypoints_locales', 'external_resources', schema='guidebook')
+    op.drop_column('waypoints_locales_archives', 'external_resources', schema='guidebook')

--- a/c2corg_api/models/common/fields_waypoint.py
+++ b/c2corg_api/models/common/fields_waypoint.py
@@ -3,6 +3,7 @@ DEFAULT_FIELDS = [
     'locales.title',
     'locales.summary',
     'locales.description',
+    'locales.external_resources',
     'geometry.geom',
     'elevation',
     'maps_info',

--- a/c2corg_api/models/waypoint.py
+++ b/c2corg_api/models/waypoint.py
@@ -244,9 +244,12 @@ class _WaypointLocaleMixin(object):
     # date de deneigment ou d'ouverture (access)
     access_period = Column(String)
 
+    # bibliographie et webographie
+    external_resources = Column(String)
+
 
 attributes_locales = [
-    'access', 'access_period'
+    'access', 'access_period', 'external_resources'
 ]
 
 


### PR DESCRIPTION
https://github.com/c2corg/c2c_ui/issues/3697

## How to test:

Run the added migration using `docker-compose exec api .build/venv/bin/alembic upgrade head`
Pull the associated front branch: feature/#3697-add-waypoints-external-resources

From the front app, create a new waypoint and fill the `external_resources` field. Then update the external resources of this.  