### PR TITLE
Implement new LTag aliases: C# and V# for crag climbing routes

### DIFF
--- a/c2corg_api/tests/markdown/ltags/aliases.html
+++ b/c2corg_api/tests/markdown/ltags/aliases.html
@@ -1,0 +1,44 @@
+<table c2c:role="ltag">
+<tbody>
+<tr>
+<td><span class="pitch"><span translate="">L</span>1</span></td>
+<td>5a</td>
+<td><span class="pitch"><span translate="">L</span>2</span>&nbsp;and <span class="pitch"><span translate="">L</span>3</span>&nbsp;are joined to <span class="pitch"><span translate="">L</span>1</span></td>
+</tr>
+<tr>
+<td><span class="pitch"><span translate="">L</span>4</span></td>
+<td>5b+</td>
+<td>Awesome pitch&#8239;!</td>
+</tr>
+<tr>
+<td><span class="pitch"><span translate="">R</span>1</span></td>
+<td>5a</td>
+<td><span class="pitch"><span translate="">R</span>2</span>&nbsp;and <span class="pitch"><span translate="">R</span>3</span>&nbsp;are joined to <span class="pitch"><span translate="">R</span>1</span></td>
+</tr>
+<tr>
+<td><span class="pitch"><span translate="">R</span>4</span></td>
+<td>5b+</td>
+<td>Awesome pitch&#8239;!</td>
+</tr>
+<tr>
+<td><span class="pitch">1</span></td>
+<td>5a</td>
+<td><span class="pitch">2</span>&nbsp;and <span class="pitch">3</span>&nbsp;are joined to <span class="pitch">1</span></td>
+</tr>
+<tr>
+<td><span class="pitch">4</span></td>
+<td>5b+</td>
+<td>Awesome pitch&#8239;!</td>
+</tr>
+<tr>
+<td><span class="pitch">1</span></td>
+<td>5a</td>
+<td><span class="pitch">2</span>&nbsp;and <span class="pitch">3</span>&nbsp;are joined to <span class="pitch">1</span></td>
+</tr>
+<tr>
+<td><span class="pitch">4</span></td>
+<td>5b+</td>
+<td>Awesome pitch&#8239;!</td>
+</tr>
+</tbody>
+</table>

--- a/c2corg_api/tests/markdown/ltags/aliases.md
+++ b/c2corg_api/tests/markdown/ltags/aliases.md
@@ -1,0 +1,8 @@
+L# | 5a | L#2 and L#3 are joined to L#
+L#4| 5b+ | Awesome pitch !
+R# | 5a | R#2 and R#3 are joined to R#
+R#4| 5b+ | Awesome pitch !
+V# | 5a | V#2 and V#3 are joined to V#
+V#4| 5b+ | Awesome pitch !
+C# | 5a | C#2 and C#3 are joined to C#
+C#4| 5b+ | Awesome pitch !


### PR DESCRIPTION
This commit adds two new syntaxes for tables of lines, intended for use with crag climbing routes:

```
V#1 | Name A | 6a+
C#2 | Name B | 5b
```

V is for "Voie", C is for "Climb", as R (could be used for Route) is already used for "Relay"  and L (could mean "Line") is used for "Longueur".

When transformed to HTML, the V or C is removed, resulting in this:

> | - | - | - |
> | -- | -- | -- |
> | 1 | Name A | 6a+ |
> | 2 | Name B | 5b |

(Table header added here to make it work with Github markdown syntax)

Apart from this, there is no difference with the handling of regular `R#`  and `L#` tags.

This is useful for writing topos for regular crags, where a climb can have multiple lengths (longueurs) and relays. It's closer to what you would find in topo guidebooks.

I added a new test to make sure the aliases work properly.