### PR TITLE
Elasticsearch migration from 2.6 to 5.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,7 @@ jobs:
       - name: Run (old) elasticsearch
         run: |
           mkdir /tmp/elasticsearch
-          wget -O - https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
-          /tmp/elasticsearch/bin/plugin install analysis-icu
+          wget -O - https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.10.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
           /tmp/elasticsearch/bin/elasticsearch --daemonize --path.data /tmp
           sleep 30 # ElasticSearch takes few seconds to start, make sure it is available when the build script runs
       - run: curl -v http://localhost:9200

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           mkdir /tmp/elasticsearch
           wget -O - https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.10.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
-          /tmp/elasticsearch/bin/elasticsearch --daemonize --path.data /tmp
+          /tmp/elasticsearch/bin/elasticsearch --daemonize
           sleep 30 # ElasticSearch takes few seconds to start, make sure it is available when the build script runs
       - run: curl -v http://localhost:9200
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           mkdir /tmp/elasticsearch
           wget -O - https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.10.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
-          /tmp/elasticsearch/bin/plugin install analysis-icu
+          /tmp/elasticsearch/bin/elasticsearch-plugin install analysis-icu
           /tmp/elasticsearch/bin/elasticsearch --daemonize
           sleep 30 # ElasticSearch takes few seconds to start, make sure it is available when the build script runs
       - run: curl -v http://localhost:9200

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
         run: |
           mkdir /tmp/elasticsearch
           wget -O - https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.10.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
+          /tmp/elasticsearch/bin/plugin install analysis-icu
           /tmp/elasticsearch/bin/elasticsearch --daemonize
           sleep 30 # ElasticSearch takes few seconds to start, make sure it is available when the build script runs
       - run: curl -v http://localhost:9200

--- a/c2corg_api/search/__init__.py
+++ b/c2corg_api/search/__init__.py
@@ -118,10 +118,10 @@ def get_text_query_on_title(search_term, search_lang=None):
             query=search_term,
             fields=fields,
             type='phrase',
-            fuzziness=2,
             max_expansions=3,
             zero_terms_query="none",
             slop=4,
+            operator="and"
         )
 
 

--- a/c2corg_api/search/mapping.py
+++ b/c2corg_api/search/mapping.py
@@ -6,7 +6,7 @@ from c2corg_api.search.mapping_types import Enum, QEnumArray, QLong, \
 from c2corg_api.models.common.attributes import default_langs
 from c2corg_api.models.common.sortable_search_attributes import \
     sortable_quality_types
-from elasticsearch_dsl import DocType, MetaField, Long, GeoPoint, Text, Keyword
+from elasticsearch_dsl import DocType, MetaField, Long, GeoPoint, Text
 
 
 class BaseMeta:
