### PR TITLE
fix(test): rate_limiting not passing in local

### DIFF
--- a/c2corg_api/tests/tweens/test_rate_limiting.py
+++ b/c2corg_api/tests/tweens/test_rate_limiting.py
@@ -115,15 +115,21 @@ class RateLimitingTest(BaseTestRest):
         # Two emails have been set for each rate limited windows, and one
         # after the user has been blocked
         self.assertEqual(_send_email.call_count, 3)
+        user_profile = f"{self.settings['ui.url']}/profiles/{self.user.id}"
         _send_email.assert_called_with(
             'fixme@camptocamp.org',
             subject="Un usage excessif de l'API a été détecté",
-            body="Bonjour\n\nLe contributeur Contributor a atteint une "
-                 "nouvelle fois le nombre maximum autorisé de modifications "
-                 "via l'API camptocamp.org.\nIl a également dépassé le nombre "
-                 "maximum autorisé de blocages temporaires et a donc été "
-                 "définitivement bloqué.\nSon profil : "
-                 "http://localhost:6553/profiles/3")
+            body=(
+                "Bonjour\n\n"
+                f"Le contributeur {self.user.name} a atteint une "
+                "nouvelle fois le nombre maximum autorisé de modifications "
+                "via l'API camptocamp.org.\n"
+                "Il a également dépassé le nombre maximum autorisé "
+                "de blocages temporaires et a donc été "
+                "définitivement bloqué.\nSon profil : "
+                f"{user_profile}"
+            ),
+        )
         self._update_document(status=403)
 
     def _create_document(self):


### PR DESCRIPTION
Attempt to fix intermittent error:

> FAILED c2corg_api/tests/tweens/test_rate_limiting.py::RateLimitingTest::test_blocked - AssertionError: expected call not found.

The hostname exposed in the unit tests can be different than the hardcoded `http://localhost:6553/profiles/3` in the `test_blocked` method (ie: `export ui_url` in `config/default` file).