### PR TITLE
Update docker-compose services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         image: postgis/postgis
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: test
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -62,10 +62,9 @@ jobs:
         run: flake8 c2corg_api es_migration
       - name: Configure postgres
         run: |
-          echo "create user \"www-data\" with password 'www-data'" | psql
-          USER=github scripts/create_user_db_test.sh
+          scripts/create_user_db_test.sh
         env:
-          PGPASSWORD: postgres
+          PGPASSWORD: test
           PGUSER: postgres
           PGHOST: localhost
           PGPORT: 5432
@@ -74,7 +73,7 @@ jobs:
       - name: Install java 8 for (old) elasticsearch
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: "adopt"
           java-version: 8
       - name: Run (old) elasticsearch
         run: |
@@ -118,7 +117,8 @@ jobs:
       - name: Publish the docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ./docker
+          file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/config/default
+++ b/config/default
@@ -10,8 +10,8 @@ export noauthorization = False
 
 export db_host = localhost
 export db_port = 5432
-export db_user = www-data
-export db_password = www-data
+export db_user = postgres
+export db_password = test
 export db_name = c2corg
 
 export elasticsearch_host = localhost
@@ -38,8 +38,8 @@ export discourse_category = Commentaires
 # database to run the unit tests
 export tests_db_host = localhost
 export tests_db_port = 5432
-export tests_db_user = www-data
-export tests_db_password = www-data
+export tests_db_user = postgres
+export tests_db_password = test
 export tests_db_name = c2corg_tests
 
 # ElasticSearch instance to run the unit tests
@@ -53,8 +53,8 @@ export tests_discourse_url = http://localhost:3000
 # database from which to import data from
 export migration_db_host = localhost
 export migration_db_port = 5432
-export migration_db_user = www-data
-export migration_db_password = www-data
+export migration_db_user = postgres
+export migration_db_password = test
 export migration_db_name = c2corg
 
 export logging_level = WARNING

--- a/config/github-actions
+++ b/config/github-actions
@@ -2,10 +2,10 @@ include config/dev
 
 export instanceid = github
 export base_url = /${instanceid}
-export db_name = c2corg_github_tests
-export tests_db_name = c2corg_github_tests
+export db_name = c2corg_tests
+export tests_db_name = c2corg_tests
 export elasticsearch_port = 9200
-export elasticsearch_index = c2corg_github_tests
+export elasticsearch_index = c2corg_tests
 export tests_elasticsearch_port = 9200
-export tests_elasticsearch_index = c2corg_github_tests
+export tests_elasticsearch_index = c2corg_tests
 export redis_url = redis://localhost:6379/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,12 @@ services:
     ports:
       - 6543:6543
     environment:
-      db_host: 'postgresql'
-      tests_db_host: 'postgresql'
-      elasticsearch_host: 'elasticsearch'
-      tests_elasticsearch_host: 'elasticsearch'
-      redis_url: 'redis://redis:6379/'
-      version: ''
+      db_host: "postgresql"
+      tests_db_host: "postgresql"
+      elasticsearch_host: "elasticsearch"
+      tests_elasticsearch_host: "elasticsearch"
+      redis_url: "redis://redis:6379/"
+      version: ""
     volumes:
       - ./alembic_migration:/var/www/alembic_migration
       - ./c2corg_api:/var/www/c2corg_api
@@ -26,26 +26,35 @@ services:
       - ./test.ini.in:/var/www/test.ini.in
       - ./pytest.ini:/var/www/pytest.ini
     command: make -f config/docker-dev serve
-    links:
-      - postgresql
-      - elasticsearch
-      - redis
 
   postgresql:
-    image: docker.io/c2corg/c2corg_pgsql:anon-2018-11-02
+    image: postgis/postgis:16-3.4
+    container_name: postgresql
+    ports:
+      - "5432:5432"
     environment:
-      PGDATA: '/c2corg_anon'
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: test
     volumes:
-      - ./docker-compose/pgsql-settings.d/:/c2corg_anon/pgsql-settings.d/
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker/postgresql.conf:/etc/postgresql.conf
       - .:/v6_api
+    command: ["postgres", "-c", "config_file=/etc/postgresql.conf"]
 
   elasticsearch:
-    image: 'docker.io/c2corg/c2corg_es:anon-2018-11-02'
+    image: "docker.io/c2corg/c2corg_es:anon-2018-11-02"
     ports:
       - 9200:9200
     command: -Des.index.number_of_replicas=0 -Des.path.data=/c2corg_anon -Des.script.inline=true
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
 
   redis:
-    image: 'docker.io/redis:3.2'
+    image: redis:7.2
     ports:
       - 6379:6379
+
+volumes:
+  postgres_data:

--- a/docker/postgresql.conf
+++ b/docker/postgresql.conf
@@ -1,4 +1,8 @@
+listen_addresses = '*'
+
 log_connections = on
 log_disconnections = on
 log_duration = on
 log_statement = 'all'
+
+max_connections = 200

--- a/scripts/create_user_db.sh
+++ b/scripts/create_user_db.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
+DBNAME="c2corg"
+
 sudo -u postgres psql <<EOF
-create database c2corg_$USER owner "www-data";
-\c c2corg_$USER
+create database ${DBNAME} owner "postgres";
+\c ${DBNAME}
 create extension postgis;
-create schema guidebook authorization "www-data";
-create schema users authorization "www-data";
-create schema sympa authorization "www-data";
-create schema alembic authorization "www-data";
+create schema guidebook authorization "postgres";
+create schema users authorization "postgres";
+create schema sympa authorization "postgres";
+create schema alembic authorization "postgres";
 \q
 EOF
 # to also set up the database, uncomment the following line

--- a/scripts/create_user_db_test.sh
+++ b/scripts/create_user_db_test.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-DBNAME="c2corg_${USER}_tests"
-[ -z "$USER" ] && DBNAME="c2corg_tests"
+DBNAME="c2corg_tests"
 
 if [ "$( psql -tAc "SELECT 1 FROM pg_database WHERE datname='${DBNAME}'" )" = '1' ]
 then
@@ -10,13 +9,13 @@ else
     echo "Create test database"
 
     psql <<EOF
-create database ${DBNAME} owner "www-data";
+create database ${DBNAME} owner "postgres";
 \c ${DBNAME}
 create extension postgis;
-create schema guidebook authorization "www-data";
-create schema users authorization "www-data";
-create schema sympa authorization "www-data";
-create schema alembic authorization "www-data";
+create schema guidebook authorization "postgres";
+create schema users authorization "postgres";
+create schema sympa authorization "postgres";
+create schema alembic authorization "postgres";
 \q
 EOF
 fi


### PR DESCRIPTION
Hey there,

You'll find in this PR a few updates 

- Schema update scripts are inline with the use of the standard `postgres` user.
- $USER variables are not used anymore in schema update scripts
- Previously built images for Postgres/Postgis and Redis are not used anymore in docker-compose
- We use the dedicated volumes feature for Postgres data now
- The obsolete links directive was removed from the docker-compose

All tests are green in local with these updates  