@@ -23,7 +23,6 @@ def default_title_field(lang: None):
     if lang is None:
         return Text(
             index='not_analyzed',
-            #BM25 use by default by lucene not required : similarity='c2corgsimilarity',
             fields={
                 'ngram': Text(
                     analyzer='index_ngram', search_analyzer='search_ngram'),
@@ -33,7 +32,6 @@ def default_title_field(lang: None):
     else:
         return Text(
             index='not_analyzed',
-            #BM25 use by default by lucene not required : similarity='c2corgsimilarity',
             fields={
                 'ngram': Text(
                     analyzer='index_ngram', search_analyzer='search_ngram'),

--- a/c2corg_api/search/mapping.py
+++ b/c2corg_api/search/mapping.py
@@ -6,7 +6,7 @@ from c2corg_api.search.mapping_types import Enum, QEnumArray, QLong, \
 from c2corg_api.models.common.attributes import default_langs
 from c2corg_api.models.common.sortable_search_attributes import \
     sortable_quality_types
-from elasticsearch_dsl import DocType, String, MetaField, Long, GeoPoint
+from elasticsearch_dsl import DocType, MetaField, Long, GeoPoint, Text, Keyword
 
 
 class BaseMeta:
@@ -21,25 +21,25 @@ class BaseMeta:
 # https://github.com/komoot/photon/blob/master/es/index_settings.json
 def default_title_field(lang: None):
     if lang is None:
-        return String(
+        return Text(
             index='not_analyzed',
-            similarity='c2corgsimilarity',
+            #BM25 use by default by lucene not required : similarity='c2corgsimilarity',
             fields={
-                'ngram': String(
+                'ngram': Text(
                     analyzer='index_ngram', search_analyzer='search_ngram'),
-                'raw': String(
+                'raw': Text(
                     analyzer='index_raw', search_analyzer='search_raw')
             })
     else:
-        return String(
+        return Text(
             index='not_analyzed',
-            similarity='c2corgsimilarity',
+            #BM25 use by default by lucene not required : similarity='c2corgsimilarity',
             fields={
-                'ngram': String(
+                'ngram': Text(
                     analyzer='index_ngram', search_analyzer='search_ngram'),
-                'raw': String(
+                'raw': Text(
                     analyzer='index_raw', search_analyzer='search_raw'),
-                'contentheavy': String(
+                'contentheavy': Text(
                     analyzer='{0}_heavy'.format(lang))
             })
 
@@ -74,65 +74,65 @@ class SearchDocument(DocType):
 
     # fr
     title_fr = default_title_field("french")
-    summary_fr = String(
+    summary_fr = Text(
         analyzer='index_french', search_analyzer='search_french')
-    description_fr = String(
+    description_fr = Text(
         analyzer='index_french', search_analyzer='search_french')
 
     # it
     title_it = default_title_field("italian")
-    summary_it = String(
+    summary_it = Text(
         analyzer='index_italian', search_analyzer='search_italian')
-    description_it = String(
+    description_it = Text(
         analyzer='index_italian', search_analyzer='search_italian')
 
     # de
     title_de = default_title_field("german")
-    summary_de = String(
+    summary_de = Text(
         analyzer='index_german', search_analyzer='search_german')
-    description_de = String(
+    description_de = Text(
         analyzer='index_german', search_analyzer='search_german')
 
     # en
     title_en = default_title_field("english")
-    summary_en = String(
+    summary_en = Text(
         analyzer='index_english', search_analyzer='search_english')
-    description_en = String(
+    description_en = Text(
         analyzer='index_english', search_analyzer='search_english')
 
     # es
     title_es = default_title_field("spanish")
-    summary_es = String(
+    summary_es = Text(
         analyzer='index_spanish', search_analyzer='search_spanish')
-    description_es = String(
+    description_es = Text(
         analyzer='index_spanish', search_analyzer='search_spanish')
 
     # ca
     title_ca = default_title_field("catalan")
-    summary_ca = String(
+    summary_ca = Text(
         analyzer='index_catalan', search_analyzer='search_catalan')
-    description_ca = String(
+    description_ca = Text(
         analyzer='index_catalan', search_analyzer='search_catalan')
 
     # eu
     title_eu = default_title_field("basque")
-    summary_eu = String(
+    summary_eu = Text(
         analyzer='index_basque', search_analyzer='search_basque')
-    description_eu = String(
+    description_eu = Text(
         analyzer='index_basque', search_analyzer='search_basque')
 
     # sl
     title_sl = default_title_field("slovene")
-    summary_sl = String(
+    summary_sl = Text(
         analyzer='index_slovene', search_analyzer='search_slovene')
-    description_sl = String(
+    description_sl = Text(
         analyzer='index_slovene', search_analyzer='search_slovene')
 
     # zh
     title_zh = default_title_field("chinois")
-    summary_zh = String(
+    summary_zh = Text(
         analyzer='index_chinois', search_analyzer='search_chinois')
-    description_zh = String(
+    description_zh = Text(
         analyzer='index_chinois', search_analyzer='search_chinois')
 
     @staticmethod

--- a/c2corg_api/search/search.py
+++ b/c2corg_api/search/search.py
@@ -46,7 +46,6 @@ def do_multi_search_for_types(search_types, search_term, limit, lang):
         (_, get_documents_config) = search_type
         search = create_search(get_documents_config.document_type).\
             query(get_text_query_on_title(search_term, lang)).\
-            fields([]).\
             extra(from_=0, size=limit)
         multi_search = multi_search.add(search)
 

--- a/c2corg_api/search/search_filters.py
+++ b/c2corg_api/search/search_filters.py
@@ -8,7 +8,8 @@ from c2corg_api.models.outing import OUTING_TYPE
 from c2corg_api.search import (create_search, get_text_query_on_title,
                                search_documents)
 from c2corg_api.search.mapping_types import reserved_query_fields
-from elasticsearch_dsl.query import (Bool, GeoBoundingBox, Range, Script, Term, Terms, Q)
+from elasticsearch_dsl.query import (Bool, GeoBoundingBox, Range,
+                                     Script, Term, Terms, Q)
 from pyproj import Transformer
 
 log = logging.getLogger(__name__)

--- a/c2corg_api/search/search_filters.py
+++ b/c2corg_api/search/search_filters.py
@@ -8,8 +8,8 @@ from c2corg_api.models.outing import OUTING_TYPE
 from c2corg_api.search import (create_search, get_text_query_on_title,
                                search_documents)
 from c2corg_api.search.mapping_types import reserved_query_fields
-from elasticsearch_dsl.query import (Bool, GeoBoundingBox, Missing, Range,
-                                     Script, Term, Terms)
+from elasticsearch_dsl.query import (Bool, GeoBoundingBox, Range,
+                                     Script, Term, Terms, Q)  # Missing not more exist
 from pyproj import Transformer
 
 log = logging.getLogger(__name__)
@@ -35,8 +35,7 @@ def build_query(url_params, meta_params, doc_type):
         if filter:
             search = search.filter(filter)
 
-    search = search.\
-        fields([]).\
+    search = search. \
         extra(from_=offset, size=limit)
 
     if url_params.get('bbox'):
@@ -171,9 +170,9 @@ def create_enum_range_min_max_filter(field, query_term):
     return Bool(must_not=Bool(should=[
         Range(**kwargs_start),
         Range(**kwargs_end),
-        Bool(must=[
-            Missing(field=field.field_min),
-            Missing(field=field.field_max)
+        Bool(must_not=[
+            Q("exists", field=field.field_min),
+            Q("exists", field=field.field_max)
         ])
     ]))
 
@@ -351,9 +350,9 @@ def create_number_range_filter(field, query_term):
     return Bool(must_not=Bool(should=[
         Range(**kwargs_start),
         Range(**kwargs_end),
-        Bool(must=[
-            Missing(field=field.field_min),
-            Missing(field=field.field_max)
+        Bool(must_not=[
+            Q('exists',field=field.field_min ),
+            Q('exists',field=field.field_max )
         ])
     ]))
 

--- a/c2corg_api/search/search_filters.py
+++ b/c2corg_api/search/search_filters.py
@@ -8,8 +8,7 @@ from c2corg_api.models.outing import OUTING_TYPE
 from c2corg_api.search import (create_search, get_text_query_on_title,
                                search_documents)
 from c2corg_api.search.mapping_types import reserved_query_fields
-from elasticsearch_dsl.query import (Bool, GeoBoundingBox, Range,
-                                     Script, Term, Terms, Q)  # Missing not more exist
+from elasticsearch_dsl.query import (Bool, GeoBoundingBox, Range, Script, Term, Terms, Q)
 from pyproj import Transformer
 
 log = logging.getLogger(__name__)
@@ -351,8 +350,8 @@ def create_number_range_filter(field, query_term):
         Range(**kwargs_start),
         Range(**kwargs_end),
         Bool(must_not=[
-            Q('exists',field=field.field_min ),
-            Q('exists',field=field.field_max )
+            Q('exists', field=field.field_min),
+            Q('exists', field=field.field_max)
         ])
     ]))
 

--- a/c2corg_api/tests/search/test_search_filters.py
+++ b/c2corg_api/tests/search/test_search_filters.py
@@ -6,8 +6,8 @@ from c2corg_api.search.search_filters import create_filter, build_query, \
 from c2corg_api.search.mappings.outing_mapping import SearchOuting
 from c2corg_api.search.mappings.waypoint_mapping import SearchWaypoint
 from c2corg_api.tests import BaseTestCase
-from elasticsearch_dsl.query import (Bool, GeoBoundingBox, Missing, Range,
-                                     Script, Term, Terms)
+from elasticsearch_dsl.query import (Bool, GeoBoundingBox, Range,
+                                     Script, Term, Terms, Q)
 
 
 class AdvancedSearchTest(BaseTestCase):
@@ -29,7 +29,6 @@ class AdvancedSearchTest(BaseTestCase):
             filter(Term(available_locales='fr')).\
             filter(Terms(areas=[1234, 4567])). \
             filter(Range(elevation={'gte': 1500})). \
-            fields([]).\
             extra(from_=0, size=10)
         self.assertQueryEqual(query, expected_query)
 
@@ -52,7 +51,6 @@ class AdvancedSearchTest(BaseTestCase):
                     'left': 6.28279913, 'bottom': 46.03129072,
                     'right': 6.28369744, 'top': 46.03191439},
                 type='indexed')). \
-            fields([]). \
             extra(from_=0, size=10)
         self.assertQueryEqual(query, expected_query)
 
@@ -67,7 +65,6 @@ class AdvancedSearchTest(BaseTestCase):
         query = build_query(params, meta_params, 'w')
         expected_query = create_search('w'). \
             query(get_text_query_on_title('search word')). \
-            fields([]).\
             extra(from_=40, size=20)
         self.assertQueryEqual(query, expected_query)
 
@@ -82,7 +79,6 @@ class AdvancedSearchTest(BaseTestCase):
         query = build_query(params, meta_params, 'o')
         expected_query = create_search('o'). \
             filter(Term(activities='skitouring')). \
-            fields([]). \
             sort({'date_end': {'order': 'desc'}}, {'id': {'order': 'desc'}}). \
             extra(from_=40, size=20)
         self.assertQueryEqual(query, expected_query)
@@ -212,9 +208,9 @@ class AdvancedSearchTest(BaseTestCase):
             Bool(must_not=Bool(should=[
                 Range(climbing_rating_min={'gt': 17}),
                 Range(climbing_rating_max={'lt': 5}),
-                Bool(must=[
-                    Missing(field='climbing_rating_min'),
-                    Missing(field='climbing_rating_max')
+                Bool(must_not=[
+                    Q("exists", field='climbing_rating_min'),
+                    Q("exists", field='climbing_rating_max')
                 ])
             ])))
 
@@ -243,9 +239,9 @@ class AdvancedSearchTest(BaseTestCase):
             Bool(must_not=Bool(should=[
                 Range(elevation_min={'gt': 2400}),
                 Range(elevation_max={'lt': 1200}),
-                Bool(must=[
-                    Missing(field='elevation_min'),
-                    Missing(field='elevation_max')
+                Bool(must_not=[
+                    Q("exists", field='elevation_min'),
+                    Q("exists", field='elevation_max')
                 ])
             ])))
         self.assertEqual(
@@ -253,9 +249,9 @@ class AdvancedSearchTest(BaseTestCase):
             Bool(must_not=Bool(should=[
                 Range(height_min={'gt': 2400}),
                 Range(height_max={'lt': 1200}),
-                Bool(must=[
-                    Missing(field='height_min'),
-                    Missing(field='height_max')
+                Bool(must_not=[
+                    Q("exists", field='height_min'),
+                    Q("exists", field='height_max')
                 ])
             ])))
 

--- a/dataMigration/README.md
+++ b/dataMigration/README.md
@@ -1,0 +1,6 @@
+## dataMigraiton folder content logstash pipeline script per target release ES number.
+
+- v5: to move ES data from 2.6 original to v5.6
+- v6: to move ES data from v5.6 to v6.x
+- v7: to move ES data from v6.X to 7.X 
+

--- a/dataMigration/v5/logstash.conf
+++ b/dataMigration/v5/logstash.conf
@@ -1,0 +1,51 @@
+#pre requisite : docker-compose run -it logstash5 /usr/share/logstash/bin/logstash-plugin install logstash-filter-prune
+input
+{
+    elasticsearch
+      {
+            hosts => ["elasticsearch26:9200"]
+            index => "c2corg"
+            docinfo => true
+            size => 1000
+            scroll => "5m"
+            docinfo_target => "[@metadata]"
+      }
+}
+
+filter {
+  if (![geom]) {
+    mutate {
+        add_field => { "geom" => [0,0] }
+    }
+  }
+
+  mutate {
+    add_field => { "doc_id" =>  "%{[@metadata][_id]}" }
+  }
+
+  #prune {
+  #  whitelist_names => [ "doc_id" ]
+  #}
+
+}
+
+output
+{
+    elasticsearch
+        {
+            hosts => ["elasticsearch:9200"]
+            index => "c2corg"
+            document_type => "%{doc_type}"
+            document_id => "%{doc_id}"
+        }
+
+    stdout {
+        codec => "dots"
+    }
+
+}
+
+#stdout { codec => "dots"}
+#stdout { codec => rubydebug }
+#stdout { codec => "json" }
+#docker-compose run logstash5 /usr/share/logstash/bin/logstash -f /root/logstash.conf

--- a/dataMigration/v6/logstash/logstash.conf
+++ b/dataMigration/v6/logstash/logstash.conf
@@ -1,0 +1,45 @@
+input
+{
+    elasticsearch
+      {
+            hosts => ["elasticsearch56:9200"]
+            index => "c2corg"
+            docinfo => true
+            size => 1000
+            scroll => "5m"
+            docinfo_target => "[@metadata]"
+      }
+}
+
+filter {
+  if (![geom]) {
+    mutate {
+        add_field => { "geom" => [0,0] }
+    }
+  }
+
+  mutate {
+    add_field => { "doc_id" =>  "%{[@metadata][_id]}" }
+  }
+}
+
+output
+{
+    elasticsearch
+        {
+            hosts => ["elasticsearch6:9200"]
+            index => "c2corg_%{[@metadata][_type]}"
+            document_type => "%{doc_type}"
+            document_id => "%{doc_id}"
+        }
+
+    stdout {
+        codec => "dots"
+    }
+
+}
+
+#stdout { codec => "dots"}
+#stdout { codec => rubydebug }
+#stdout { codec => "json" }
+#docker-compose run logstash5 /usr/share/logstash/bin/logstash -f /root/logstash.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,14 +57,13 @@ services:
       network: host
     environment:
        - discovery.type=single-node
-       - cluster.initial_master_nodes="docker-cluster"
     ports:
       - 9200:9200
       - 9300:9300
 
   logstash5:
     platform: linux/x86_64
-    name: logstash5
+    container_name: logstash5
     build:
       context: .
       dockerfile: logstash5.Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: .
       dockerfile: dev_api.Dockerfile
+      network: host
     depends_on:
       - postgresql
       - elasticsearch
@@ -25,6 +26,7 @@ services:
       - ./development.ini.in:/var/www/development.ini.in
       - ./test.ini.in:/var/www/test.ini.in
       - ./pytest.ini:/var/www/pytest.ini
+      - ./requirements.txt:/var/www/requirements.txt
     command: make -f config/docker-dev serve
     links:
       - postgresql
@@ -39,11 +41,38 @@ services:
       - ./docker-compose/pgsql-settings.d/:/c2corg_anon/pgsql-settings.d/
       - .:/v6_api
 
-  elasticsearch:
+  elasticsearch26:
     image: 'docker.io/c2corg/c2corg_es:anon-2018-11-02'
+    container_name: elasticsearch26
+    ports:
+      - 9201:9200
+    command: -Des.index.number_of_replicas=0 -Des.path.data=/c2corg_anon -Des.script.inline=true
+
+  elasticsearch:
+    platform: linux/x86_64
+    container_name: elasticsearch
+    build:
+      context: .
+      dockerfile: elasticsearch5.Dockerfile
+      network: host
+    environment:
+       - discovery.type=single-node
+       - cluster.initial_master_nodes="docker-cluster"
     ports:
       - 9200:9200
-    command: -Des.index.number_of_replicas=0 -Des.path.data=/c2corg_anon -Des.script.inline=true
+      - 9300:9300
+
+  logstash5:
+    platform: linux/x86_64
+    name: logstash5
+    build:
+      context: .
+      dockerfile: logstash5.Dockerfile
+      network: host
+    ports:
+      -  5044:5044
+    volumes:
+      - ./dataMigration/v5/logstash.conf:/root/logstash.conf
 
   redis:
     image: 'docker.io/redis:3.2'

--- a/elasticsearch5.Dockerfile
+++ b/elasticsearch5.Dockerfile
@@ -1,0 +1,2 @@
+FROM elasticsearch:5.6.10
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu

--- a/logstash5.Dockerfile
+++ b/logstash5.Dockerfile
@@ -1,0 +1,2 @@
+FROM --platform=linux/X86_64 logstash:5.6.16
+#RUN /usr/share/logstash/bin/logstash-plugin install logstash-filter-prune

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ bcrypt==4.1.2
 bleach[css]==6.1.0
 colander==2.0
 dogpile.cache==1.3.2
-elasticsearch==2.4.1
-elasticsearch_dsl==2.2.0
+elasticsearch==6.0.0 #elasticsearch==2.4.1
+elasticsearch-dsl==6.0.1 #elasticsearch_dsl==2.2.0
 geoalchemy2==0.4.2
 geojson==3.1.0
 geomet==1.1.0

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,4 +1,31 @@
-# ElasticSearch 2.4 update for search improvement
+# ElasticSearch Upgrade from v2.6 to V5.6 for docker env. like dev one.
+
+The docker-compose file has been updated in order to facilitate and automotive plugins installation and prepare the environment for migration.
+The ElasticSearch 2.6 is still build and run but would not be the main ES for the service. It could be decommissioned after migration. 
+docker-compose file contains as well :
+
+- api building with integration of the requirements.txt for python pip installation (component updates)
+- legacy ES 2.6 listening on port 9201 instead of 9200 : > elasticsearch26
+- redis no change
+- postgresql no change
+- ES 5.6 listening on port 9200 and 9300 (elasticsearch5.Dockerfile) > elasticsearch
+- Logstash 5.6 for data migration purpose. (logstash5.Dockerfile) 
+
+## migration steps
+
+ 1. **build the environment :**  ` docker-compose build `
+ 2. **Launch the environment :** ` docker-compose up -d `
+ 3. **Create the index and its mapping :** `./scripts/esUpdateMappings25.sh` 
+ 4. **Data Migration :** `docker-compose run logstash5 /usr/share/logstash/bin/logstash -f /root/logstash.conf`
+ 5. **postgresql shema up to date:** `docker-compose exec api .build/venv/bin/alembic upgrade head`
+
+## post migration
+
+if all the process has been passed without issues. you can comment or remove in the docker-compose.yml services :
+- logstash
+- elasticsearch26
+
+# ElasticSearch 2.6 update for search improvement
 
 Script has to be execute one time in order to be relevant with the code update. 
 
@@ -6,17 +33,15 @@ Script has to be execute one time in order to be relevant with the code update.
 
 ### script requirement : 
 - it requires curl from the execution machine
-
 - it will update elasticsearch on localhost:9200, if elasticsearch is on other server, please update script changing localhost by the correct ES url.
 - an elasticsearch plugin has to be install, in case of elasticsearch cluster - the plugin has to be install on each node
 
- 
-To install manually the the plugin analysis-icu from elasticsearch server :
+
+## To install manually the the plugin analysis-icu from elasticsearch server :
 
 ```
 ./bin/plugin install analysis-icu analysis-icu
 ```
-
 
 The installation process is :
 - Install the plugin, 
@@ -25,7 +50,8 @@ The installation process is :
 - update document mapping (_mappings /espon)
 - start a full indexation.
 
-To launch the script from the host side :
+## Automatic update via shell script from the host server
+
 ```
 cd scripts/
 ./esUpdateMapSettings.sh

--- a/scripts/esUpdateMapSettings25.sh
+++ b/scripts/esUpdateMapSettings25.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#change localhost to the correct url if elasticsearch is not hosted on your computer, or in docker
+#operate the plugin installation from the server side manually if not dockerized.
+#installation du plugin es et reboot
+#Install elastic plugin analysis-icu
+#echo 'Installing es plugin to elasticsearch docker'
+#docker-compose exec -it elasticsearch bin/plugin install analysis-icu
+#echo 'Installing done - restarting es docker'
+#docker-compose restart elasticsearch
+#sleep 10 #in sec to let the docker restart
+#1. index Creation
+echo -e '\n index Creation'
+curl -X PUT -H "Content-Type: application/json" http://localhost:9200/c2corg
+sleep 2
+#2. closing the index to upgrade settings
+echo -e '\n closing index'
+curl -X POST -H "Content-Type: application/json" http://localhost:9200/c2corg/_close
+sleep 2
+#3. Updating analyser settings
+echo -e  '\n updating Settings'
+curl -X PUT -H "Content-Type: application/json" -d @./scripts/esjson2-5/settings.json http://localhost:9200/c2corg/_settings
+sleep 2
+#4. restarting the index
+echo -e  '\n restarting index'
+curl -X POST -H "Content-Type: application/json" http://localhost:9200/c2corg/_open
+sleep 2
+#5. Docs Mappings update
+echo 'updating doc type mappings'
+echo 'doc type : a'
+curl -X PUT -H "Content-Type: application/json" -d @./scripts/esjson2-5/a.json http://localhost:9200/c2corg/_mapping/a
+echo -e '\n doc type : b'
+curl -X PUT -H "Content-Type: application/json" -d @./scripts/esjson2-5/b.json http://localhost:9200/c2corg/_mapping/b
+echo -e '\n doc type : c'
+curl -X PUT -H "Content-Type: application/json" -d @./scripts/esjson2-5/c.json http://localhost:9200/c2corg/_mapping/c
+echo -e  '\n doc type : i'
+curl -X PUT -H "Content-Type: application/json" -d @./scripts/esjson2-5/i.json http://localhost:9200/c2corg/_mapping/i
+echo -e  '\n doc type : m'
+curl -X PUT -H "Content-Type: application/json" -d @./scripts/esjson2-5/m.json http://localhost:9200/c2corg/_mapping/m
+echo -e  '\n doc type : o'
+curl -X PUT -H "Content-Type: application/json" -d @./scripts/esjson2-5/o.json http://localhost:9200/c2corg/_mapping/o
+echo -e  '\n doc type : r'
+curl -X PUT -H "Content-Type: application/json" -d @./scripts/esjson2-5/r.json http://localhost:9200/c2corg/_mapping/r
+echo -e  '\n doc type : u'
+curl -X PUT -H "Content-Type: application/json" -d @./scripts/esjson2-5/u.json http://localhost:9200/c2corg/_mapping/u
+echo -e  '\n doc type : w'
+curl -X PUT -H "Content-Type: application/json" -d @./scripts/esjson2-5/w.json http://localhost:9200/c2corg/_mapping/w
+echo -e  '\n doc type : x'
+curl -X PUT -H "Content-Type: application/json" -d @./scripts/esjson2-5/x.json http://localhost:9200/c2corg/_mapping/x
+sleep 2
+#6. RE-index the indice to apply mappings
+echo -e  '\n Indexing with new parameters - should take sometimes - pls wait server acknowlegment'
+curl -X POST -H "Content-Type: application/json" http://localhost:9200/c2corg/_update_by_query?conflicts=proceed

--- a/scripts/esjson2-5/a.json
+++ b/scripts/esjson2-5/a.json
@@ -1,0 +1,242 @@
+{
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"area_type": {
+						"type": "text",
+						"index": false
+					},
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": false
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": false
+					},
+					"geom": {
+						"type": "geo_point",
+						"ignore_malformed": true
+					},
+					"id": {
+						"type": "long"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					}
+				}
+			}

--- a/scripts/esjson2-5/b.json
+++ b/scripts/esjson2-5/b.json
@@ -1,0 +1,246 @@
+{
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"activities": {
+						"type": "text",
+						"index": false
+					},
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": false
+					},
+					"book_types": {
+						"type": "text",
+						"index": false
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": false
+					},
+					"geom": {
+						"type": "geo_point",
+						"ignore_malformed": true
+					},
+					"id": {
+						"type": "long"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					}
+				}
+			}

--- a/scripts/esjson2-5/c.json
+++ b/scripts/esjson2-5/c.json
@@ -1,0 +1,250 @@
+{
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"activities": {
+						"type": "text",
+						"index": false
+					},
+					"areas": {
+						"type": "long"
+					},
+					"article_categories": {
+						"type": "text",
+						"index": false
+					},
+					"article_type": {
+						"type": "text",
+						"index": false
+					},
+					"available_locales": {
+						"type": "text",
+						"index": false
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": false
+					},
+					"geom": {
+						"type": "geo_point",
+						"ignore_malformed": true
+					},
+					"id": {
+						"type": "long"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					}
+				}
+			}

--- a/scripts/esjson2-5/i.json
+++ b/scripts/esjson2-5/i.json
@@ -1,0 +1,257 @@
+{
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"activities": {
+						"type": "text",
+						"index": false
+					},
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": false
+					},
+					"categories": {
+						"type": "text",
+						"index": false
+					},
+					"date_time": {
+						"type": "date",
+						"format": "strict_date_optional_time||epoch_millis"
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": false
+					},
+					"elevation": {
+						"type": "integer"
+					},
+					"geom": {
+						"type": "geo_point",
+						"ignore_malformed": true
+					},
+					"id": {
+						"type": "long"
+					},
+					"image_type": {
+						"type": "text",
+						"index": false
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					}
+				}
+			}

--- a/scripts/esjson2-5/m.json
+++ b/scripts/esjson2-5/m.json
@@ -1,0 +1,238 @@
+{
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": false
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": false
+					},
+					"geom": {
+						"type": "geo_point",
+						"ignore_malformed": true
+					},
+					"id": {
+						"type": "long"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					}
+				}
+			}

--- a/scripts/esjson2-5/mappings.json
+++ b/scripts/esjson2-5/mappings.json
@@ -1,0 +1,2823 @@
+{
+	"c2corg": {
+		"mappings": {
+			"x": {
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"activities": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"avalanche_level": {
+						"type": "integer"
+					},
+					"avalanche_slope": {
+						"type": "integer"
+					},
+					"date": {
+						"type": "date",
+						"format": "strict_date_optional_time||epoch_millis"
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"elevation": {
+						"type": "integer"
+					},
+					"event_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"geom": {
+						"type": "geo_point"
+					},
+					"id": {
+						"type": "long"
+					},
+					"nb_impacted": {
+						"type": "integer"
+					},
+					"nb_participants": {
+						"type": "integer"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"severity": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					}
+				}
+			},
+			"c": {
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"activities": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"areas": {
+						"type": "long"
+					},
+					"article_categories": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"article_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"geom": {
+						"type": "geo_point"
+					},
+					"id": {
+						"type": "long"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					}
+				}
+			},
+			"u": {
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"geom": {
+						"type": "geo_point"
+					},
+					"id": {
+						"type": "long"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					}
+				}
+			},
+			"o": {
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"activities": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"avalanche_signs": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"condition_rating": {
+						"type": "integer"
+					},
+					"date_end": {
+						"type": "date",
+						"format": "strict_date_optional_time||epoch_millis"
+					},
+					"date_start": {
+						"type": "date",
+						"format": "strict_date_optional_time||epoch_millis"
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"elevation_access": {
+						"type": "integer"
+					},
+					"elevation_down_snow": {
+						"type": "integer"
+					},
+					"elevation_max": {
+						"type": "integer"
+					},
+					"elevation_up_snow": {
+						"type": "integer"
+					},
+					"engagement_rating": {
+						"type": "integer"
+					},
+					"equipment_rating": {
+						"type": "integer"
+					},
+					"frequentation": {
+						"type": "integer"
+					},
+					"geom": {
+						"type": "geo_point"
+					},
+					"glacier_rating": {
+						"type": "integer"
+					},
+					"global_rating": {
+						"type": "integer"
+					},
+					"height_diff_difficulties": {
+						"type": "integer"
+					},
+					"height_diff_up": {
+						"type": "integer"
+					},
+					"hiking_rating": {
+						"type": "integer"
+					},
+					"ice_rating": {
+						"type": "integer"
+					},
+					"id": {
+						"type": "long"
+					},
+					"labande_global_rating": {
+						"type": "integer"
+					},
+					"length_total": {
+						"type": "integer"
+					},
+					"mtb_down_rating": {
+						"type": "integer"
+					},
+					"mtb_up_rating": {
+						"type": "integer"
+					},
+					"public_transport": {
+						"type": "boolean"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"rock_free_rating": {
+						"type": "integer"
+					},
+					"routes": {
+						"type": "long"
+					},
+					"ski_rating": {
+						"type": "integer"
+					},
+					"snow_quality": {
+						"type": "integer"
+					},
+					"snow_quantity": {
+						"type": "integer"
+					},
+					"snowshoe_rating": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					},
+					"users": {
+						"type": "long"
+					},
+					"via_ferrata_rating": {
+						"type": "integer"
+					},
+					"waypoints": {
+						"type": "long"
+					}
+				}
+			},
+			"m": {
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"geom": {
+						"type": "geo_point"
+					},
+					"id": {
+						"type": "long"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					}
+				}
+			},
+			"b": {
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"activities": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"book_types": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"geom": {
+						"type": "geo_point"
+					},
+					"id": {
+						"type": "long"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					}
+				}
+			},
+			"w": {
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"access_time": {
+						"type": "integer"
+					},
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"best_periods": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"capacity": {
+						"type": "integer"
+					},
+					"capacity_staffed": {
+						"type": "integer"
+					},
+					"children_proof": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"climbing_indoor_types": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"climbing_outdoor_types": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"climbing_rating_max": {
+						"type": "integer"
+					},
+					"climbing_rating_median": {
+						"type": "integer"
+					},
+					"climbing_rating_min": {
+						"type": "integer"
+					},
+					"climbing_styles": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"custodianship": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"elevation": {
+						"type": "integer"
+					},
+					"equipment_ratings": {
+						"type": "integer"
+					},
+					"exposition_rating": {
+						"type": "integer"
+					},
+					"geom": {
+						"type": "geo_point"
+					},
+					"height_max": {
+						"type": "integer"
+					},
+					"height_median": {
+						"type": "integer"
+					},
+					"height_min": {
+						"type": "integer"
+					},
+					"id": {
+						"type": "long"
+					},
+					"length": {
+						"type": "integer"
+					},
+					"lift_access": {
+						"type": "boolean"
+					},
+					"orientations": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"paragliding_rating": {
+						"type": "integer"
+					},
+					"product_types": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"prominence": {
+						"type": "integer"
+					},
+					"public_transportation_rating": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"public_transportation_types": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"rain_proof": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"rock_types": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"routes_quantity": {
+						"type": "integer"
+					},
+					"snow_clearance_rating": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					},
+					"waypoint_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"weather_station_types": {
+						"type": "text",
+						"index": "not_analyzed"
+					}
+				}
+			},
+			"a": {
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"area_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"geom": {
+						"type": "geo_point"
+					},
+					"id": {
+						"type": "long"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							}
+						}
+					},
+					"title_ca": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					}
+				}
+			},
+			"i": {
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"activities": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"categories": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"date_time": {
+						"type": "date",
+						"format": "strict_date_optional_time||epoch_millis"
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"elevation": {
+						"type": "integer"
+					},
+					"geom": {
+						"type": "geo_point"
+					},
+					"id": {
+						"type": "long"
+					},
+					"image_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							}
+						}
+					},
+					"title_ca": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					}
+				}
+			},
+			"r": {
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"activities": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"aid_rating": {
+						"type": "integer"
+					},
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"climbing_outdoor_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"configuration": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"difficulties_height": {
+						"type": "integer"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"durations": {
+						"type": "integer"
+					},
+					"elevation_max": {
+						"type": "integer"
+					},
+					"elevation_min": {
+						"type": "integer"
+					},
+					"engagement_rating": {
+						"type": "integer"
+					},
+					"equipment_rating": {
+						"type": "integer"
+					},
+					"exposition_rock_rating": {
+						"type": "integer"
+					},
+					"geom": {
+						"type": "geo_point"
+					},
+					"glacier_gear": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"global_rating": {
+						"type": "integer"
+					},
+					"height_diff_access": {
+						"type": "integer"
+					},
+					"height_diff_difficulties": {
+						"type": "integer"
+					},
+					"height_diff_down": {
+						"type": "integer"
+					},
+					"height_diff_up": {
+						"type": "integer"
+					},
+					"hiking_mtb_exposition": {
+						"type": "integer"
+					},
+					"hiking_rating": {
+						"type": "integer"
+					},
+					"ice_rating": {
+						"type": "integer"
+					},
+					"id": {
+						"type": "long"
+					},
+					"labande_global_rating": {
+						"type": "integer"
+					},
+					"labande_ski_rating": {
+						"type": "integer"
+					},
+					"mixed_rating": {
+						"type": "integer"
+					},
+					"mtb_down_rating": {
+						"type": "integer"
+					},
+					"mtb_height_diff_portages": {
+						"type": "integer"
+					},
+					"mtb_length_asphalt": {
+						"type": "integer"
+					},
+					"mtb_length_trail": {
+						"type": "integer"
+					},
+					"mtb_up_rating": {
+						"type": "integer"
+					},
+					"orientations": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"risk_rating": {
+						"type": "integer"
+					},
+					"rock_free_rating": {
+						"type": "integer"
+					},
+					"rock_required_rating": {
+						"type": "integer"
+					},
+					"rock_types": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"route_length": {
+						"type": "integer"
+					},
+					"route_types": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"ski_exposition": {
+						"type": "integer"
+					},
+					"ski_rating": {
+						"type": "integer"
+					},
+					"slackline_type": {
+						"type": "text",
+						"index": "not_analyzed"
+					},
+					"snowshoe_rating": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": "not_analyzed",
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					},
+					"via_ferrata_rating": {
+						"type": "integer"
+					},
+					"waypoints": {
+						"type": "long"
+					}
+				}
+			}
+		}
+	}
+}

--- a/scripts/esjson2-5/o.json
+++ b/scripts/esjson2-5/o.json
@@ -1,0 +1,338 @@
+{
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"activities": {
+						"type": "text",
+						"index": false
+					},
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": false
+					},
+					"avalanche_signs": {
+						"type": "text",
+						"index": false
+					},
+					"condition_rating": {
+						"type": "integer"
+					},
+					"date_end": {
+						"type": "date",
+						"format": "strict_date_optional_time||epoch_millis"
+					},
+					"date_start": {
+						"type": "date",
+						"format": "strict_date_optional_time||epoch_millis"
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": false
+					},
+					"elevation_access": {
+						"type": "integer"
+					},
+					"elevation_down_snow": {
+						"type": "integer"
+					},
+					"elevation_max": {
+						"type": "integer"
+					},
+					"elevation_up_snow": {
+						"type": "integer"
+					},
+					"engagement_rating": {
+						"type": "integer"
+					},
+					"equipment_rating": {
+						"type": "integer"
+					},
+					"frequentation": {
+						"type": "integer"
+					},
+					"geom": {
+						"type": "geo_point",
+						"ignore_malformed": true
+					},
+					"glacier_rating": {
+						"type": "integer"
+					},
+					"global_rating": {
+						"type": "integer"
+					},
+					"height_diff_difficulties": {
+						"type": "integer"
+					},
+					"height_diff_up": {
+						"type": "integer"
+					},
+					"hiking_rating": {
+						"type": "integer"
+					},
+					"ice_rating": {
+						"type": "integer"
+					},
+					"id": {
+						"type": "long"
+					},
+					"labande_global_rating": {
+						"type": "integer"
+					},
+					"length_total": {
+						"type": "integer"
+					},
+					"mtb_down_rating": {
+						"type": "integer"
+					},
+					"mtb_up_rating": {
+						"type": "integer"
+					},
+					"public_transport": {
+						"type": "boolean"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"rock_free_rating": {
+						"type": "integer"
+					},
+					"routes": {
+						"type": "long"
+					},
+					"ski_rating": {
+						"type": "integer"
+					},
+					"snow_quality": {
+						"type": "integer"
+					},
+					"snow_quantity": {
+						"type": "integer"
+					},
+					"snowshoe_rating": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					},
+					"users": {
+						"type": "long"
+					},
+					"via_ferrata_rating": {
+						"type": "integer"
+					},
+					"waypoints": {
+						"type": "long"
+					}
+				}
+			}

--- a/scripts/esjson2-5/r.json
+++ b/scripts/esjson2-5/r.json
@@ -1,0 +1,369 @@
+{
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"activities": {
+						"type": "text",
+						"index": false
+					},
+					"aid_rating": {
+						"type": "integer"
+					},
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": false
+					},
+					"climbing_outdoor_type": {
+						"type": "text",
+						"index": false
+					},
+					"configuration": {
+						"type": "text",
+						"index": false
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"difficulties_height": {
+						"type": "integer"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": false
+					},
+					"durations": {
+						"type": "integer"
+					},
+					"elevation_max": {
+						"type": "integer"
+					},
+					"elevation_min": {
+						"type": "integer"
+					},
+					"engagement_rating": {
+						"type": "integer"
+					},
+					"equipment_rating": {
+						"type": "integer"
+					},
+					"exposition_rock_rating": {
+						"type": "integer"
+					},
+					"geom": {
+						"type": "geo_point",
+						"ignore_malformed": true
+					},
+					"glacier_gear": {
+						"type": "text",
+						"index": false
+					},
+					"global_rating": {
+						"type": "integer"
+					},
+					"height_diff_access": {
+						"type": "integer"
+					},
+					"height_diff_difficulties": {
+						"type": "integer"
+					},
+					"height_diff_down": {
+						"type": "integer"
+					},
+					"height_diff_up": {
+						"type": "integer"
+					},
+					"hiking_mtb_exposition": {
+						"type": "integer"
+					},
+					"hiking_rating": {
+						"type": "integer"
+					},
+					"ice_rating": {
+						"type": "integer"
+					},
+					"id": {
+						"type": "long"
+					},
+					"labande_global_rating": {
+						"type": "integer"
+					},
+					"labande_ski_rating": {
+						"type": "integer"
+					},
+					"mixed_rating": {
+						"type": "integer"
+					},
+					"mtb_down_rating": {
+						"type": "integer"
+					},
+					"mtb_height_diff_portages": {
+						"type": "integer"
+					},
+					"mtb_length_asphalt": {
+						"type": "integer"
+					},
+					"mtb_length_trail": {
+						"type": "integer"
+					},
+					"mtb_up_rating": {
+						"type": "integer"
+					},
+					"orientations": {
+						"type": "text",
+						"index": false
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"risk_rating": {
+						"type": "integer"
+					},
+					"rock_free_rating": {
+						"type": "integer"
+					},
+					"rock_required_rating": {
+						"type": "integer"
+					},
+					"rock_types": {
+						"type": "text",
+						"index": false
+					},
+					"route_length": {
+						"type": "integer"
+					},
+					"route_types": {
+						"type": "text",
+						"index": false
+					},
+					"ski_exposition": {
+						"type": "integer"
+					},
+					"ski_rating": {
+						"type": "integer"
+					},
+					"slackline_type": {
+						"type": "text",
+						"index": false
+					},
+					"snowshoe_rating": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					},
+					"via_ferrata_rating": {
+						"type": "integer"
+					},
+					"waypoints": {
+						"type": "long"
+					}
+				}
+			}

--- a/scripts/esjson2-5/settings.json
+++ b/scripts/esjson2-5/settings.json
@@ -1,0 +1,378 @@
+{
+    "analysis": {
+        "filter": {
+            "autocomplete_filter": {
+                "type": "edge_ngram",
+                "min_gram": "2",
+                "max_gram": "15",
+                "token_chars": [
+                    "letter",
+                    "digit"
+                ]
+            },
+            "english_stop": {
+                "type": "stop",
+                "stopwords": "_english_"
+            },
+            "english_stemmer": {
+                "type": "stemmer",
+                "language": "english"
+            },
+            "english_possessive_stemmer": {
+                "type": "stemmer",
+                "language": "possessive_english"
+            },
+            "french_elision": {
+                "type": "elision",
+                "articles_case": true,
+                "articles": [
+                    "l", "m", "t", "qu", "n", "s",
+                    "j", "d", "c", "jusqu", "quoiqu",
+                    "lorsqu", "puisqu"
+                ]
+            },
+            "french_stop": {
+                "type": "stop",
+                "stopwords": "_french_"
+            },
+            "french_stemmer": {
+                "type": "stemmer",
+                "language": "light_french"
+            },
+            "german_stop": {
+                "type": "stop",
+                "stopwords": "_german_"
+            },
+            "german_stemmer": {
+                "type": "stemmer",
+                "language": "light_german"
+            },
+            "italian_elision": {
+                "type": "elision",
+                "articles_case": true,
+                "articles": [
+                    "c", "l", "all", "dall", "dell",
+                    "nell", "sull", "coll", "pell",
+                    "gl", "agl", "dagl", "degl", "negl",
+                    "sugl", "un", "m", "t", "s", "v", "d"
+                ]
+            },
+            "italian_stop": {
+                "type": "stop",
+                "stopwords": "_italian_"
+            },
+            "italian_stemmer": {
+                "type": "stemmer",
+                "language": "light_italian"
+            },
+            "spanish_stop": {
+                "type": "stop",
+                "stopwords": "_spanish_"
+            },
+            "spanish_stemmer": {
+                "type": "stemmer",
+                "language": "light_spanish"
+            },
+            "catalan_elision": {
+                "type": "elision",
+                "articles_case": true,
+                "articles": ["d", "l", "m", "n", "s", "t"]
+            },
+            "catalan_stop": {
+                "type": "stop",
+                "stopwords": "_catalan_"
+            },
+            "catalan_stemmer": {
+                "type": "stemmer",
+                "language": "catalan"
+            },
+            "basque_stop": {
+                "type": "stop",
+                "stopwords": "_basque_"
+            },
+            "basque_stemmer": {
+                "type": "stemmer",
+                "language": "basque"
+            }
+        },
+        "similarity": {
+            "c2corgsimilarity": {
+                "type": "BM25"
+            }
+        },
+        "char_filter": {
+            "punctuationgreedy": {
+                "type": "pattern_replace",
+                "pattern": "[\\.,]"
+            }
+        },
+        "analyzer": {
+            "index_ngram": {
+                "char_filter": ["punctuationgreedy"],
+                "filter": [
+                    "word_delimiter", "lowercase", "icu_folding",
+                    "autocomplete_filter"],
+                "tokenizer": "icu_tokenizer"
+            },
+            "search_ngram": {
+                "char_filter": ["punctuationgreedy"],
+                "filter": [
+                    "word_delimiter", "lowercase", "asciifolding", "unique"],
+                "tokenizer": "standard"
+            },
+            "index_raw": {
+                "char_filter": ["punctuationgreedy"],
+                "filter": [
+                    "word_delimiter", "lowercase", "asciifolding", "unique"],
+                "tokenizer": "standard"
+            },
+            "search_raw": {
+                "char_filter": ["punctuationgreedy"],
+                "filter": [
+                    "word_delimiter", "lowercase", "asciifolding", "unique"],
+                "tokenizer": "standard"
+            },
+            "index_english": {
+                "type": "custom",
+                "tokenizer": "standard",
+                "filter": [
+                    "english_possessive_stemmer",
+                    "lowercase",
+                    "english_stop",
+                    "english_stemmer",
+                    "autocomplete_filter"
+                ]
+            },
+            "search_english": {
+                "type": "custom",
+                "tokenizer": "standard",
+                "filter": [
+                    "english_possessive_stemmer",
+                    "lowercase",
+                    "english_stop",
+                    "english_stemmer"
+                ]
+            },
+            "index_french": {
+                "tokenizer": "standard",
+                "filter": [
+                    "french_elision",
+                    "lowercase",
+                    "french_stop",
+                    "french_stemmer",
+                    "autocomplete_filter"
+                ]
+            },
+            "search_french": {
+                "tokenizer": "standard",
+                "filter": [
+                    "french_elision",
+                    "lowercase",
+                    "french_stop",
+                    "french_stemmer",
+                    "autocomplete_filter"
+                ]
+            },
+            "index_german": {
+                "tokenizer": "standard",
+                "filter": [
+                    "lowercase",
+                    "german_stop",
+                    "german_normalization",
+                    "german_stemmer",
+                    "autocomplete_filter"
+                ]
+            },
+            "search_german": {
+                "tokenizer": "standard",
+                "filter": [
+                    "lowercase",
+                    "german_stop",
+                    "german_normalization",
+                    "german_stemmer"
+                ]
+            },
+            "index_italian": {
+                "tokenizer": "standard",
+                "filter": [
+                    "italian_elision",
+                    "lowercase",
+                    "italian_stop",
+                    "italian_stemmer",
+                    "autocomplete_filter"
+                ]
+            },
+            "search_italian": {
+                "tokenizer": "standard",
+                "filter": [
+                    "italian_elision",
+                    "lowercase",
+                    "italian_stop",
+                    "italian_stemmer"
+                ]
+            },
+            "index_spanish": {
+                "tokenizer": "standard",
+                "filter": [
+                    "lowercase",
+                    "spanish_stop",
+                    "spanish_stemmer",
+                    "autocomplete_filter"
+                ]
+            },
+            "search_spanish": {
+                "tokenizer": "standard",
+                "filter": [
+                    "lowercase",
+                    "spanish_stop",
+                    "spanish_stemmer"
+                ]
+            },
+            "index_catalan": {
+                "tokenizer": "standard",
+                "filter": [
+                    "catalan_elision",
+                    "lowercase",
+                    "catalan_stop",
+                    "catalan_stemmer",
+                    "autocomplete_filter"
+                ]
+            },
+            "search_catalan": {
+                "tokenizer": "standard",
+                "filter": [
+                    "catalan_elision",
+                    "lowercase",
+                    "catalan_stop",
+                    "catalan_stemmer"
+                ]
+            },
+            "index_basque": {
+                "tokenizer": "standard",
+                "filter": [
+                    "lowercase",
+                    "basque_stop",
+                    "basque_stemmer",
+                    "autocomplete_filter"
+                ]
+            },
+            "search_basque": {
+                "tokenizer": "standard",
+                "filter": [
+                    "lowercase",
+                    "basque_stop",
+                    "basque_stemmer"
+                ]
+            },
+            "french_heavy": {
+                "tokenizer": "icu_tokenizer",
+                "filter": [
+                    "french_elision",
+                    "french_stop",
+                    "icu_folding",
+                    "lowercase",
+                    "french_stemmer"
+                ]
+            },
+            "german_heavy": {
+                "tokenizer": "icu_tokenizer",
+                "filter": [
+                    "german_stop",
+                    "german_stemmer",
+                    "lowercase",
+                    "icu_folding"
+                ]
+            },
+            "english_heavy": {
+                "tokenizer": "icu_tokenizer",
+                "filter": [
+                    "english_possessive_stemmer",
+                    "english_stop",
+                    "lowercase",
+                    "icu_folding"
+                ]
+            },
+            "italian_heavy": {
+                "tokenizer": "icu_tokenizer",
+                "filter": [
+                    "italian_elision",
+                    "italian_stop",
+                    "lowercase",
+                    "icu_folding",
+                    "italian_stemmer"
+                ]
+            },
+            "spanish_heavy": {
+                "tokenizer": "icu_tokenizer",
+                "filter": [
+                    "lowercase",
+                    "spanish_stop",
+                    "spanish_stemmer",
+                    "icu_folding"
+                ]
+            },
+            "catalan_heavy": {
+                "tokenizer": "icu_tokenizer",
+                "filter": [
+                    "catalan_elision",
+                    "lowercase",
+                    "catalan_stop",
+                    "catalan_stemmer",
+                    "icu_folding"
+                ]
+            },
+            "basque_heavy": {
+                "tokenizer": "icu_tokenizer",
+                "filter": [
+                    "lowercase",
+                    "basque_stop",
+                    "basque_stemmer",
+                    "icu_folding"
+                ]
+            },
+            "index_slovene": {
+                "type": "custom",
+                "tokenizer": "standard",
+                "filter": [
+                    "autocomplete_filter",
+                    "lowercase"
+                ]
+            },
+            "search_slovene": {
+                "type": "custom",
+                "tokenizer": "standard",
+                "filter": [
+                    "lowercase"
+                ]
+            },
+            "slovene_heavy": {
+                "tokenizer": "icu_tokenizer",
+                "filter": [
+                    "lowercase",
+                    "icu_folding"
+                ]
+            },
+            "index_chinois": {
+                "type": "custom",
+                "tokenizer": "standard",
+                "filter": [
+                    "autocomplete_filter"
+                ]
+            },
+            "search_chinois": {
+                "type": "custom",
+                "tokenizer": "standard",
+                "filter": [
+                    "lowercase"
+                ]
+            },
+            "chinois_heavy": {
+                "tokenizer": "icu_tokenizer",
+                "filter": [
+                    "lowercase",
+                    "icu_folding"
+                ]
+            }
+        }
+    }
+}

--- a/scripts/esjson2-5/u.json
+++ b/scripts/esjson2-5/u.json
@@ -1,0 +1,238 @@
+{
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": false
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": false
+					},
+					"geom": {
+						"type": "geo_point",
+						"ignore_malformed": true
+					},
+					"id": {
+						"type": "long"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					}
+				}
+			}

--- a/scripts/esjson2-5/w.json
+++ b/scripts/esjson2-5/w.json
@@ -1,0 +1,349 @@
+{
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"access_time": {
+						"type": "integer"
+					},
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": false
+					},
+					"best_periods": {
+						"type": "text",
+						"index": false
+					},
+					"capacity": {
+						"type": "integer"
+					},
+					"capacity_staffed": {
+						"type": "integer"
+					},
+					"children_proof": {
+						"type": "text",
+						"index": false
+					},
+					"climbing_indoor_types": {
+						"type": "text",
+						"index": false
+					},
+					"climbing_outdoor_types": {
+						"type": "text",
+						"index": false
+					},
+					"climbing_rating_max": {
+						"type": "integer"
+					},
+					"climbing_rating_median": {
+						"type": "integer"
+					},
+					"climbing_rating_min": {
+						"type": "integer"
+					},
+					"climbing_styles": {
+						"type": "text",
+						"index": false
+					},
+					"custodianship": {
+						"type": "text",
+						"index": false
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": false
+					},
+					"elevation": {
+						"type": "integer"
+					},
+					"equipment_ratings": {
+						"type": "integer"
+					},
+					"exposition_rating": {
+						"type": "integer"
+					},
+					"geom": {
+						"type": "geo_point",
+						"ignore_malformed": true
+					},
+					"height_max": {
+						"type": "integer"
+					},
+					"height_median": {
+						"type": "integer"
+					},
+					"height_min": {
+						"type": "integer"
+					},
+					"id": {
+						"type": "long"
+					},
+					"length": {
+						"type": "integer"
+					},
+					"lift_access": {
+						"type": "boolean"
+					},
+					"orientations": {
+						"type": "text",
+						"index": false
+					},
+					"paragliding_rating": {
+						"type": "integer"
+					},
+					"product_types": {
+						"type": "text",
+						"index": false
+					},
+					"prominence": {
+						"type": "integer"
+					},
+					"public_transportation_rating": {
+						"type": "text",
+						"index": false
+					},
+					"public_transportation_types": {
+						"type": "text",
+						"index": false
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"rain_proof": {
+						"type": "text",
+						"index": false
+					},
+					"rock_types": {
+						"type": "text",
+						"index": false
+					},
+					"routes_quantity": {
+						"type": "integer"
+					},
+					"snow_clearance_rating": {
+						"type": "text",
+						"index": false
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					},
+					"waypoint_type": {
+						"type": "text",
+						"index": false
+					},
+					"weather_station_types": {
+						"type": "text",
+						"index": false
+					}
+				}
+			}

--- a/scripts/esjson2-5/x.json
+++ b/scripts/esjson2-5/x.json
@@ -1,0 +1,268 @@
+{
+				"_all": {
+					"enabled": false
+				},
+				"properties": {
+					"activities": {
+						"type": "text",
+						"index": false
+					},
+					"areas": {
+						"type": "long"
+					},
+					"available_locales": {
+						"type": "text",
+						"index": false
+					},
+					"avalanche_level": {
+						"type": "integer"
+					},
+					"avalanche_slope": {
+						"type": "integer"
+					},
+					"date": {
+						"type": "date",
+						"format": "strict_date_optional_time||epoch_millis"
+					},
+					"description_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"description_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"description_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"description_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"description_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"description_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"description_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"doc_type": {
+						"type": "text",
+						"index": false
+					},
+					"elevation": {
+						"type": "integer"
+					},
+					"event_type": {
+						"type": "text",
+						"index": false
+					},
+					"geom": {
+						"type": "geo_point",
+						"ignore_malformed": true
+					},
+					"id": {
+						"type": "long"
+					},
+					"nb_impacted": {
+						"type": "integer"
+					},
+					"nb_participants": {
+						"type": "integer"
+					},
+					"quality": {
+						"type": "integer"
+					},
+					"severity": {
+						"type": "integer"
+					},
+					"summary_ca": {
+						"type": "text",
+						"analyzer": "index_catalan",
+						"search_analyzer": "search_catalan"
+					},
+					"summary_de": {
+						"type": "text",
+						"analyzer": "index_german",
+						"search_analyzer": "search_german"
+					},
+					"summary_en": {
+						"type": "text",
+						"analyzer": "index_english",
+						"search_analyzer": "search_english"
+					},
+					"summary_es": {
+						"type": "text",
+						"analyzer": "index_spanish",
+						"search_analyzer": "search_spanish"
+					},
+					"summary_eu": {
+						"type": "text",
+						"analyzer": "index_basque",
+						"search_analyzer": "search_basque"
+					},
+					"summary_fr": {
+						"type": "text",
+						"analyzer": "index_french",
+						"search_analyzer": "search_french"
+					},
+					"summary_it": {
+						"type": "text",
+						"analyzer": "index_italian",
+						"search_analyzer": "search_italian"
+					},
+					"title_ca": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "catalan_heavy"
+							}
+						}
+					},
+					"title_de": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "german_heavy"
+							}
+						}
+					},
+					"title_en": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "english_heavy"
+							}
+						}
+					},
+					"title_es": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "spanish_heavy"
+							}
+						}
+					},
+					"title_eu": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "basque_heavy"
+							}
+						}
+					},
+					"title_fr": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "french_heavy"
+							}
+						}
+					},
+					"title_it": {
+						"type": "text",
+						"index": false,
+						"fields": {
+							"ngram": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
+							"raw": {
+								"type": "text",
+								"analyzer": "index_raw",
+								"search_analyzer": "search_raw"
+							},
+							"contentheavy": {
+								"type": "text",
+								"analyzer": "italian_heavy"
+							}
+						}
+					}
+				}
+			}


### PR DESCRIPTION
Upgrade Elasticsearch from 2.6 to 5.6
- Mapping Update (scripts and code)
- Code update for deprecation update (fields, missings, ...)
- Component update (elasticsearch, elasticsearch DSL)
- Migration scripts and logstash engine / pipeline
- CI scripts
- ES 5.6
- Logstash 5.6
- elastic plugin

please README: ./scripts/README.md